### PR TITLE
Add callback-props to Avatar component to bind image loading

### DIFF
--- a/demo/src/screens/componentScreens/AvatarsScreen.js
+++ b/demo/src/screens/componentScreens/AvatarsScreen.js
@@ -9,6 +9,13 @@ const examples = [
   {title: 'Initials (online)', label: 'ES', isOnline: true, status: Avatar.modes.NONE},
   {title: 'Initials with Color', label: 'AD', backgroundColor: Colors.yellow60, labelColor: Colors.orange20, ribbonLabel: 'New', ribbonStyle: {backgroundColor: Colors.purple30}},
   {title: 'Image (online)', imageSource: {uri: 'https://lh3.googleusercontent.com/-cw77lUnOvmI/AAAAAAAAAAI/AAAAAAAAAAA/WMNck32dKbc/s181-c/104220521160525129167.jpg'}, isOnline: true},
+  {
+    title: 'Monitored Avatar (see logs)',
+    backgroundColor: Colors.red60,
+    imageSource: {uri: 'https://static.altomusic.com/media/catalog/product/M/A/MAJ100SBK_0.jpg'},
+    onImageLoadStart: () => console.log('Monitored image load STARTED...'), // eslint-disable-line
+    onImageLoadEnd: () => console.log('Monitored image load ENDED'), // eslint-disable-line
+  },
   {title: 'Smaller', size: 40, imageSource: {uri: 'https://lh3.googleusercontent.com/-CMM0GmT5tiI/AAAAAAAAAAI/AAAAAAAAAAA/-o9gKbC6FVo/s181-c/111308920004613908895.jpg'}},
   {title: 'Bigger', size: 60, backgroundColor: 'red', imageSource: {uri: 'https://lh3.googleusercontent.com/-NQvYunR8V0U/AAAAAAAAAAI/AAAAAAAAAAA/lGLfZ92rPeE/s181-c/108911355181327993622.jpg'}},
   {title: 'Empty Gravatar', backgroundColor: Colors.red60, imageSource: {uri: 'https://gravatar.com/avatar/2497473d558a37020c558bf26e380a7c?d=blank'}},

--- a/src/components/avatar/index.js
+++ b/src/components/avatar/index.js
@@ -41,6 +41,16 @@ export default class Avatar extends BaseComponent {
      */
     imageSource: PropTypes.oneOfType([PropTypes.object, PropTypes.number]),
     /**
+     * Listener-callback for when an image's (uri) loading
+     * starts (equiv. to Image.onLoadStart()).
+     */
+    onImageLoadStart: PropTypes.func,
+    /**
+     * Listener-callback for when an image's (uri) loading
+     * either succeeds or fails (equiv. to Image.onLoadEnd()).
+     */
+    onImageLoadEnd: PropTypes.func,
+    /**
      * Label that can represent initials
      */
     label: PropTypes.string,
@@ -140,8 +150,25 @@ export default class Avatar extends BaseComponent {
     }
   }
 
+  renderImage() {
+    const {imageSource, onImageLoadStart, onImageLoadEnd, testID} = this.props;
+    const hasImage = !_.isUndefined(imageSource);
+    if (hasImage) {
+      return (
+        <Image
+          style={this.styles.image}
+          source={imageSource}
+          onLoadStart={onImageLoadStart}
+          onLoadEnd={onImageLoadEnd}
+          testID={`${testID}.image`}
+        />
+      );
+    }
+    return undefined;
+  }
+
   render() {
-    const {label, labelColor: color, imageSource, backgroundColor, testID, onPress} = this.props;
+    const {label, labelColor: color, imageSource, backgroundColor, onPress, testID} = this.props;
     const containerStyle = this.extractContainerStyle(this.props);
     const Container = onPress ? TouchableOpacity : View;
     const hasImage = !_.isUndefined(imageSource);
@@ -155,7 +182,7 @@ export default class Avatar extends BaseComponent {
             {label}
           </Text>
         </View>
-        {imageSource && <Image style={this.styles.image} source={imageSource} testID={`${testID}.image`} />}
+        {this.renderImage()}
         {this.renderBadge()}
         {this.renderRibbon()}
       </Container>


### PR DESCRIPTION
@ethanshar @inbalTish this is needed in order to fix the transparent avatars problem with no initials. When image loading ends, we'll rerendering the avatar component *with* labels; if the avatar is transparent, they will show.