### PR TITLE
avoid passing to TextField accessibilityStates on Android

### DIFF
--- a/src/components/inputs/TextField.js
+++ b/src/components/inputs/TextField.js
@@ -226,9 +226,11 @@ export default class TextField extends BaseInput {
       accessibilityLabel = `${accessibilityLabel || ''}. ${value || ''}`;
     }
 
+    const accessibilityStates = this.isDisabled() ? ['disabled'] : [];
     return {
       accessibilityLabel,
-      accessibilityStates: this.isDisabled() ? ['disabled'] : []
+      // on Android accessibilityStates cause issues with expandable input
+      accessibilityStates: Constants.isIOS ? accessibilityStates : undefined
     };
   }
 


### PR DESCRIPTION
that caused the issue that made expandable input to not work (e.g Pickers)