### PR TITLE
Cloning props.tags

### DIFF
--- a/src/components/tagsInput/index.js
+++ b/src/components/tagsInput/index.js
@@ -97,7 +97,7 @@ export default class TagsInput extends BaseComponent {
 
     this.state = {
       value: props.value,
-      tags: props.tags || [],
+      tags: _.cloneDeep(props.tags) || [],
       tagIndexToRemove: undefined
     };
   }


### PR DESCRIPTION
Cloning tags from props to avoid array manipulations by ref that affect the original array (this.props.tags)