### PR TITLE
fix for warning:

### DIFF
--- a/src/components/inputs/TextField.js
+++ b/src/components/inputs/TextField.js
@@ -388,6 +388,8 @@ export default class TextField extends BaseInput {
       return renderExpandable(this.getThemeProps(), this.state);
     }
 
+    const textInputProps = TextField.extractOwnProps(this.props, 'error');
+
     return (
       <Modal
         animationType={'slide'}
@@ -404,7 +406,7 @@ export default class TextField extends BaseInput {
             ref={(textarea) => {
               this.expandableInput = textarea;
             }}
-            {...this.props}
+            {...textInputProps}
             value={this.state.value}
           />
         </View>


### PR DESCRIPTION
 'Failed prop type: Invalid prop 'error' of type 'string' supplied to 'TextArea', expected 'boolean'.