### PR TITLE
Expandable input improvements

### DIFF
--- a/demo/src/screens/componentScreens/InputsScreen.js
+++ b/demo/src/screens/componentScreens/InputsScreen.js
@@ -116,6 +116,8 @@ export default class InputScreen extends Component {
           expandable
           expandableModalTitle="Modal Title"
           containerStyle={{marginBottom: INPUT_SPACING}}
+          maxLength={180}
+          showCharacterCounter
         />
 
         <TextInput

--- a/demo/src/screens/componentScreens/InputsScreen.js
+++ b/demo/src/screens/componentScreens/InputsScreen.js
@@ -114,6 +114,7 @@ export default class InputScreen extends Component {
           placeholder="Tell us about yourself"
           value={LONG_TEXT}
           expandable
+          expandableModalTitle="Modal Title"
           containerStyle={{marginBottom: INPUT_SPACING}}
         />
 

--- a/src/components/inputs/TextInput.js
+++ b/src/components/inputs/TextInput.js
@@ -64,6 +64,10 @@ export default class TextInput extends BaseInput {
      */
     expandable: PropTypes.bool,
     /**
+     * set the modal title when expandable prop is set to 'true'
+     */
+    expandableModalTitle: PropTypes.string,
+    /**
      * transform function executed on value and return transformed value
      */
     transformer: PropTypes.func,
@@ -314,6 +318,7 @@ export default class TextInput extends BaseInput {
         <Modal.TopBar
           onCancel={() => this.toggleExpandableModal(false)}
           onDone={this.onDoneEditingExpandableInput}
+          title={this.props.expandableModalTitle}         
         />
         <View style={this.styles.expandableModalContent}>
           <TextArea

--- a/src/components/inputs/TextInput.js
+++ b/src/components/inputs/TextInput.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {TextInput as RNTextInput, StyleSheet, Animated} from 'react-native';
+import {TextInput as RNTextInput, StyleSheet, Animated, SafeAreaView, KeyboardAvoidingView} from 'react-native';
 import _ from 'lodash';
 import BaseInput from './BaseInput';
 import Text from '../text';
@@ -318,17 +318,26 @@ export default class TextInput extends BaseInput {
         <Modal.TopBar
           onCancel={() => this.toggleExpandableModal(false)}
           onDone={this.onDoneEditingExpandableInput}
-          title={this.props.expandableModalTitle}         
+          title={this.props.expandableModalTitle}
         />
-        <View style={this.styles.expandableModalContent}>
+        <KeyboardAvoidingView
+          behavior={Constants.isIOS ? 'padding' : undefined}
+          style={this.styles.expandableModalContent}
+        >
           <TextArea
             ref={(textarea) => {
               this.expandableInput = textarea;
             }}
             {...this.props}
             value={this.state.value}
+            onChangeText={this.onChangeText}
           />
-        </View>
+          <SafeAreaView>
+            <View style={this.styles.expandableModalCounter}>
+              {this.renderCharCounter()}
+            </View>
+          </SafeAreaView>
+        </KeyboardAvoidingView>
       </Modal>
     );
   }
@@ -516,8 +525,15 @@ function createStyles({
     },
     expandableModalContent: {
       flex: 1,
+      justifyContent: 'space-between',
       paddingTop: 15,
       paddingHorizontal: 20,
+    },
+    expandableModalCounter: {
+      position: 'absolute',
+      right: 0,
+      bottom: 0,
+      paddingBottom: 10,
     },
     title: {
       top: 0,


### PR DESCRIPTION
This PR should add a couple of improvements to the expandable TextInput:
1. Should fix the issue wherein iOS text is hidden behind the keyboard.
2. Should add a capability to define the modal title (with the expandableModalTitle prop)
3. Should add a capability to display the character counter inside the modal (following Katrin design)
Video: https://screencast.com/t/ygediYQg2