### PR TITLE
Bug Fix: Invariant Violation issue/Malformed calls from JS

### DIFF
--- a/src/helpers/Constants.js
+++ b/src/helpers/Constants.js
@@ -22,11 +22,13 @@ const {StatusBarManager} = NativeModules;
 export let statusBarHeight = setStatusBarHeight();
 
 function setStatusBarHeight() {
-  statusBarHeight = isIOS ? 20 : StatusBarManager.HEIGHT;
+  let height = 0;
+  height = isIOS ? 20 : StatusBarManager.HEIGHT;
   if (isIOS) {
     // override guesstimate height with the actual height from StatusBarManager
-    StatusBarManager.getHeight(data => (statusBarHeight = data.height));
+    StatusBarManager.getHeight(data => (height = data.height));
   }
+  return height;
 }
 
 /* Layout */


### PR DESCRIPTION
It seems like the value of **`StatusBarManager.HEIGHT`** inside 
> `/react-native-ui-lib/src/helpers/Constants.js`
 is always resulting to **`undefined`** when called inside the container stylesheet of the following file: 
> `/react-native-ui-lib/src/screensComponents/modal/TopBar.js`

That's why it's showing up the error height: "NaN" as referenced by this #539 and #536 

You have a problem with the way you are exporting the **setStatusBarHeight** method inside the **Constants.js** file.

Fix: 

```
function setStatusBarHeight() {
  let height = 0;
  height = isIOS ? 20 : StatusBarManager.HEIGHT;
  if (isIOS) {
    // override guesstimate height with the actual height from StatusBarManager
    StatusBarManager.getHeight(data => (height = data.height));
  }
  return height;
}

```