### PR TITLE
Adding carousel support to tab controller

### DIFF
--- a/demo/src/screens/incubatorScreens/TabControllerScreen/index.js
+++ b/demo/src/screens/incubatorScreens/TabControllerScreen/index.js
@@ -6,18 +6,19 @@ import Tab1 from './tab1';
 import Tab2 from './tab2';
 import Tab3 from './tab3';
 
-const TABS = ['tab1', 'tab2' , 'tab3', 'account', 'groups', 'blog'];
+const USE_CAROUSEL = true;
+const TABS = ['tab1', 'tab2', 'tab3', 'account', 'groups', 'blog'];
 
 class TabControllerScreen extends Component {
   state = {
     selectedIndex: 0,
     items: [
       ..._.map(TABS, tab => ({label: tab, key: tab})),
-      {key: 'addTabs', icon: Assets.icons.settings, ignore: true, onPress: this.addTab},
+      {key: 'addTabs', icon: Assets.icons.settings, ignore: true, onPress: this.addTab}
     ],
 
     tabsCount: 3,
-    key: Date.now(),
+    key: Date.now()
   };
 
   componentDidMount() {
@@ -44,11 +45,14 @@ class TabControllerScreen extends Component {
 
   getItems = () => {
     const {tabsCount} = this.state;
-    const items = _.chain(TABS).take(tabsCount).map(tab => ({label: tab, key: tab})).value();
+    const items = _.chain(TABS)
+      .take(tabsCount)
+      .map(tab => ({label: tab, key: tab}))
+      .value();
     items.push({key: 'addTabs', icon: Assets.icons.settings, ignore: true, onPress: this.addTab});
 
     return items;
-  }
+  };
 
   // renderTabItems() {
   //   const {tabsCount} = this.state;
@@ -68,27 +72,29 @@ class TabControllerScreen extends Component {
   // }
 
   renderTabPages() {
+    const Container = USE_CAROUSEL ? Incubator.TabController.PageCarousel : View;
+    const containerProps = USE_CAROUSEL ? {} : {flex: true};
     return (
-      <View flex>
-        <Incubator.TabController.TabPage index={0}>
-          <Tab1 />
+      <Container {...containerProps}>
+        <Incubator.TabController.TabPage asCarouselPage={USE_CAROUSEL} index={0}>
+          <Tab1/>
         </Incubator.TabController.TabPage>
-        <Incubator.TabController.TabPage index={1} lazy>
-          <Tab2 />
+        <Incubator.TabController.TabPage asCarouselPage={USE_CAROUSEL} index={1} lazy={!USE_CAROUSEL}>
+          <Tab2/>
         </Incubator.TabController.TabPage>
-        <Incubator.TabController.TabPage index={2}>
-          <Tab3 />
+        <Incubator.TabController.TabPage asCarouselPage={USE_CAROUSEL} index={2}>
+          <Tab3/>
         </Incubator.TabController.TabPage>
-        <Incubator.TabController.TabPage index={3}>
+        {/* <Incubator.TabController.TabPage asCarouselPage={USE_CAROUSEL} index={3}>
           <Text text40>ACCOUNT</Text>
         </Incubator.TabController.TabPage>
-        <Incubator.TabController.TabPage index={4}>
+        <Incubator.TabController.TabPage asCarouselPage={USE_CAROUSEL} index={4}>
           <Text text40>GROUPS</Text>
         </Incubator.TabController.TabPage>
-        <Incubator.TabController.TabPage index={5}>
+        <Incubator.TabController.TabPage asCarouselPage={USE_CAROUSEL} index={5}>
           <Text text40>BLOG</Text>
-        </Incubator.TabController.TabPage>
-      </View>
+        </Incubator.TabController.TabPage> */}
+      </Container>
     );
   }
 

--- a/demo/src/screens/incubatorScreens/TabControllerScreen/index.js
+++ b/demo/src/screens/incubatorScreens/TabControllerScreen/index.js
@@ -76,22 +76,22 @@ class TabControllerScreen extends Component {
     const containerProps = USE_CAROUSEL ? {} : {flex: true};
     return (
       <Container {...containerProps}>
-        <Incubator.TabController.TabPage asCarouselPage={USE_CAROUSEL} index={0}>
+        <Incubator.TabController.TabPage index={0}>
           <Tab1/>
         </Incubator.TabController.TabPage>
-        <Incubator.TabController.TabPage asCarouselPage={USE_CAROUSEL} index={1} lazy={!USE_CAROUSEL}>
+        <Incubator.TabController.TabPage index={1} lazy={!USE_CAROUSEL}>
           <Tab2/>
         </Incubator.TabController.TabPage>
-        <Incubator.TabController.TabPage asCarouselPage={USE_CAROUSEL} index={2}>
+        <Incubator.TabController.TabPage index={2}>
           <Tab3/>
         </Incubator.TabController.TabPage>
-        {/* <Incubator.TabController.TabPage asCarouselPage={USE_CAROUSEL} index={3}>
+        {/* <Incubator.TabController.TabPage index={3}>
           <Text text40>ACCOUNT</Text>
         </Incubator.TabController.TabPage>
-        <Incubator.TabController.TabPage asCarouselPage={USE_CAROUSEL} index={4}>
+        <Incubator.TabController.TabPage index={4}>
           <Text text40>GROUPS</Text>
         </Incubator.TabController.TabPage>
-        <Incubator.TabController.TabPage asCarouselPage={USE_CAROUSEL} index={5}>
+        <Incubator.TabController.TabPage index={5}>
           <Text text40>BLOG</Text>
         </Incubator.TabController.TabPage> */}
       </Container>
@@ -99,12 +99,13 @@ class TabControllerScreen extends Component {
   }
 
   render() {
-    const {key, selectedIndex, items} = this.state;
+    const {key, selectedIndex} = this.state;
     return (
       <View flex bg-dark80>
         <View flex>
           <Incubator.TabController
             key={key}
+            asCarousel={USE_CAROUSEL}
             selectedIndex={selectedIndex}
             _onChangeIndex={index => console.warn('tab index is', index)}
           >

--- a/src/components/carousel/index.js
+++ b/src/components/carousel/index.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {StyleSheet} from 'react-native';
+import {StyleSheet, ScrollView} from 'react-native';
 import Animated from 'react-native-reanimated';
 import {Constants} from '../../helpers';
 import {Colors} from '../../style';
@@ -116,6 +116,11 @@ export default class Carousel extends BaseComponent {
 
   generateStyles() {
     this.styles = createStyles(this.props);
+  }
+
+  shouldUseAnimatedCarousel() {
+    const {onScroll} = this.props;
+    return _.isObject(onScroll);
   }
 
   updateOffset = (animated = false) => {
@@ -288,9 +293,11 @@ export default class Carousel extends BaseComponent {
     const scrollContainerStyle = this.shouldUsePageWidth() ? {paddingRight: itemSpacings} : undefined;
     const snapToOffsets = this.getSnapToOffsets();
 
+    const ScrollViewContainer = this.shouldUseAnimatedCarousel() ? Animated.ScrollView : ScrollView;
+
     return (
       <View style={containerStyle} onLayout={this.onContainerLayout}>
-        <Animated.ScrollView
+        <ScrollViewContainer
           {...others}
           ref={this.carousel}
           contentContainerStyle={scrollContainerStyle}
@@ -301,11 +308,11 @@ export default class Carousel extends BaseComponent {
           contentOffset={initialOffset} // iOS only
           scrollEventThrottle={200}
           onContentSizeChange={this.onContentSizeChange}
-          onScroll={_.isObject(onScroll) ? onScroll : this.onScroll}
+          onScroll={this.shouldUseAnimatedCarousel() ? onScroll : this.onScroll}
           onMomentumScrollEnd={this.onMomentumScrollEnd}
         >
           {this.renderChildren()}
-        </Animated.ScrollView>
+        </ScrollViewContainer>
         {this.renderPageControl()}
         {this.renderCounter()}
       </View>

--- a/src/components/carousel/index.js
+++ b/src/components/carousel/index.js
@@ -1,7 +1,8 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {ScrollView, StyleSheet} from 'react-native';
+import {StyleSheet} from 'react-native';
+import Animated from 'react-native-reanimated';
 import {Constants} from '../../helpers';
 import {Colors} from '../../style';
 import {BaseComponent} from '../../commons';
@@ -121,8 +122,9 @@ export default class Carousel extends BaseComponent {
       (Constants.screenWidth - this.state.pageWidth) / 2 : 0;
     const x = presenter.calcOffset(this.props, this.state) - centerOffset;
 
-    if (this.carousel) {
-      this.carousel.current.scrollTo({x, animated});
+    const node = _.invoke(this.carousel, 'current.getNode') || _.get(this.carousel, 'current');
+    if (node) {
+      node.scrollTo({x, animated});
 
       if (Constants.isAndroid) {
         // this is done to handle onMomentumScrollEnd not being called in Android:
@@ -133,7 +135,7 @@ export default class Carousel extends BaseComponent {
     }
   };
 
-  goToPage(pageIndex, animated = true) {
+  goToPage = (pageIndex, animated = true) => {
     this.setState({currentPage: this.getCalcIndex(pageIndex)}, () => this.updateOffset(animated));
   }
 
@@ -281,14 +283,14 @@ export default class Carousel extends BaseComponent {
   }
 
   render() {
-    const {containerStyle, itemSpacings, ...others} = this.props;
+    const {containerStyle, itemSpacings, onScroll, ...others} = this.props;
     const {initialOffset} = this.state;
     const scrollContainerStyle = this.shouldUsePageWidth() ? {paddingRight: itemSpacings} : undefined;
     const snapToOffsets = this.getSnapToOffsets();
 
     return (
       <View style={containerStyle} onLayout={this.onContainerLayout}>
-        <ScrollView
+        <Animated.ScrollView
           {...others}
           ref={this.carousel}
           contentContainerStyle={scrollContainerStyle}
@@ -299,11 +301,11 @@ export default class Carousel extends BaseComponent {
           contentOffset={initialOffset} // iOS only
           scrollEventThrottle={200}
           onContentSizeChange={this.onContentSizeChange}
-          onScroll={this.onScroll}
+          onScroll={_.isObject(onScroll) ? onScroll : this.onScroll}
           onMomentumScrollEnd={this.onMomentumScrollEnd}
         >
           {this.renderChildren()}
-        </ScrollView>
+        </Animated.ScrollView>
         {this.renderPageControl()}
         {this.renderCounter()}
       </View>

--- a/src/components/carousel/index.js
+++ b/src/components/carousel/index.js
@@ -1,8 +1,7 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {StyleSheet, ScrollView} from 'react-native';
-import Animated from 'react-native-reanimated';
+import {ScrollView, StyleSheet} from 'react-native';
 import {Constants} from '../../helpers';
 import {Colors} from '../../style';
 import {BaseComponent} from '../../commons';
@@ -52,7 +51,7 @@ export default class Carousel extends BaseComponent {
     /**
      * callback for onScroll event of the internal ScrollView
      */
-    onScroll: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+    onScroll: PropTypes.func,
     /**
      * the carousel style
      */
@@ -118,19 +117,13 @@ export default class Carousel extends BaseComponent {
     this.styles = createStyles(this.props);
   }
 
-  shouldUseAnimatedCarousel() {
-    const {onScroll} = this.props;
-    return _.isObject(onScroll);
-  }
-
   updateOffset = (animated = false) => {
     const centerOffset = Constants.isIOS && this.shouldUsePageWidth() ? 
       (Constants.screenWidth - this.state.pageWidth) / 2 : 0;
     const x = presenter.calcOffset(this.props, this.state) - centerOffset;
 
-    const node = _.invoke(this.carousel, 'current.getNode') || _.get(this.carousel, 'current');
-    if (node) {
-      node.scrollTo({x, animated});
+    if (this.carousel) {
+      this.carousel.current.scrollTo({x, animated});
 
       if (Constants.isAndroid) {
         // this is done to handle onMomentumScrollEnd not being called in Android:
@@ -141,7 +134,7 @@ export default class Carousel extends BaseComponent {
     }
   };
 
-  goToPage = (pageIndex, animated = true) => {
+  goToPage(pageIndex, animated = true) {
     this.setState({currentPage: this.getCalcIndex(pageIndex)}, () => this.updateOffset(animated));
   }
 
@@ -288,16 +281,14 @@ export default class Carousel extends BaseComponent {
   }
 
   render() {
-    const {containerStyle, itemSpacings, onScroll, ...others} = this.props;
+    const {containerStyle, itemSpacings, ...others} = this.props;
     const {initialOffset} = this.state;
     const scrollContainerStyle = this.shouldUsePageWidth() ? {paddingRight: itemSpacings} : undefined;
     const snapToOffsets = this.getSnapToOffsets();
 
-    const ScrollViewContainer = this.shouldUseAnimatedCarousel() ? Animated.ScrollView : ScrollView;
-
     return (
       <View style={containerStyle} onLayout={this.onContainerLayout}>
-        <ScrollViewContainer
+        <ScrollView
           {...others}
           ref={this.carousel}
           contentContainerStyle={scrollContainerStyle}
@@ -308,11 +299,11 @@ export default class Carousel extends BaseComponent {
           contentOffset={initialOffset} // iOS only
           scrollEventThrottle={200}
           onContentSizeChange={this.onContentSizeChange}
-          onScroll={this.shouldUseAnimatedCarousel() ? onScroll : this.onScroll}
+          onScroll={this.onScroll}
           onMomentumScrollEnd={this.onMomentumScrollEnd}
         >
           {this.renderChildren()}
-        </ScrollViewContainer>
+        </ScrollView>
         {this.renderPageControl()}
         {this.renderCounter()}
       </View>

--- a/src/components/carousel/index.js
+++ b/src/components/carousel/index.js
@@ -52,7 +52,7 @@ export default class Carousel extends BaseComponent {
     /**
      * callback for onScroll event of the internal ScrollView
      */
-    onScroll: PropTypes.func,
+    onScroll: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     /**
      * the carousel style
      */

--- a/src/incubator/TabController/PageCarousel.js
+++ b/src/incubator/TabController/PageCarousel.js
@@ -10,9 +10,6 @@ class PageCarousel extends Component {
   state = {
     scrollOffset: new Animated.Value(0)
   };
-
-  onChangePage = (index) => {
-  };
   
   onTabChange = ([index]) => {
     this.carousel.goToPage(index, true);
@@ -20,8 +17,6 @@ class PageCarousel extends Component {
 
   onScroll = Animated.event([{nativeEvent: {contentOffset: {x: this.context.carouselOffset}}}], {
     useNativeDriver: true
-    // listener: event => {
-    // }
   });
 
   render() {

--- a/src/incubator/TabController/PageCarousel.js
+++ b/src/incubator/TabController/PageCarousel.js
@@ -1,41 +1,40 @@
 import React, {Component} from 'react';
-import Carousel from '../../components/carousel';
 import TabBarContext from './TabBarContext';
 import Animated from 'react-native-reanimated';
+import {Constants} from '../../helpers';
 
 const {Code, block, call} = Animated;
 
 class PageCarousel extends Component {
   static contextType = TabBarContext;
-  state = {
-    scrollOffset: new Animated.Value(0)
-  };
-  
-  onTabChange = ([index]) => {
-    this.carousel.goToPage(index, true);
-  };
+  carousel = React.createRef();
 
   onScroll = Animated.event([{nativeEvent: {contentOffset: {x: this.context.carouselOffset}}}], {
     useNativeDriver: true
   });
 
+  onTabChange = ([index]) => {
+    const node = this.carousel.current.getNode();
+    node.scrollTo({x: index * Constants.screenWidth, animated: true});
+  };
+
   render() {
     const {currentPage} = this.context;
     return (
       <>
-        <Carousel
-          ref={r => (this.carousel = r)}
+        <Animated.ScrollView
           {...this.props}
-          onChangePage={this.onChangePage}
-          containerStyle={{flex: 1}}
+          ref={this.carousel}
+          horizontal
+          pagingEnabled
+          showsHorizontalScrollIndicator={false}
           onScroll={this.onScroll}
-          scrollEventThrottle={100}
+          scrollEventThrottle={200}
         />
+
         <Code>
           {() => {
-            return block([
-              call([currentPage], this.onTabChange)
-            ]);
+            return block([call([currentPage], this.onTabChange)]);
           }}
         </Code>
       </>

--- a/src/incubator/TabController/PageCarousel.js
+++ b/src/incubator/TabController/PageCarousel.js
@@ -1,0 +1,51 @@
+import React, {Component} from 'react';
+import Carousel from '../../components/carousel';
+import TabBarContext from './TabBarContext';
+import Animated from 'react-native-reanimated';
+
+const {Code, block, call} = Animated;
+
+class PageCarousel extends Component {
+  static contextType = TabBarContext;
+  state = {
+    scrollOffset: new Animated.Value(0)
+  };
+
+  onChangePage = (index) => {
+  };
+  
+  onTabChange = ([index]) => {
+    this.carousel.goToPage(index, true);
+  };
+
+  onScroll = Animated.event([{nativeEvent: {contentOffset: {x: this.context.carouselOffset}}}], {
+    useNativeDriver: true
+    // listener: event => {
+    // }
+  });
+
+  render() {
+    const {currentPage} = this.context;
+    return (
+      <>
+        <Carousel
+          ref={r => (this.carousel = r)}
+          {...this.props}
+          onChangePage={this.onChangePage}
+          containerStyle={{flex: 1}}
+          onScroll={this.onScroll}
+          scrollEventThrottle={100}
+        />
+        <Code>
+          {() => {
+            return block([
+              call([currentPage], this.onTabChange)
+            ]);
+          }}
+        </Code>
+      </>
+    );
+  }
+}
+
+export default PageCarousel;

--- a/src/incubator/TabController/TabPage.js
+++ b/src/incubator/TabController/TabPage.js
@@ -23,7 +23,11 @@ export default class TabPage extends PureComponent {
     /**
      * Whether this page should be loaded lazily
      */
-    lazy: PropTypes.bool
+    lazy: PropTypes.bool,
+    /**
+     * Is page being rendered in a page carousel
+     */
+    asCarouselPage: PropTypes.bool
   };
 
   static defaultProps = {
@@ -36,7 +40,11 @@ export default class TabPage extends PureComponent {
 
   _opacity = new Value(0);
   _zIndex = new Value(0);
-  _pageStyle = [styles.page, {opacity: this._opacity}, {zIndex: this._zIndex}];
+  _pageStyle = [
+    {opacity: this._opacity},
+    this.props.asCarouselPage ? styles.carouselPage : styles.page,
+    {zIndex: this._zIndex}
+  ];
 
   lazyLoad = () => {
     this.setState({
@@ -58,7 +66,7 @@ export default class TabPage extends PureComponent {
               cond(and(eq(currentPage, index), lazy, !loaded), call([], this.lazyLoad)),
               cond(eq(currentPage, index),
                 [set(this._opacity, 1), set(this._zIndex, 1)],
-                [set(this._opacity, 0), set(this._zIndex, 0)],)
+                [set(this._opacity, 0), set(this._zIndex, 0)])
             ]);
           }}
         </Code>
@@ -70,5 +78,9 @@ export default class TabPage extends PureComponent {
 const styles = StyleSheet.create({
   page: {
     ...StyleSheet.absoluteFillObject
+  },
+  carouselPage: {
+    flex: 1,
+    opacity: 1
   }
 });

--- a/src/incubator/TabController/TabPage.js
+++ b/src/incubator/TabController/TabPage.js
@@ -23,11 +23,7 @@ export default class TabPage extends PureComponent {
     /**
      * Whether this page should be loaded lazily
      */
-    lazy: PropTypes.bool,
-    /**
-     * Is page being rendered in a page carousel
-     */
-    asCarouselPage: PropTypes.bool
+    lazy: PropTypes.bool
   };
 
   static defaultProps = {
@@ -42,7 +38,7 @@ export default class TabPage extends PureComponent {
   _zIndex = new Value(0);
   _pageStyle = [
     {opacity: this._opacity},
-    this.props.asCarouselPage ? styles.carouselPage : styles.page,
+    this.context.asCarousel ? styles.carouselPage : styles.page,
     {zIndex: this._zIndex}
   ];
 

--- a/src/incubator/TabController/TabPage.js
+++ b/src/incubator/TabController/TabPage.js
@@ -3,6 +3,7 @@ import {StyleSheet} from 'react-native';
 import PropTypes from 'prop-types';
 import Reanimated from 'react-native-reanimated';
 import TabBarContext from './TabBarContext';
+import {Constants} from '../../helpers';
 
 const {Code, Value, cond, set, and, call, block, eq} = Reanimated;
 
@@ -76,6 +77,7 @@ const styles = StyleSheet.create({
     ...StyleSheet.absoluteFillObject
   },
   carouselPage: {
+    width: Constants.screenWidth,
     flex: 1,
     opacity: 1
   }

--- a/src/incubator/TabController/index.js
+++ b/src/incubator/TabController/index.js
@@ -13,7 +13,7 @@ import TabBarItem from './TabBarItem';
 import TabPage from './TabPage';
 import PageCarousel from './PageCarousel';
 
-const {cond, Code, and, eq, set, Value, block} = Reanimated;
+const {cond, Code, and, eq, set, Value, block, round} = Reanimated;
 
 /**
  * @description: A performant solution for a tab controller with lazy load mechanism
@@ -75,6 +75,9 @@ class TabController extends Component {
 
   render() {
     const {itemStates, ignoredItems} = this.state;
+    
+    // Rounding on Android, cause it cause issues when comparing values
+    const screenWidth = Constants.isAndroid ? Math.round(Constants.screenWidth) : Constants.screenWidth;
 
     return (
       <TabBarContext.Provider value={this.getProviderContextValue()}>
@@ -84,8 +87,10 @@ class TabController extends Component {
             {() =>
               block([
                 // Carousel Page change
-                ..._.times(itemStates.length, (index) => {
-                  return cond(eq(this._carouselOffset, index * Constants.screenWidth), set(this._currentPage, index));
+                ..._.times(itemStates.length, index => {
+                  return cond(eq(Constants.isAndroid ? round(this._carouselOffset) : this._carouselOffset,
+                    index * screenWidth),
+                  [set(this._currentPage, index)]);
                 }),
                 // TabBar Page change
                 ..._.map(itemStates, (state, index) => {

--- a/src/incubator/TabController/index.js
+++ b/src/incubator/TabController/index.js
@@ -35,11 +35,15 @@ class TabController extends Component {
     /**
      * callback for when index has change (will not be called on ignored items)
      */
-    onChangeIndex: PropTypes.func
+    onChangeIndex: PropTypes.func,
     // /**
     //  * callback for when tab selected
     //  */
     // onTabSelected: PropTypes.func,
+    /**
+     * When using TabController.PageCarousel this should be turned on
+     */
+    asCarousel: PropTypes.bool
   };
 
   static defaultProps = {
@@ -57,14 +61,15 @@ class TabController extends Component {
 
   getProviderContextValue = () => {
     const {itemStates} = this.state;
-    const {onChangeIndex, selectedIndex} = this.props;
+    const {onChangeIndex, selectedIndex, asCarousel} = this.props;
     return {
       selectedIndex,
       currentPage: this._currentPage,
       carouselOffset: this._carouselOffset,
       itemStates,
       registerTabItems: this.registerTabItems,
-      onChangeIndex
+      onChangeIndex,
+      asCarousel
     };
   };
 

--- a/src/incubator/TabController/index.js
+++ b/src/incubator/TabController/index.js
@@ -13,7 +13,7 @@ import TabBarItem from './TabBarItem';
 import TabPage from './TabPage';
 import PageCarousel from './PageCarousel';
 
-const {cond, Code, and, eq, set, Value, block, round} = Reanimated;
+const {cond, Code, and, eq, set, Value, block} = Reanimated;
 
 /**
  * @description: A performant solution for a tab controller with lazy load mechanism
@@ -75,7 +75,6 @@ class TabController extends Component {
 
   render() {
     const {itemStates, ignoredItems} = this.state;
-    const screenWidth = Math.round(Constants.screenWidth);
 
     return (
       <TabBarContext.Provider value={this.getProviderContextValue()}>
@@ -85,9 +84,9 @@ class TabController extends Component {
             {() =>
               block([
                 // Carousel Page change
-                cond(eq(round(this._carouselOffset), 0), set(this._currentPage, 0)),
-                cond(eq(round(this._carouselOffset), screenWidth), set(this._currentPage, 1)),
-                cond(eq(round(this._carouselOffset), screenWidth * 2), set(this._currentPage, 2)),
+                ..._.times(itemStates.length, (index) => {
+                  return cond(eq(this._carouselOffset, index * Constants.screenWidth), set(this._currentPage, index));
+                }),
                 // TabBar Page change
                 ..._.map(itemStates, (state, index) => {
                   return [


### PR DESCRIPTION
In general, I added the option for the user to wrap `TabPage`s with `PageCarousel` component.
this will change the behavior of the TabController to render the pages as carousel instead of single page each time.

I made some changes in `Carousel` component to allow it to accept `Animated.event` for `onScroll` instead of a function. This way I can intercept the carousel offset position to use in the TabController. 
