### PR TITLE
fix accessibilityState in case of dynamic state change

### DIFF
--- a/src/components/inputs/TextField.js
+++ b/src/components/inputs/TextField.js
@@ -220,7 +220,7 @@ export default class TextField extends BaseInput {
 
     return {
       accessibilityLabel,
-      accessibilityStates: this.isDisabled() ? ['disabled'] : undefined
+      accessibilityStates: this.isDisabled() ? ['disabled'] : []
     };
   }
 

--- a/src/components/slider/index.js
+++ b/src/components/slider/index.js
@@ -380,7 +380,7 @@ export default class Slider extends PureBaseComponent {
         accessibilityLabel={'Slider'}
         {...this.extractAccessibilityProps()}
         accessibilityRole={'adjustable'}
-        accessibilityStates={disabled ? ['disabled'] : undefined}
+        accessibilityStates={disabled ? ['disabled'] : []}
         // accessibilityActions={['increment', 'decrement']}
         accessibilityActions={[{name: 'increment', label: 'increment'}, {name: 'decrement', label: 'decrement'}]}
         onAccessibilityAction={this.onAccessibilityAction}

--- a/src/components/tabBar/TabBarItem.js
+++ b/src/components/tabBar/TabBarItem.js
@@ -174,7 +174,7 @@ export default class TabBarItem extends PureBaseComponent {
         testID={testID}
         activeBackgroundColor={activeBackgroundColor}
         onLayout={this.onLayout}
-        accessibilityStates={selected ? ['selected'] : undefined}
+        accessibilityStates={selected ? ['selected'] : []}
       >
         <View row flex center style={[showDivider && this.styles.divider, {paddingHorizontal: 16}]}>
           {icon && (


### PR DESCRIPTION
When the state (disable, selected etc.) of a component is changed dynamically the `accessibilityState` prop should change accordingly and not be set only once in the first render.