### PR TITLE
Bug/getColorTint support for single Ui-Lib colors

### DIFF
--- a/src/style/__tests__/colors.spec.js
+++ b/src/style/__tests__/colors.spec.js
@@ -74,6 +74,10 @@ describe('style/Colors', () => {
       expect(uut.getColorTint(undefined, 10)).toEqual(undefined);
     });
 
+    it('should handle a color which exists in uiLib but doesn\'t have predefined tints', () => {
+      expect(uut.getColorTint('#000000', 60)).toEqual('#B3B3B3');
+    });
+
     it('should handle color that does not exist in uilib', () => {
       expect(uut.getColorTint('#F1BE0B', 10)).toEqual('#624D04');
       expect(uut.getColorTint('#F1BE0B', 20)).toEqual('#927307');

--- a/src/style/colors.js
+++ b/src/style/colors.js
@@ -74,8 +74,6 @@ class Colors {
   }
 
   getColorTint(color, tintKey) {
-    const dynamicHexColor = this.getTintedColorForDynamicHex(color, tintKey);
-
     if (_.isUndefined(tintKey) || isNaN(tintKey) || _.isUndefined(color)) {
       console.error('"Colors.getColorTint" must accept a color and tintKey params');
       return color;
@@ -92,11 +90,11 @@ class Colors {
       const requiredColor = this[requiredColorKey];
 
       if (_.isUndefined(requiredColor)) {
-        return dynamicHexColor;
+        return this.getTintedColorForDynamicHex(color, tintKey);
       }
       return requiredColor;
     }
-    return dynamicHexColor;
+    return this.getTintedColorForDynamicHex(color, tintKey);
   }
 
   getTintedColorForDynamicHex(color, tintKey) {

--- a/src/style/colors.js
+++ b/src/style/colors.js
@@ -74,6 +74,8 @@ class Colors {
   }
 
   getColorTint(color, tintKey) {
+    const dynamicHexColor = this.getTintedColorForDynamicHex(color, tintKey);
+
     if (_.isUndefined(tintKey) || isNaN(tintKey) || _.isUndefined(color)) {
       console.error('"Colors.getColorTint" must accept a color and tintKey params');
       return color;
@@ -90,17 +92,19 @@ class Colors {
       const requiredColor = this[requiredColorKey];
 
       if (_.isUndefined(requiredColor)) {
-        console.warn('"Colors.getColorTint" could not find color with this tint');
-        return color;
+        return dynamicHexColor;
       }
       return requiredColor;
-    } else {
-      // Handles dynamic colors (non uilib colors)
-      let tintLevel = Math.floor(Number(tintKey) / 10 + 1);
-      tintLevel = Math.max(2, tintLevel);
-      tintLevel = Math.min(9, tintLevel);
-      return generateColorTint(color, tintLevel * 10);
     }
+    return dynamicHexColor;
+  }
+
+  getTintedColorForDynamicHex(color, tintKey) {
+    // Handles dynamic colors (non uilib colors)
+    let tintLevel = Math.floor(Number(tintKey) / 10 + 1);
+    tintLevel = Math.max(2, tintLevel);
+    tintLevel = Math.min(9, tintLevel);
+    return generateColorTint(color, tintLevel * 10);
   }
 
   generateColorPalette(color) {


### PR DESCRIPTION
- Fixed exception where ui-lib Colors without tint variants returned original color instead of tinted one.
- Added test coverage