### PR TITLE
Tweak ActionSheet style to more closely match native component on Android

### DIFF
--- a/src/components/actionSheet/index.js
+++ b/src/components/actionSheet/index.js
@@ -66,7 +66,7 @@ export default class ActionSheet extends BaseComponent {
         duration={600}
         easing="ease-out-quint"
       >
-        <View paddingB-8 bg-white>
+        <View paddingV-8 bg-white>
           {this.renderTitle()}
           {this.renderActions()}
         </View>
@@ -78,8 +78,8 @@ export default class ActionSheet extends BaseComponent {
     const {title} = this.props;
     if (!_.isEmpty(title)) {
       return (
-        <View height={56} paddingL-16 centerV>
-          <Text dark40 text70>
+        <View height={48} paddingL-20 centerV>
+          <Text dark40 text80>
             {title}
           </Text>
         </View>


### PR DESCRIPTION
ActionSheet before:
<img width="459" alt="current-uilib-sheet" src="https://user-images.githubusercontent.com/2990253/31223645-a0db5c3e-a9d3-11e7-9947-47f10f5e829b.png">

ActionSheet after:
<img width="459" alt="fixed-uilib-sheet" src="https://user-images.githubusercontent.com/2990253/31223778-15e3b21a-a9d4-11e7-9c71-c10417598e6f.png">

Native component on Android (Google Photos app):
<img width="459" alt="native-sheet-2" src="https://user-images.githubusercontent.com/2990253/31224241-ca370cac-a9d5-11e7-8650-a3f9f550b58b.png">


Ideally, ActionSheet action items would have TouchableHighlight (as pictured in native component screenshot), not sure how to add it though.