### PR TITLE
Button - onOrientationChange re-render

### DIFF
--- a/demo/src/screens/componentScreens/ButtonsScreen.js
+++ b/demo/src/screens/componentScreens/ButtonsScreen.js
@@ -65,7 +65,7 @@ export default class ButtonsScreen extends DemoScreen {
     return (
       <View useSafeArea>
         {!!snippet && <SnippetBlock snippet={snippet} onClose={() => this.hideSnippet()}/>}
-        <ScrollView>
+        <ScrollView showsVerticalScrollIndicator={false}>
           <View centerH>
             <Text style={styles.title}>Buttons</Text>
 

--- a/src/components/button/index.js
+++ b/src/components/button/index.js
@@ -176,6 +176,21 @@ export default class Button extends PureBaseComponent {
     }
   }
 
+  componentDidMount() {
+    Constants.addDimensionsEventListener(this.onOrientationChanged);
+  }
+
+  componentWillUnmount() {
+    Constants.removeDimensionsEventListener(this.onOrientationChanged);
+  }
+
+  onOrientationChanged = () => {
+    if (Constants.isTablet && this.props.fullWidth) {
+      // only to trigger re-render
+      this.setState({isLandscape: Constants.isLandscape});
+    }
+  };
+
   // This method will be called more than once in case of layout change!
   onLayout = event => {
     const height = event.nativeEvent.layout.height;


### PR DESCRIPTION
Adding onOrientationChange event to trigger re-render on tablets when 'fullWidth' is passed.