### PR TITLE
Fixed this.setState error for android api under 17

### DIFF
--- a/src/components/button/index.js
+++ b/src/components/button/index.js
@@ -138,6 +138,7 @@ export default class Button extends BaseComponent {
     if (!_.isUndefined(props.containerStyle)) {
       console.error('Button "containerStyle" prop will be deprecated soon, please use "style" instead');
     }
+    this.getComponentDimensions = this.getComponentDimensions.bind(this);
   }
 
   // This method will be called more than once in case of layout change!

--- a/typings/components/button/index.js
+++ b/typings/components/button/index.js
@@ -21,6 +21,7 @@ export default class Button extends BaseComponent {
         if (!_.isUndefined(props.containerStyle)) {
             console.error('Button "containerStyle" prop will be deprecated soon, please use "style" instead');
         }
+        this.getComponentDimensions = this.getComponentDimensions.bind(this);
     }
     // This method will be called more than once in case of layout change!
     getComponentDimensions(event) {


### PR DESCRIPTION
This function is throwing error on android api <= 17 because of getComponentDimensions scope.
What i did is bind this context to the function on constructor. Now there is no more error thrown.