### PR TITLE
Fix Toast animated prop

### DIFF
--- a/src/components/toast/index.js
+++ b/src/components/toast/index.js
@@ -170,7 +170,7 @@ export default class Toast extends BaseComponent {
       delay, 
       useNativeDriver, 
       onAnimationEnd: () => this.onAnimationEnd()
-    };    
+    };
   }
 
   getContentAnimation(shouldShow) {

--- a/src/components/toast/index.js
+++ b/src/components/toast/index.js
@@ -169,7 +169,7 @@ export default class Toast extends BaseComponent {
       duration, 
       delay, 
       useNativeDriver, 
-      onAnimationEnd: () => this.onAnimationEnd()
+      onAnimationEnd: () => this.onAnimationEnd(),
     };
   }
 

--- a/src/components/toast/index.js
+++ b/src/components/toast/index.js
@@ -113,15 +113,16 @@ export default class Toast extends BaseComponent {
   constructor(props) {
     super(props);
 
+    const {animated} = this.props;
+
     this.state = {
       isVisible: false,
-      animationConfig: this.getAnimation(true),
-      contentAnimation: this.getContentAnimation(true),
+      animationConfig: animated ? this.getAnimation(true) : {},
+      contentAnimation: animated ? this.getContentAnimation(true) : {},
       duration: DURATION,
       delay: DELAY,
     };
 
-    const {animated} = this.props;
     if (animated) {
       setupRelativeAnimation(getHeight(this.props));
     }
@@ -160,17 +161,11 @@ export default class Toast extends BaseComponent {
   }
 
   getAnimation(shouldShow) {
-    const {position, useNativeDriver, animated} = this.props;
+    const {position, useNativeDriver} = this.props;
     const animationDescriptor = getAnimationDescriptor(position, this.state);
     const {animation, duration, delay} = shouldShow ? animationDescriptor.enter : animationDescriptor.exit;
 
-    return {
-      animation: animated ? animation : null, 
-      duration, 
-      delay, 
-      useNativeDriver, 
-      onAnimationEnd: () => this.onAnimationEnd(),
-    };
+    return {animation, duration, delay, useNativeDriver, onAnimationEnd: () => this.onAnimationEnd()};
   }
 
   getContentAnimation(shouldShow) {
@@ -278,7 +273,7 @@ export default class Toast extends BaseComponent {
     }
   }
 
-  // This weird layout should support iphoneX safe are
+  // This weird layout should support iphoneX safe area
   render() {
     const {backgroundColor, actions, enableBlur, testID, zIndex, renderContent} = this.getThemeProps();
     const {animationConfig} = this.state;

--- a/src/components/toast/index.js
+++ b/src/components/toast/index.js
@@ -160,7 +160,7 @@ export default class Toast extends BaseComponent {
   }
 
   getAnimation(shouldShow) {
-    const {position, useNativeDriver} = this.props;
+    const {position, useNativeDriver, animated} = this.props;
     const animationDescriptor = getAnimationDescriptor(position, this.state);
     const {animation, duration, delay} = shouldShow ? animationDescriptor.enter : animationDescriptor.exit;
 

--- a/src/components/toast/index.js
+++ b/src/components/toast/index.js
@@ -164,7 +164,13 @@ export default class Toast extends BaseComponent {
     const animationDescriptor = getAnimationDescriptor(position, this.state);
     const {animation, duration, delay} = shouldShow ? animationDescriptor.enter : animationDescriptor.exit;
 
-    return {animation, duration, delay, useNativeDriver, onAnimationEnd: () => this.onAnimationEnd()};
+    return {
+      animation: animated ? animation : null, 
+      duration, 
+      delay, 
+      useNativeDriver, 
+      onAnimationEnd: () => this.onAnimationEnd()
+    };    
   }
 
   getContentAnimation(shouldShow) {


### PR DESCRIPTION
Hi there, this is a fantastic UI library that we just started using for our app and we've all been extremely happy with so thank you very much for putting so much care and effort into it!

I just started using the Toast component and came across a situation where I don't want it to be animated at all, so I set `animated={false}` but this results in the following error:

<img src="https://user-images.githubusercontent.com/11965195/44691904-756b8b80-aa2e-11e8-885b-fa2f8f126b29.jpeg" data-canonical-src="https://user-images.githubusercontent.com/11965195/44691904-756b8b80-aa2e-11e8-885b-fa2f8f126b29.jpeg" width="200" height="400" />

Took a look into the source code and came up with this small solution. The issue it seems is that when the `animated` prop is false, registering the animations is skipped, but then the unregistered animations are still attempted to be used in the `Animated.View` props.

According to [this issue comment](https://github.com/oblador/react-native-animatable/issues/129#issuecomment-352246126) over at react-native-animatible, you can just pass `null` or `undefined` as the animation prop value to disable it, so I'm checking the Toast `animated` prop and doing that based on its value. This seems to work pretty well, but I don't have a lot of knowledge about animations so not sure if this is the optimal solution. Also I didn't see any tests for this component to confirm my fix didn't break anything else.

Please take a look and if it works for you great, if not then I can create an issue and let you tackle in this in another way!

Thanks again!