### PR TITLE
swipeable: mark componentWillUpdate as unsafe

### DIFF
--- a/src/interactableComponents/drawer/Swipeable.js
+++ b/src/interactableComponents/drawer/Swipeable.js
@@ -91,7 +91,7 @@ export default class Swipeable extends Component<PropType, StateType> {
     });
   }
 
-  componentWillUpdate(props: PropType, state: StateType) {
+  UNSAFE_componentWillUpdate(props: PropType, state: StateType) {
     if (
       this.props.friction !== props.friction ||
       this.props.overshootLeft !== props.overshootLeft ||


### PR DESCRIPTION
This component should be deprecated soon. For now this will get rid of Reace lifecycle hooks warning