### PR TITLE
Deprecate createJSModules

### DIFF
--- a/lib/android/src/main/java/com/wix/reactnativeuilib/textinput/TextInputDelKeyHandlerPackage.java
+++ b/lib/android/src/main/java/com/wix/reactnativeuilib/textinput/TextInputDelKeyHandlerPackage.java
@@ -16,7 +16,7 @@ public class TextInputDelKeyHandlerPackage implements ReactPackage {
         return Arrays.<NativeModule>asList(new TextInputDelKeyHandlerModule(reactContext));
     }
 
-    @Override
+    // Deprecated in RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
createJSModules was deprecated in RN 0.47, this fix is backwards compatible.