### PR TITLE
Expo.io support for BlurView

### DIFF
--- a/src/screensComponents/modal/index.js
+++ b/src/screensComponents/modal/index.js
@@ -8,7 +8,7 @@ import TopBar from './TopBar';
 
 // EXPO.io Workaround - use BlurView from 'expo'
 let BlurView;
-if(Expo) {
+if (Expo) {
   BlurView = require('expo').BlurView;
 } else {
   BlurView = require('react-native-blur').BlurView;

--- a/src/screensComponents/modal/index.js
+++ b/src/screensComponents/modal/index.js
@@ -1,10 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {BlurView} from 'react-native-blur';
+
 import {View, Modal as RNModal} from 'react-native';
 import {Constants} from '../../helpers';
 import {BaseComponent} from '../../commons';
 import TopBar from './TopBar';
+
+// EXPO.io Workaround - use BlurView from 'expo'
+let BlurView;
+if(Expo) {
+  BlurView = require('expo').BlurView;
+} else {
+  BlurView = require('react-native-blur').BlurView;
+}
 
 /**
  * @description: Component that present content on top of the invoking screen


### PR DESCRIPTION
Expo uses its own bundled version of BlurView. So we need to have a check in the Modal component wether its Expo or a regular React-Native app and change the import.
Would be nice to see more expo support.
