### PR TITLE
support selection mode in Card

### DIFF
--- a/demo/src/screens/componentScreens/CardsScreen.js
+++ b/demo/src/screens/componentScreens/CardsScreen.js
@@ -11,15 +11,12 @@ const cardImage2 = require('../../assets/images/empty-state.jpg');
 
 export default class CardsScreen extends Component {
   state = {
-    selected: true,
-  };
-
-  selectCard = () => {
-    this.setState({selected: !this.state.selected});
+    selected1: true,
+    selected2: true,
   };
 
   render() {
-    const {selected} = this.state;
+    const {selected1, selected2} = this.state;
     return (
       <View>
         <Image
@@ -53,11 +50,30 @@ export default class CardsScreen extends Component {
             </ScrollView>
 
             <View row>
-              <Card height={120} flex marginV-20 marginR-20>
+              <Card
+                height={120}
+                flex
+                marginV-20
+                selected={selected1}
+                onPress={() => this.setState({selected1: !selected1})}
+                activeOpacity={1}
+                marginR-20
+              >
                 <Card.Image height={'100%'} imageSource={cardImage} />
               </Card>
-
-              <Card height={120} flex marginV-20 selected={selected} onPress={this.selectCard} activeOpacity={1}>
+              <Card
+                height={120}
+                flex
+                marginV-20
+                selected={selected2}
+                onPress={() => this.setState({selected2: !selected2})}
+                activeOpacity={1}
+                selectionOptions={{
+                  color: Colors.dark10,
+                  indicatorSize: 25,
+                  borderWidth: 3,
+                }}
+              >
                 <Card.Image height={'100%'} imageSource={cardImage} />
               </Card>
             </View>

--- a/demo/src/screens/componentScreens/CardsScreen.js
+++ b/demo/src/screens/componentScreens/CardsScreen.js
@@ -10,7 +10,16 @@ const cardImage = require('../../assets/images/card-example.jpg');
 const cardImage2 = require('../../assets/images/empty-state.jpg');
 
 export default class CardsScreen extends Component {
+  state = {
+    selected: true,
+  };
+
+  selectCard = () => {
+    this.setState({selected: !this.state.selected});
+  };
+
   render() {
+    const {selected} = this.state;
     return (
       <View>
         <Image
@@ -43,43 +52,47 @@ export default class CardsScreen extends Component {
               })}
             </ScrollView>
 
-            <Card height={120} width={120} marginV-20>
-              <Card.Image height={'100%'} imageSource={cardImage} />
-            </Card>
+            <View row>
+              <Card height={120} flex marginV-20 marginR-20>
+                <Card.Image height={'100%'} imageSource={cardImage} />
+              </Card>
 
-            <Card marginB-20 height={80} style={{backgroundColor: Colors.dark60}}>
-              <View flex padding-20>
-                <Text text50 white>
+              <Card height={120} flex marginV-20 selected={selected} onPress={this.selectCard} activeOpacity={1}>
+                <Card.Image height={'100%'} imageSource={cardImage} />
+              </Card>
+            </View>
+
+            <View row>
+              <Card flex center marginB-20 height={80} style={{backgroundColor: Colors.dark60}} marginR-20>
+                <Text text80 center white>
                   With custom background color
                 </Text>
-              </View>
-            </Card>
-
-            <Card marginB-20 height={80} style={{backgroundColor: Colors.rgba(Colors.dark60, 0.75)}}>
-              <View flex padding-20>
-                <Text text50 white>
+              </Card>
+              <Card flex center marginB-20 height={80} style={{backgroundColor: Colors.rgba(Colors.dark60, 0.75)}}>
+                <Text text70 center white>
                   With opacity
                 </Text>
-              </View>
-            </Card>
+              </Card>
 
-            {Constants.isIOS && (
-              <Card
-                marginB-20
-                height={80}
-                enableBlur
-                // onPress={() => {}}
-              >
-                <View flex padding-20>
-                  <Text text50 dark20>
+              {Constants.isIOS && (
+                <Card
+                  flex
+                  center
+                  marginL-20
+                  marginB-20
+                  height={80}
+                  enableBlur
+                  // onPress={() => {}}
+                >
+                  <Text text70 dark20 center>
                     With Blur effect
                   </Text>
-                  <Text text80 dark20>
+                  <Text text80 dark20 center>
                     (iOS only)
                   </Text>
-                </View>
-              </Card>
-            )}
+                </Card>
+              )}
+            </View>
 
             <Card row height={160} style={{marginBottom: 15}} onPress={() => {}} enableBlur>
               <Card.Image width={115} imageSource={cardImage} />

--- a/src/components/card/CardPresenter.js
+++ b/src/components/card/CardPresenter.js
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import {Constants} from '../../helpers';
 
 export function extractPositionValues(position) {
   const top = _.includes(position, 'top');
@@ -11,15 +10,13 @@ export function extractPositionValues(position) {
 }
 
 export function generateBorderRadiusStyle({position, borderRadius}) {
-  if (Constants.isIOS) {
-    const borderRadiusStyle = {};
+  const borderRadiusStyle = {};
 
-    const {top, left, right, bottom} = extractPositionValues(position);
+  const {top, left, right, bottom} = extractPositionValues(position);
 
-    borderRadiusStyle.borderTopLeftRadius = top || left ? borderRadius : undefined;
-    borderRadiusStyle.borderTopRightRadius = top || right ? borderRadius : undefined;
-    borderRadiusStyle.borderBottomLeftRadius = bottom || left ? borderRadius : undefined;
-    borderRadiusStyle.borderBottomRightRadius = bottom || right ? borderRadius : undefined;
-    return borderRadiusStyle;
-  }
+  borderRadiusStyle.borderTopLeftRadius = top || left ? borderRadius : undefined;
+  borderRadiusStyle.borderTopRightRadius = top || right ? borderRadius : undefined;
+  borderRadiusStyle.borderBottomLeftRadius = bottom || left ? borderRadius : undefined;
+  borderRadiusStyle.borderBottomRightRadius = bottom || right ? borderRadius : undefined;
+  return borderRadiusStyle;
 }

--- a/src/components/card/index.js
+++ b/src/components/card/index.js
@@ -1,18 +1,27 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {StyleSheet, ViewPropTypes} from 'react-native';
+import {StyleSheet, ViewPropTypes, Animated} from 'react-native';
 import {BlurView} from 'react-native-blur';
 import {Constants} from '../../helpers';
 import {Colors, BorderRadiuses} from '../../style';
 import {BaseComponent} from '../../commons';
 import View from '../view';
 import TouchableOpacity from '../touchableOpacity';
+import Image from '../image';
 import CardSection from './CardSection';
 import CardItem from './CardItem';
 import CardImage from './CardImage';
+import Assets from '../../assets';
 
 const DEFAULT_BORDER_RADIUS = BorderRadiuses.br40;
+
+const DEFAULT_SELECTION_PROPS = {
+  borderWidth: 2,
+  color: Colors.blue30,
+  indicatorSize: 20,
+  icon: Assets.icons.checkSmall,
+};
 
 /**
  * @description: Card component
@@ -67,11 +76,45 @@ class Card extends BaseComponent {
      * Additional styles for the top container
      */
     containerStyle: ViewPropTypes.style,
+    /**
+     * Adds visual indication that the card is selected
+     */
+    selected: PropTypes.bool,
+    /**
+     * Custom options for styling the selection indication
+     */
+    selectionOptions: PropTypes.shape({
+      icon: PropTypes.number,
+      color: PropTypes.string,
+      borderWidth: PropTypes.number,
+      indicatorSize: PropTypes.number,
+    }),
   };
 
   static defaultProps = {
+    selected: false,
     enableShadow: true,
   };
+
+  state = {
+    animatedSelected: new Animated.Value(Number(this.props.selected)),
+  };
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.selected !== this.props.selected) {
+      this.animateSelection();
+    }
+  }
+
+  animateSelection() {
+    const {animatedSelected} = this.state;
+    const {selected} = this.props;
+    Animated.timing(animatedSelected, {
+      toValue: Number(selected),
+      duration: 120,
+      useNativeDriver: true,
+    }).start();
+  }
 
   generateStyles() {
     this.styles = createStyles(this.getThemeProps());
@@ -126,17 +169,29 @@ class Card extends BaseComponent {
     }
   }
 
-  renderChildren() {
-    if (Constants.isAndroid) {
-      return this.props.children;
-    }
+  renderSelection() {
+    const {selectionOptions, borderRadius} = this.getThemeProps();
+    const {animatedSelected} = this.state;
 
+    return (
+      <Animated.View
+        style={[this.styles.selectedBorder, borderRadius && {borderRadius}, {opacity: animatedSelected}]}
+        pointerEvents="none"
+      >
+        <View style={this.styles.selectedIndicator}>
+          <Image source={_.get(selectionOptions, 'icon', DEFAULT_SELECTION_PROPS.icon)} />
+        </View>
+      </Animated.View>
+    );
+  }
+
+  renderChildren() {
     const {borderRadius} = this.getThemeProps();
     const children = React.Children.map(this.props.children, (child, index) => {
       if (_.get(child, 'type.displayName') === CardImage.displayName) {
         const position = this.calcImagePosition(index);
         return React.cloneElement(child, {
-          /* key: index, */ position,
+          position,
           borderRadius: borderRadius || DEFAULT_BORDER_RADIUS,
         });
       }
@@ -173,18 +228,18 @@ class Card extends BaseComponent {
         )}
 
         {this.renderChildren()}
+        {this.renderSelection()}
       </Container>
     );
   }
 }
 
-function createStyles({width, height, borderRadius = DEFAULT_BORDER_RADIUS}) {
+function createStyles({width, height, borderRadius = DEFAULT_BORDER_RADIUS, selectionOptions = DEFAULT_SELECTION_PROPS}) {
   return StyleSheet.create({
     container: {
       width,
       height,
-      // must use visible for iOS for shadow
-      overflow: Constants.isIOS ? 'visible' : 'hidden',
+      overflow: 'visible',
       borderRadius,
     },
     containerShadow: {
@@ -197,6 +252,23 @@ function createStyles({width, height, borderRadius = DEFAULT_BORDER_RADIUS}) {
     blurView: {
       ...StyleSheet.absoluteFillObject,
       borderRadius,
+    },
+    selectedBorder: {
+      ...StyleSheet.absoluteFillObject,
+      borderRadius: DEFAULT_BORDER_RADIUS,
+      borderWidth: selectionOptions.borderWidth,
+      borderColor: selectionOptions.color,
+    },
+    selectedIndicator: {
+      borderRadius: BorderRadiuses.br100,
+      position: 'absolute',
+      top: -selectionOptions.indicatorSize / 2 + 2,
+      right: -selectionOptions.indicatorSize / 2 + 1,
+      width: selectionOptions.indicatorSize,
+      height: selectionOptions.indicatorSize,
+      backgroundColor: selectionOptions.color,
+      alignItems: 'center',
+      justifyContent: 'center',
     },
   });
 }

--- a/src/components/card/index.js
+++ b/src/components/card/index.js
@@ -234,7 +234,8 @@ class Card extends BaseComponent {
   }
 }
 
-function createStyles({width, height, borderRadius = DEFAULT_BORDER_RADIUS, selectionOptions = DEFAULT_SELECTION_PROPS}) {
+function createStyles({width, height, borderRadius = DEFAULT_BORDER_RADIUS, selectionOptions}) {
+  const selectionOptionsWithDefaults = _.merge(DEFAULT_SELECTION_PROPS, selectionOptions);
   return StyleSheet.create({
     container: {
       width,
@@ -256,17 +257,17 @@ function createStyles({width, height, borderRadius = DEFAULT_BORDER_RADIUS, sele
     selectedBorder: {
       ...StyleSheet.absoluteFillObject,
       borderRadius: DEFAULT_BORDER_RADIUS,
-      borderWidth: selectionOptions.borderWidth,
-      borderColor: selectionOptions.color,
+      borderWidth: selectionOptionsWithDefaults.borderWidth,
+      borderColor: selectionOptionsWithDefaults.color,
     },
     selectedIndicator: {
       borderRadius: BorderRadiuses.br100,
       position: 'absolute',
-      top: -selectionOptions.indicatorSize / 2 + 2,
-      right: -selectionOptions.indicatorSize / 2 + 1,
-      width: selectionOptions.indicatorSize,
-      height: selectionOptions.indicatorSize,
-      backgroundColor: selectionOptions.color,
+      top: -selectionOptionsWithDefaults.indicatorSize / 2 + 2,
+      right: -selectionOptionsWithDefaults.indicatorSize / 2 + 1,
+      width: selectionOptionsWithDefaults.indicatorSize,
+      height: selectionOptionsWithDefaults.indicatorSize,
+      backgroundColor: selectionOptionsWithDefaults.color,
       alignItems: 'center',
       justifyContent: 'center',
     },


### PR DESCRIPTION
I had to fix my recent change in Card component and to always allow overflow to be visible (for Android and iOS). this is in order to support the overflowing of the selection mode. 
regardless, I guess it makes sense to avoid hiding card's overflow content. 