### PR TITLE
Render FloatingButton in SafeAreaView

### DIFF
--- a/src/components/floatingButton/index.js
+++ b/src/components/floatingButton/index.js
@@ -137,28 +137,33 @@ class FloatingButton extends BaseComponent {
     }
 
     return (
-      <SafeAreaView>
-        <View>
-          <Container
-            pointerEvents="box-none"
-            style={[styles.animatedContainer, Constants.isAndroid && {zIndex: 99}]}
-            animation={!isVisible ? 'fadeOutDown' : 'fadeInUp'}
-            duration={SHOW_ANIMATION_DURATION}
-            delay={!isVisible ? HIDE_ANIMATION_DURATION : SHOW_ANIMATION_DELAY}
-            easing={'ease-out'}
-            onAnimationEnd={this.onAnimationEnd}
-          >
-            {this.renderOverlay()}
-            {this.renderButton()}
-            {secondaryButton && this.renderSecondaryButton()}
-          </Container>
-        </View>
+      <SafeAreaView style={styles.safeArea}>
+        <Container
+          pointerEvents="box-none"
+          style={[styles.animatedContainer, Constants.isAndroid && {zIndex: 99}]}
+          animation={!isVisible ? 'fadeOutDown' : 'fadeInUp'}
+          duration={SHOW_ANIMATION_DURATION}
+          delay={!isVisible ? HIDE_ANIMATION_DURATION : SHOW_ANIMATION_DELAY}
+          easing={'ease-out'}
+          onAnimationEnd={this.onAnimationEnd}
+        >
+          {this.renderOverlay()}
+          {this.renderButton()}
+          {secondaryButton && this.renderSecondaryButton()}
+        </Container>
       </SafeAreaView>
     );
   }
 }
 
 const styles = StyleSheet.create({
+  safeArea: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    top: 0
+  },
   animatedContainer: {
     position: 'absolute',
     left: 0,

--- a/src/components/floatingButton/index.js
+++ b/src/components/floatingButton/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {StyleSheet} from 'react-native';
+import {StyleSheet, SafeAreaView} from 'react-native';
 import {View as AnimatableView} from 'react-native-animatable';
 import {Constants, Colors, Spacings, BaseComponent, View, Image, Button} from 'react-native-ui-lib';
 
@@ -137,19 +137,23 @@ class FloatingButton extends BaseComponent {
     }
 
     return (
-      <Container
-        pointerEvents="box-none"
-        style={[styles.animatedContainer, Constants.isAndroid && {zIndex: 99}]}
-        animation={!isVisible ? 'fadeOutDown' : 'fadeInUp'}
-        duration={SHOW_ANIMATION_DURATION}
-        delay={!isVisible ? HIDE_ANIMATION_DURATION : SHOW_ANIMATION_DELAY}
-        easing={'ease-out'}
-        onAnimationEnd={this.onAnimationEnd}
-      >
-        {this.renderOverlay()}
-        {this.renderButton()}
-        {secondaryButton && this.renderSecondaryButton()}
-      </Container>
+      <SafeAreaView>
+        <View>
+          <Container
+            pointerEvents="box-none"
+            style={[styles.animatedContainer, Constants.isAndroid && {zIndex: 99}]}
+            animation={!isVisible ? 'fadeOutDown' : 'fadeInUp'}
+            duration={SHOW_ANIMATION_DURATION}
+            delay={!isVisible ? HIDE_ANIMATION_DURATION : SHOW_ANIMATION_DELAY}
+            easing={'ease-out'}
+            onAnimationEnd={this.onAnimationEnd}
+          >
+            {this.renderOverlay()}
+            {this.renderButton()}
+            {secondaryButton && this.renderSecondaryButton()}
+          </Container>
+        </View>
+      </SafeAreaView>
     );
   }
 }


### PR DESCRIPTION
When the view is rendered behind the UITabBar on iOS, the absolute position `bottom: 0` means that the button will be rendered behind the tab bar. That's why we need to wrap it in `SafeAreaView` so that `bottom: 0` will take the tab bar into consideration. 