### PR TITLE
Fix/dialog on dismiss

### DIFF
--- a/src/components/dialog/index.js
+++ b/src/components/dialog/index.js
@@ -99,7 +99,9 @@ class Dialog extends BaseComponent {
 
     this.setAlignment();
 
-    LogService.deprecationWarn({component: 'Dialog', oldProp: 'onModalDismissed', newProp: 'onDialogDismissed'});
+    if (!_.isUndefined(props.onModalDismissed)) {
+      LogService.deprecationWarn({component: 'Dialog', oldProp: 'onModalDismissed', newProp: 'onDialogDismissed'});
+    }
   }
 
   componentDidMount() {

--- a/src/components/dialog/index.js
+++ b/src/components/dialog/index.js
@@ -140,6 +140,10 @@ class Dialog extends BaseComponent {
       if (props.visible) {
         _.invoke(props, 'onDismiss', props);
       }
+      // Parity with iOS Modal's onDismiss
+      if (Constants.isAndroid) {
+        _.invoke(props, 'onModalDismissed', props);
+      }
     });
   };
 

--- a/src/components/dialog/index.js
+++ b/src/components/dialog/index.js
@@ -59,9 +59,13 @@ class Dialog extends BaseComponent {
      */
     useSafeArea: PropTypes.bool,
     /**
-     * Called once the modal has been dissmissed (iOS only)
+     * Called once the modal has been dismissed (iOS only) - Deprecated, use onDialogDismissed instead
      */
     onModalDismissed: PropTypes.func,
+    /**
+     * Called once the dialog has been dismissed completely
+     */
+    onDialogDismissed: PropTypes.func,
     /**
      * If this is added only the header will be pannable;
      * this allows for scrollable content (the children of the dialog)
@@ -142,10 +146,15 @@ class Dialog extends BaseComponent {
       }
       // Parity with iOS Modal's onDismiss
       if (Constants.isAndroid) {
-        _.invoke(props, 'onModalDismissed', props);
+        _.invoke(props, 'onDialogDismissed', props);
       }
     });
   };
+  
+  onModalDismissed = () => {
+    _.invoke(this.props, 'onDialogDismissed', this.props);
+    _.invoke(this.props, 'onModalDismissed', this.props);
+  }
 
   hideDialogView = () => {
     this.setState({dialogVisibility: false});
@@ -203,7 +212,7 @@ class Dialog extends BaseComponent {
 
   render = () => {
     const {orientationKey, modalVisibility} = this.state;
-    const {overlayBackgroundColor, onModalDismissed, supportedOrientations, accessibilityLabel} = this.getThemeProps();
+    const {overlayBackgroundColor, supportedOrientations, accessibilityLabel} = this.getThemeProps();
 
     return (
       <Modal
@@ -214,7 +223,7 @@ class Dialog extends BaseComponent {
         onBackgroundPress={this.hideDialogView}
         onRequestClose={this.hideDialogView}
         overlayBackgroundColor={overlayBackgroundColor}
-        onDismiss={onModalDismissed}
+        onDismiss={this.onModalDismissed}
         supportedOrientations={supportedOrientations}
         accessibilityLabel={accessibilityLabel}
       >

--- a/src/components/dialog/index.js
+++ b/src/components/dialog/index.js
@@ -137,7 +137,9 @@ class Dialog extends BaseComponent {
   onDismiss = () => {
     this.setState({modalVisibility: false}, () => {
       const props = this.getThemeProps();
-      _.invoke(props, 'onDismiss', props);
+      if (props.visible) {
+        _.invoke(props, 'onDismiss', props);
+      }
     });
   };
 

--- a/src/components/dialog/index.js
+++ b/src/components/dialog/index.js
@@ -5,6 +5,7 @@ import {StyleSheet} from 'react-native';
 import {Constants} from '../../helpers';
 import {Colors} from '../../style';
 import {BaseComponent} from '../../commons';
+import {LogService} from '../../services';
 import Modal from '../modal';
 import View from '../view';
 import PanListenerView from '../panningViews/panListenerView';
@@ -97,6 +98,8 @@ class Dialog extends BaseComponent {
     };
 
     this.setAlignment();
+
+    LogService.deprecationWarn({component: 'Dialog', oldProp: 'onModalDismissed', newProp: 'onDialogDismissed'});
   }
 
   componentDidMount() {


### PR DESCRIPTION
-  Revert recent changes with onDismiss functionality 
- Add parity to Android with Modal's onDismiss callback that was supported only for iOS
