### PR TITLE
feat: loadAssetsGroup() accepts ES5 getters to facilitate lazy assets requiring

### DIFF
--- a/src/assets/Assets.js
+++ b/src/assets/Assets.js
@@ -1,0 +1,44 @@
+import _ from 'lodash';
+
+function assignProperties(a, b) {
+  return Object.defineProperties(a, Object.getOwnPropertyDescriptors(b));
+}
+
+function ensurePath(obj, path) {
+  let pointer = obj;
+
+  const pathArray = path.split('.');
+  const n = pathArray.length;
+
+  for (let i = 0; i < n; i++) {
+    const segment = pathArray[i];
+    pointer[segment] = pointer[segment] || {};
+    pointer = pointer[segment];
+  }
+
+  return pointer;
+}
+
+export class Assets {
+  loadAssetsGroup(groupName, assets) {
+    if (!_.isString(groupName)) {
+      throw new Error('group name should be a string');
+    }
+
+    if (!_.isPlainObject(assets)) {
+      throw new Error('assets should be a hash map or a function (for lazy access)');
+    }
+
+    if (groupName === '') {
+      assignProperties(this, assets);
+    } else {
+      assignProperties(ensurePath(this, groupName), assets);
+    }
+
+    return this;
+  }
+
+  static merge(...assets) {
+    return assets.reduce(assignProperties);
+  }
+}

--- a/src/assets/Assets.js
+++ b/src/assets/Assets.js
@@ -37,8 +37,4 @@ export class Assets {
 
     return this;
   }
-
-  static merge(...assets) {
-    return assets.reduce(assignProperties);
-  }
 }

--- a/src/assets/__tests__/Assets.test.js
+++ b/src/assets/__tests__/Assets.test.js
@@ -95,30 +95,4 @@ describe('Assets', () => {
       });
     });
   });
-
-  describe('.merge(...assets)', () => {
-    it('should merge plain assets objects with getters and values', () => {
-      const fns = [jest.fn(() => '1'), jest.fn(() => '2'), jest.fn(() => '3')];
-
-      const basic = {
-        get back() { return fns[0](); },
-        get forward() { return fns[1](); },
-      };
-
-      const advanced = {
-        get forward() { return fns[2](); },
-        discard: 'discard.png',
-      };
-
-      const icons = Assets.merge({}, basic, advanced);
-      expect(icons.discard).toBe('discard.png');
-
-      expect(icons.back).toBe('1');
-      expect(fns[0]).toHaveBeenCalled();
-
-      expect(icons.forward).toBe('3');
-      expect(fns[1]).not.toHaveBeenCalled();
-      expect(fns[2]).toHaveBeenCalled();
-    });
-  });
 });

--- a/src/assets/__tests__/Assets.test.js
+++ b/src/assets/__tests__/Assets.test.js
@@ -1,0 +1,124 @@
+import { Assets } from '../Assets';
+
+describe('Assets', () => {
+  let assets;
+
+  beforeEach(() => {
+    assets = new Assets();
+  });
+
+  describe('.loadAssetsGroup(groupName, assets)', () => {
+    it('should return the assets object itself', () => {
+      expect(assets.loadAssetsGroup('emojis', {})).toBe(assets);
+    });
+
+    it('should create nested groups', () => {
+      assets.loadAssetsGroup('emojis.ascii', { smile: ':)' });
+      expect(assets.emojis.ascii.smile).toBe(':)');
+    });
+
+    describe('edge cases', () => {
+      it('should throw if group name is not a string', () => {
+        expect(() => assets.loadAssetsGroup(42, {})).toThrowErrorMatchingSnapshot();
+      });
+
+      it('should throw if assets are not a plain object', () => {
+        expect(() => assets.loadAssetsGroup('assets', new class {})).toThrowErrorMatchingSnapshot();
+      });
+    });
+
+    describe('when called with empty group name', () => {
+      describe('and plain object of assets', () => {
+        it('should create root asset groups', () => {
+          const emojis = {};
+          const icons = {};
+          assets.loadAssetsGroup('', { emojis, icons });
+
+          expect(assets.emojis).toBe(emojis);
+          expect(assets.icons).toBe(icons);
+        });
+      });
+
+      describe('and an object with assets getters', () => {
+        it('should create lazy root asset groups', () => {
+          const emojis = {};
+          const heavyIconsModule = {};
+          const requireHeavyIcons = jest.fn().mockReturnValue(heavyIconsModule);
+
+          assets.loadAssetsGroup('', {
+            emojis,
+            get icons() { return requireHeavyIcons(); },
+          });
+
+          expect(assets.emojis).toBe(emojis);
+
+          expect(requireHeavyIcons).not.toHaveBeenCalled();
+          expect(assets.icons).toBe(heavyIconsModule);
+          expect(requireHeavyIcons).toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe('when has a lazy group', () => {
+      let iconsModule;
+
+      beforeEach(() => {
+        iconsModule = {
+          get apply() { return './apply.png'; },
+          get back() { return './back.png'; },
+        };
+
+        assets.loadAssetsGroup('', {
+          get icons() { return iconsModule; },
+        });
+      });
+
+      describe('and called with the same group name', () => {
+        beforeEach(() => {
+          assets.loadAssetsGroup('icons', {
+            get back() { return './back-dark.png'; },
+            get forward() { return './forward-dark.png'; },
+          });
+        });
+
+        it('should preserve existing assets upon load', () => {
+          expect(assets.icons.apply).toBe('./apply.png');
+        });
+
+        it('should overwrite existing assets if they have the same names', () => {
+          expect(assets.icons.back).toBe('./back-dark.png');
+        });
+
+        it('should append extra assets to the group', () => {
+          expect(assets.icons.forward).toBe('./forward-dark.png');
+        });
+      });
+    });
+  });
+
+  describe('.merge(...assets)', () => {
+    it('should merge plain assets objects with getters and values', () => {
+      const fns = [jest.fn(), jest.fn(), jest.fn()];
+
+      const basic = {
+        get back() { return fns[0](); },
+        get forward() { return fns[1](); },
+      };
+
+      const advanced = {
+        get forward() { return fns[2](); },
+        discard: 'discard.png',
+      };
+
+      const icons = Assets.merge({}, basic, advanced);
+      expect(icons.discard).toBe('discard.png');
+
+      icons.back;
+      expect(fns[0]).toHaveBeenCalled();
+
+      icons.forward;
+      expect(fns[1]).not.toHaveBeenCalled();
+      expect(fns[2]).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/assets/__tests__/Assets.test.js
+++ b/src/assets/__tests__/Assets.test.js
@@ -23,7 +23,7 @@ describe('Assets', () => {
       });
 
       it('should throw if assets are not a plain object', () => {
-        expect(() => assets.loadAssetsGroup('assets', new class {})).toThrowErrorMatchingSnapshot();
+        expect(() => assets.loadAssetsGroup('assets', new class {}())).toThrowErrorMatchingSnapshot();
       });
     });
 
@@ -98,7 +98,7 @@ describe('Assets', () => {
 
   describe('.merge(...assets)', () => {
     it('should merge plain assets objects with getters and values', () => {
-      const fns = [jest.fn(), jest.fn(), jest.fn()];
+      const fns = [jest.fn(() => '1'), jest.fn(() => '2'), jest.fn(() => '3')];
 
       const basic = {
         get back() { return fns[0](); },
@@ -113,10 +113,10 @@ describe('Assets', () => {
       const icons = Assets.merge({}, basic, advanced);
       expect(icons.discard).toBe('discard.png');
 
-      icons.back;
+      expect(icons.back).toBe('1');
       expect(fns[0]).toHaveBeenCalled();
 
-      icons.forward;
+      expect(icons.forward).toBe('3');
       expect(fns[1]).not.toHaveBeenCalled();
       expect(fns[2]).toHaveBeenCalled();
     });

--- a/src/assets/__tests__/__snapshots__/Assets.test.js.snap
+++ b/src/assets/__tests__/__snapshots__/Assets.test.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Assets .loadAssetsGroup(groupName, assets) edge cases should throw if assets are not a plain object 1`] = `"assets should be a hash map or a function (for lazy access)"`;
+
+exports[`Assets .loadAssetsGroup(groupName, assets) edge cases should throw if group name is not a string 1`] = `"group name should be a string"`;

--- a/src/assets/icons/index.js
+++ b/src/assets/icons/index.js
@@ -1,6 +1,6 @@
 export const icons = {
-  check: require('./check.png'),
-  checkSmall: require('./check-small.png'),
-  x: require('./x.png'),
-  search: require('./search.png'),
+  get check() { return require('./check.png'); },
+  get checkSmall() { return require('./check-small.png'); },
+  get x() { return require('./x.png'); },
+  get search() { return require('./search.png'); },
 };

--- a/src/assets/images/index.js
+++ b/src/assets/images/index.js
@@ -1,3 +1,3 @@
 export const images = {
-  gradient: require('./gradient.png'),
+  get gradient() { return require('./gradient.png'); },
 };

--- a/src/assets/index.js
+++ b/src/assets/index.js
@@ -1,27 +1,7 @@
-import _ from 'lodash';
+import { Assets } from './Assets';
 
-import {icons} from './icons';
-import {emojis} from './emojis';
-import {images} from './images';
-
-class Assets {
-  icons = icons;
-  emojis = emojis;
-  images = images;
-
-  loadAssetsGroup(groupName, assets) {
-    if (!_.isString(groupName)) {
-      throw new Error('group name should be a string');
-    }
-
-    if (!_.isPlainObject(assets)) {
-      throw new Error('assets should be a hash map');
-    }
-
-    _.forEach(assets, (value, key) => {
-      _.set(this, `${groupName}.${key}`, value);
-    });
-  }
-}
-
-export default new Assets();
+export default new Assets().loadAssetsGroup('', {
+  get icons() { return require('./icons'); },
+  get emojis() { return require('./emojis'); },
+  get images() { return require('./images'); },
+});

--- a/src/assets/index.js
+++ b/src/assets/index.js
@@ -1,7 +1,7 @@
 import { Assets } from './Assets';
 
 export default new Assets().loadAssetsGroup('', {
-  get icons() { return require('./icons'); },
-  get emojis() { return require('./emojis'); },
-  get images() { return require('./images'); },
+  get icons() { return require('./icons').icons; },
+  get emojis() { return require('./emojis').emojis; },
+  get images() { return require('./images').images; },
 });


### PR DESCRIPTION
For more details see: https://github.com/wix-private/wix-react-native-ui-lib/issues/261

The problem is that [assets/index.js](https://github.com/wix-private/wix-react-native-ui-lib/blob/master/src/assets/index.js) there is reliant on the existing implementation of `Assets.loadAssetsGroup` which stands in my way if I want to rewrite most of the assets' key-values to ES5 getters.

The new implementation helps to avoid `require()` calls to the assets as long as it is possible. This is important for us because it eats up to 200ms of the loading time in WOA or possibly more.