### PR TITLE
create commons/new.ts for typescript migration

### DIFF
--- a/generatedTypes/commons/new.d.ts
+++ b/generatedTypes/commons/new.d.ts
@@ -1,0 +1,5 @@
+export { default as UIComponent } from './UIComponent';
+export { default as asBaseComponent } from './asBaseComponent';
+export { BaseComponentInjectedProps } from './asBaseComponent';
+export { default as forwardRef } from './forwardRef';
+export { ForwardRefInjectedProps } from './forwardRef';

--- a/generatedTypes/components/view/index.d.ts
+++ b/generatedTypes/components/view/index.d.ts
@@ -1,20 +1,19 @@
 import React from 'react';
 import { ViewProps } from 'react-native';
-import { BaseComponentInjectedProps } from '../../commons/asBaseComponent';
-import { ForwardRefInjectedProps } from '../../commons/forwardRef';
+import { BaseComponentInjectedProps, ForwardRefInjectedProps } from '../../commons/new';
 import { ContainerModifiers } from '../../../typings/modifiers';
-/**
- * @description: Wrapper component for React Native View component
- * @extends: View
- * @extendslink: https://facebook.github.io/react-native/docs/view.html
- * @modifiers: margins, paddings, alignments, background, borderRadius
- */
 interface ViewPropTypes extends ViewProps {
     /**
      * If true, will render as SafeAreaView
      */
     useSafeArea?: boolean;
+    /**
+     * Use Animate.View as a container
+     */
     animated?: boolean;
+    /**
+     * Turn off accessibility for this view and its nested children
+     */
     inaccessible?: boolean;
 }
 declare type PropsTypes = BaseComponentInjectedProps & ViewPropTypes & ForwardRefInjectedProps & ContainerModifiers;

--- a/src/commons/asBaseComponent.tsx
+++ b/src/commons/asBaseComponent.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
+//@ts-ignore
 import hoistStatics from 'hoist-non-react-statics';
 //@ts-ignore
 import * as Modifiers from './modifiers';

--- a/src/commons/forwardRef.tsx
+++ b/src/commons/forwardRef.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
+//@ts-ignore
 import hoistStatics from 'hoist-non-react-statics';
 
 export interface ForwardRefInjectedProps {
   forwardedRef: any;
 }
+
 export default function forwardRef<P>(WrappedComponent: React.ComponentType<P>): React.ComponentType<Omit<P, keyof ForwardRefInjectedProps>> {
   function forwardRef(props: P, ref: any) {
     return <WrappedComponent {...props} forwardedRef={ref}/>;

--- a/src/commons/new.ts
+++ b/src/commons/new.ts
@@ -1,0 +1,7 @@
+// TODO: this file should replace commons/index.js
+
+export {default as UIComponent} from './UIComponent';
+export {default as asBaseComponent} from './asBaseComponent';
+export {BaseComponentInjectedProps} from './asBaseComponent';
+export {default as forwardRef} from './forwardRef';
+export {ForwardRefInjectedProps} from './forwardRef';

--- a/src/components/view/index.tsx
+++ b/src/components/view/index.tsx
@@ -1,7 +1,6 @@
 import React, {PureComponent} from 'react';
 import {View as RNView, SafeAreaView, Animated, ViewProps} from 'react-native';
-import asBaseComponent, {BaseComponentInjectedProps} from '../../commons/asBaseComponent';
-import forwardRef, {ForwardRefInjectedProps} from '../../commons/forwardRef';
+import {asBaseComponent, forwardRef, BaseComponentInjectedProps, ForwardRefInjectedProps} from '../../commons/new';
 import Constants from '../../helpers/Constants';
 import {ContainerModifiers} from '../../../typings/modifiers';
 
@@ -48,7 +47,18 @@ class View extends PureComponent<PropsTypes> {
   render() {
     // (!) extract left, top, bottom... props to avoid passing them on Android
     // eslint-disable-next-line
-    const {modifiers, style, left, top, right, bottom, flex: propsFlex, forwardedRef, inaccessible, ...others} = this.props;
+    const {
+      modifiers,
+      style,
+      left,
+      top,
+      right,
+      bottom,
+      flex: propsFlex,
+      forwardedRef,
+      inaccessible,
+      ...others
+    } = this.props;
     const {backgroundColor, borderRadius, paddings, margins, alignments, flexStyle, positionStyle} = modifiers;
     const Element = this.Container;
     return (


### PR DESCRIPTION
in order to import with destruct all `commons` components I created a a separate file with the relevant components (that were already migrated to ts)  