### PR TITLE
perf: fix performance killer

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-// module.exports = require('./src/index');
-import * as UILIB from './src/index';
+// import * as UILIB from './src/index';
+// module.exports = {...UILIB};
 
-module.exports = {...UILIB};
+module.exports = require('./src/index');


### PR DESCRIPTION
The object spread `{ ...UILIB }` basically results in a full evaluation of all getters in the `./src/index` file.

Can we use an older but more efficient way or take another way to avoid the evaluation? It is quite heavy, about 240ms to execute.