### PR TITLE
Fixed RTL bug in Picker.Item

### DIFF
--- a/src/components/picker/PickerItem.js
+++ b/src/components/picker/PickerItem.js
@@ -145,6 +145,7 @@ function createStyles() {
       ...Typography.text70,
       color: Colors.dark10,
       flex: 1,
+      textAlign: 'left',
     },
     labelTextDisabled: {
       color: Colors.dark60,


### PR DESCRIPTION
What changed:

Fixed RTL bug when using react-native's I18nManager (When RTL is active).

Before:
![rtl-wrong](https://user-images.githubusercontent.com/5933939/45291007-3812fd80-b506-11e8-9696-a1c29bcd0baa.png)

After:
![rtl-right](https://user-images.githubusercontent.com/5933939/45291010-3cd7b180-b506-11e8-8a00-d911cff26637.png)
