### PR TITLE
fix custom modifier types to be strictly boolean

### DIFF
--- a/src/commons/modifiers.ts
+++ b/src/commons/modifiers.ts
@@ -74,10 +74,10 @@ export type AlignmentLiterals =
 | 'left' | 'right' | 'top' | 'bottom';
 
 export type Modifier<T extends string> = Partial<Record<T, boolean>>
-export type CustomModifier = {[key: string]: any};
+export type CustomModifier = {[key: string]: boolean};
 
-export type TypographyModifiers = Modifier<TypographyLiterals> & CustomModifier;
-export type ColorsModifiers = Modifier<ColorLiterals> & CustomModifier;
+export type TypographyModifiers = Modifier<TypographyLiterals> | CustomModifier;
+export type ColorsModifiers = Modifier<ColorLiterals> | CustomModifier;
 export type BackgroundColorModifier = Modifier<'bg'>;
 export type AlignmentModifiers = Modifier<AlignmentLiterals>;
 export type PaddingModifiers = Modifier<PaddingLiterals>;

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -13,7 +13,7 @@ import {Colors} from '../../style';
 import _ from 'lodash';
 
 
-interface TextPropTypes extends TextProps, TypographyModifiers, ColorsModifiers, MarginModifiers {
+type TextPropTypes = TextProps & TypographyModifiers & ColorsModifiers & MarginModifiers & {
   /**
    * color of the text
    */
@@ -43,7 +43,7 @@ interface TextPropTypes extends TextProps, TypographyModifiers, ColorsModifiers,
   textAlign?: string;
 }
 
-type PropsTypes = BaseComponentInjectedProps & ForwardRefInjectedProps & TextPropTypes;
+type PropsTypes = BaseComponentInjectedProps & ForwardRefInjectedProps & TextPropTypes & { [key: string]: boolean };
 
 /**
  * @description: A wrapper for Text component with extra functionality like modifiers support

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -43,7 +43,7 @@ type TextPropTypes = TextProps & TypographyModifiers & ColorsModifiers & MarginM
   textAlign?: string;
 }
 
-type PropsTypes = BaseComponentInjectedProps & ForwardRefInjectedProps & TextPropTypes & { [key: string]: boolean };
+type PropsTypes = BaseComponentInjectedProps & ForwardRefInjectedProps & TextPropTypes;
 
 /**
  * @description: A wrapper for Text component with extra functionality like modifiers support


### PR DESCRIPTION
Changed the typings of the `Text` component from `interface` to `type`.
Changed the `CustomModifier` type to be strictly boolean and integrated it with `ColorsModifiers` and `TypographyModifiers` via `Union` type rather than `Intersection` type.