### PR TITLE
Fix/Accessibility props extractor regex test

### DIFF
--- a/src/commons/modifiers.ts
+++ b/src/commons/modifiers.ts
@@ -93,7 +93,7 @@ export type ContainerModifiers =
   PaddingModifiers &
   MarginModifiers &
   FlexModifiers &
-  BorderRadiusModifiers & 
+  BorderRadiusModifiers &
   BackgroundColorModifier;
 
 
@@ -256,7 +256,7 @@ export function extractFlexStyle(props: Dictionary<any>): Partial<Record<NativeF
 //@ts-ignore
 export function extractAccessibilityProps(props: any = this.props) {
   return _.pickBy(props, (_value, key) => {
-    return /.*access.*/.test(key);
+    return /.*ccessib.*/.test(key);
   });
 }
 


### PR DESCRIPTION
Old regex pattern checked for `access`. This missed out on props like: `onAccessibilityTap` and `middlePartAccessibilityLabel`. Also, it will potentially return unrelated props starting with the word `access`.