### PR TITLE
Do not compare unnecessary prop values in modifiers

### DIFF
--- a/src/commons/baseComponent.js
+++ b/src/commons/baseComponent.js
@@ -83,7 +83,8 @@ export default function baseComponent(usePure) {
     }
 
     updateModifiers(currentProps, nextProps) {
-      const allKeys = _.union([..._.keys(currentProps), ..._.keys(nextProps)]);
+      const ignoredKeys = ['children', 'forwardedRef', 'style', 'testID'];
+      const allKeys = _.union([..._.keys(currentProps), ..._.keys(nextProps)]).filter((key) => !ignoredKeys.includes(key));
       const changedKeys = _.filter(allKeys, key => !_.isEqual(currentProps[key], nextProps[key]));
 
       const options = {};

--- a/src/commons/modifiers.js
+++ b/src/commons/modifiers.js
@@ -254,7 +254,8 @@ props = this.props,) {
 }
 
 export function getAlteredModifiersOptions(currentProps, nextProps) {
-  const allKeys = _.union([..._.keys(currentProps), ..._.keys(nextProps)]);
+  const ignoredKeys = ['children', 'forwardedRef', 'style', 'testID'];
+  const allKeys = _.union([..._.keys(currentProps), ..._.keys(nextProps)]).filter((key) => !ignoredKeys.includes(key));
   const changedKeys = _.filter(allKeys, key => !_.isEqual(currentProps[key], nextProps[key]));
 
   const options = {};


### PR DESCRIPTION
`updateModifiers` and `getAlteredModifiersOptions` were doing deep comparisons with prop values, and `children` prop was not excluded, leading to really long execution times (in some cases, 500-5000ms per render).

I excluded children, forwardedRef, style and testID props, these are not required to extract modifiers.