### PR TITLE
Fix Docs link to go somewhere with docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ UI Toolset & Components Library for React Native
 
 ### Documentation
 
-Check out our [Docs Site](https://wix.github.io/react-native-ui-lib/).
+Check out our [Docs Site](https://wix.github.io/react-native-ui-lib/docs/).
 
 ### Demo
 


### PR DESCRIPTION
The docs link as-is went to some "Coming Soon Page".
This link goes to the actual docs.