### PR TITLE
Fix ConnectionStatusBar NetInfo

### DIFF
--- a/jest-setup.js
+++ b/jest-setup.js
@@ -5,3 +5,4 @@ jest.spyOn(AccessibilityInfo, 'fetch').mockImplementation(() => new Promise.reso
 
 // mock native modules
 jest.mock('@react-native-community/blur', () => {});
+jest.mock('@react-native-community/netinfo', () => {});

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@react-native-community/blur": "^3.4.1",
     "@react-native-community/datetimepicker": "^2.1.0",
     "@react-native-community/eslint-config": "latest",
+    "@react-native-community/netinfo": "^5.6.2",
     "@types/prop-types": "^15.5.3",
     "@types/react-native": "^0.55.21",
     "@welldone-software/why-did-you-render": "^3.2.1",
@@ -92,7 +93,8 @@
     "react-native-gesture-handler": ">=1.5.0",
     "react-native-reanimated": ">=1.4.0",
     "@react-native-community/blur": ">=3.4.1",
-    "@react-native-community/datetimepicker": "^2.1.0"
+    "@react-native-community/datetimepicker": "^2.1.0",
+    "@react-native-community/netinfo": "^5.6.2"
   },
   "jest": {
     "preset": "react-native",

--- a/src/components/connectionStatusBar/index.js
+++ b/src/components/connectionStatusBar/index.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import {StyleSheet, Text, NetInfo} from 'react-native';
+import {StyleSheet, Text} from 'react-native';
+import NetInfo from '@react-native-community/netinfo';
 import {Constants} from '../../helpers';
 import {PureBaseComponent} from '../../commons';
 import {Colors, Typography} from '../../style';
@@ -66,12 +67,12 @@ export default class ConnectionStatusBar extends PureBaseComponent {
   }
 
   componentDidMount() {
-    this.netInfoListener = NetInfo.addEventListener('connectionChange', this.onConnectionChange);
+    this.unsubscribe = NetInfo.addEventListener(this.onConnectionChange);
   }
 
   componentWillUnmount() {
-    if (this.netInfoListener) {
-      this.netInfoListener.remove();
+    if (this.unsubscribe) {
+      this.unsubscribe();
     }
   }
 
@@ -99,8 +100,8 @@ export default class ConnectionStatusBar extends PureBaseComponent {
   }
 
   async getInitialConnectionState() {
-    const state = await NetInfo.getConnectionInfo();
-    const isConnected = this.isStateConnected(state);
+    const isConnected = (await NetInfo.fetch()).isConnected;
+
     this.setState({isConnected});
     if (this.props.onConnectionChange) {
       this.props.onConnectionChange(isConnected, true);


### PR DESCRIPTION
Since `NetInfo` moved from `react-native` to `@react-native-community/netinfo`, the component `ConnectionStatusBar` is not working anymore.