### PR TITLE
Migrate ConnectionStatusBar component to RN51

### DIFF
--- a/src/components/connectionStatusBar/__tests__/index.spec.js
+++ b/src/components/connectionStatusBar/__tests__/index.spec.js
@@ -5,6 +5,7 @@ describe('ConnectionStatusBar', () => {
   let uut;
   beforeEach(() => {
     uut = new ConnectionStatusBar({});
+    ConnectionStatusBar.unregisterGlobalOnConnectionLost();
   });
 
   describe('registerGlobalOnConnectionLost', () => {
@@ -22,7 +23,7 @@ describe('ConnectionStatusBar', () => {
       ConnectionStatusBar.registerGlobalOnConnectionLost(callback);
       _.set(uut, 'state.isConnected', true);
 
-      uut.onConnectionChange('none');
+      uut.onConnectionChange({type: 'none'});
 
       expect(callback).toHaveBeenCalled();
     });
@@ -32,7 +33,7 @@ describe('ConnectionStatusBar', () => {
       ConnectionStatusBar.registerGlobalOnConnectionLost(callback);
       _.set(uut, 'state.isConnected', false);
 
-      uut.onConnectionChange('wifi');
+      uut.onConnectionChange({type: 'wifi'});
 
       expect(callback).not.toHaveBeenCalled();
     });

--- a/src/components/connectionStatusBar/index.js
+++ b/src/components/connectionStatusBar/index.js
@@ -59,7 +59,7 @@ export default class ConnectionStatusBar extends BaseComponent {
   }
 
   componentDidMount() {
-    this.netInfoListener = NetInfo.addEventListener('change', this.onConnectionChange);
+    this.netInfoListener = NetInfo.addEventListener('connectionChange', this.onConnectionChange);
   }
 
   componentWillUnmount() {
@@ -92,7 +92,7 @@ export default class ConnectionStatusBar extends BaseComponent {
   }
 
   async getInitialConnectionState() {
-    const state = await NetInfo.fetch();
+    const state = await NetInfo.getConnectionInfo();
     const isConnected = this.isStateConnected(state);
     this.setState({isConnected});
     if (this.props.onConnectionChange) {
@@ -101,7 +101,7 @@ export default class ConnectionStatusBar extends BaseComponent {
   }
 
   isStateConnected(state) {
-    const lowerCaseState = _.lowerCase(state);
+    const lowerCaseState = _.lowerCase(state.type);
     const isConnected = lowerCaseState !== 'none';
     return isConnected;
   }


### PR DESCRIPTION
replacing deprecated 'change' event and fetch() with their replacements