### PR TITLE
support in spaces at the begin/end of the name when get the initials

### DIFF
--- a/src/helpers/AvatarHelper.js
+++ b/src/helpers/AvatarHelper.js
@@ -30,7 +30,11 @@ export function getColorById(id) {
 export function getInitials(name) {
   let initials = '';
   if (name && _.isString(name)) {
-    const nameSplitted = _.chain(name).split(/\s+/g).take(2).value();
+    const nameSplitted = _.chain(name)
+      .split(/\s+/g)
+      .filter(word => word.length > 0)
+      .take(2)
+      .value();
     _.each(nameSplitted, (str) => {
       initials += str[0];
     });

--- a/test/spec/helpers/AvatarHelper.spec.js
+++ b/test/spec/helpers/AvatarHelper.spec.js
@@ -27,5 +27,6 @@ describe('services/AvatarService', () => {
     expect(uut.getInitials('Sarah Michelle Galler')).toBe('SM');
     expect(uut.getInitials('Keith')).toBe('K');
     expect(uut.getInitials()).toBe('');
+    expect(uut.getInitials(' Austin ')).toBe('A');
   });
 });


### PR DESCRIPTION
fix(AvatarHelper): support in spaces at the begin/end of the name when get the initials.