### PR TITLE
react-native-interactable version inc

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-native-animatable": "^1.1.0",
     "react-native-blur": "^3.1.1",
     "react-native-gesture-handler": "^1.1.0",
-    "react-native-interactable": "0.1.10",
+    "react-native-interactable": "1.0.0-alpha.1",
     "react-native-reanimated": "^1.0.0-alpha.12",
     "react-native-text-size": "^2.0.4",
     "semver": "^5.5.0",


### PR DESCRIPTION
fix for 
`Could not list contents of '/{project-folder}/node_modules/react-native-interactable/{ios,android}'. Couldn't follow symbolic link.`
