### PR TITLE
connectionStatusBar: bug fix

### DIFF
--- a/src/components/connectionStatusBar/index.js
+++ b/src/components/connectionStatusBar/index.js
@@ -116,7 +116,7 @@ export default class ConnectionStatusBar extends BaseComponent {
 
   render() {
     if (this.state.isConnected || this.state.isCancelled) {
-      return false;
+      return null;
     }
     const containerStyle = [this.styles.topContainer, this.props.useAbsolutePosition ? this.styles.absolutePosition : null];
     return (


### PR DESCRIPTION
After being shown bar did not disappear when connection is resumed.