### PR TITLE
Fix/TagsInput-Handle undefined tag

### DIFF
--- a/src/components/tagsInput/index.js
+++ b/src/components/tagsInput/index.js
@@ -131,7 +131,7 @@ export default class TagsInput extends BaseComponent {
     const {value, tags} = this.state;
     
     if (disableTagAdding) return;
-    if (_.isEmpty(value.trim())) return;
+    if (_.isNil(value) || _.isEmpty(value.trim())) return;
 
     const newTag = _.isFunction(onCreateTag) ? onCreateTag(value) : value;
     const newTags = [...tags, newTag];


### PR DESCRIPTION
Bug: When entering an empty tag value it was sent undefined and an error was thrown.
Now does not allow sending an empty tag (does nothing).