### PR TITLE
Proxy testID inside CardImage

### DIFF
--- a/src/components/card/CardImage.js
+++ b/src/components/card/CardImage.js
@@ -49,12 +49,12 @@ export default class CardImage extends BaseComponent {
   }
 
   render() {
-    const {imageSource, style, position, borderRadius} = this.props;
+    const {imageSource, style, position, borderRadius, testID} = this.props;
     const borderStyle = CardPresenter.generateBorderRadiusStyle({position, borderRadius});
     if (imageSource) {
       return (
         <View style={[this.styles.container, borderStyle, style]}>
-          <Image source={imageSource} style={[this.styles.image, borderStyle]}/>
+          <Image testID={testID} source={imageSource} style={[this.styles.image, borderStyle]}/>
         </View>
       );
     }


### PR DESCRIPTION
It seems, that the `CardImage` component supports `testID` from outside signature, but does not actually use the prop anywhere. :(

_edit: just noticed this is issue no. 42, sorry for squatting this for something so trivial :(_