### PR TITLE
Fix typo

### DIFF
--- a/uilib-docs/.gitignore
+++ b/uilib-docs/.gitignore
@@ -36,7 +36,7 @@ build/Release
 node_modules/
 jspm_packages/
 
-# Typescript v1 declaration files
+# TypeScript v1 declaration files
 typings/
 
 # Optional npm cache directory

--- a/uilib-docs/src/components/header.js
+++ b/uilib-docs/src/components/header.js
@@ -16,7 +16,7 @@ const Header = () => {
       <div className="links">
         <Link to="/docs/">Docs</Link>
         <a target="_blank" href="https://github.com/wix/react-native-ui-lib">
-          Github
+          GitHub
         </a>
         <a target="_blank" href="https://github.com/wix/react-native-ui-lib/wiki">
           Wiki


### PR DESCRIPTION
Two minor typo fixes:

- `Typescript` -> `TypeScript`
- `Github` -> `GitHub`