### PR TITLE
Handle Image prop source.uri when it is an empty string.

### DIFF
--- a/src/components/image/__tests__/index.spec.js
+++ b/src/components/image/__tests__/index.spec.js
@@ -59,5 +59,10 @@ describe('Image', () => {
       const uut = new Image({source: {uri: null}});
       expect(uut.getImageSource()).toEqual({uri: undefined});
     });
+
+    it('should handle when source sent with uri is empty string', () => {
+      const uut = new Image({source: {uri: ''}});
+      expect(uut.getImageSource()).toEqual({uri: undefined});
+    });
   });
 });

--- a/src/components/image/index.js
+++ b/src/components/image/index.js
@@ -51,7 +51,7 @@ class Image extends BaseComponent {
     }
 
     const {source} = this.props;
-    if (_.get(source, 'uri') === null) {
+    if (_.get(source, 'uri') === null || _.get(source, 'uri') === '') {
       return {...source, uri: undefined};
     }
 


### PR DESCRIPTION
This causes a warning in react-native: 'Error source.uri should not be an empty string'