### PR TITLE
hoist static members in asRadioGroupChild HOC

### DIFF
--- a/generatedTypes/components/radioButton/RadioButton.d.ts
+++ b/generatedTypes/components/radioButton/RadioButton.d.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TextStyle, ImageStyle } from 'react-native';
+import { TextStyle, ImageSourcePropType, ImageStyle } from 'react-native';
 interface RadioButtonPropTypes {
     /**
      * The identifier value of the radio button. must be different than other RadioButtons in the same group
@@ -40,7 +40,7 @@ interface RadioButtonPropTypes {
     /**
      * Icon image source
      */
-    iconSource?: object | number;
+    iconSource?: ImageSourcePropType;
     /**
      * Icon image style
      */

--- a/src/components/radioButton/RadioButton.tsx
+++ b/src/components/radioButton/RadioButton.tsx
@@ -280,4 +280,4 @@ function createStyles(props: Props) {
   });
 }
 
-export default asRadioGroupChild(asBaseComponent<RadioButtonPropTypes>(forwardRef(RadioButton)));
+export default asBaseComponent<RadioButtonPropTypes>(forwardRef(asRadioGroupChild(RadioButton)));

--- a/src/components/radioButton/asRadioGroupChild.tsx
+++ b/src/components/radioButton/asRadioGroupChild.tsx
@@ -1,4 +1,6 @@
 import React, {Component} from 'react';
+// @ts-ignore
+import hoistStatics from 'hoist-non-react-statics';
 import RadioGroupContext from './RadioGroupContext';
 
 interface RadioGroupChildPropTypes {
@@ -16,6 +18,8 @@ type PropTypes = RadioGroupChildPropTypes;
 
 export default function asRadioGroupChild(WrappedComponent: React.ComponentType<any>) {
   class RadioGroupChild extends Component<PropTypes> {
+    static displayName: string | undefined;
+    
     render() {
       const {value: buttonValue, selected} = this.props;
       return (
@@ -32,6 +36,9 @@ export default function asRadioGroupChild(WrappedComponent: React.ComponentType<
       );
     }
   }
+
+  hoistStatics(RadioGroupChild, WrappedComponent);
+  RadioGroupChild.displayName = WrappedComponent.displayName;
 
   return RadioGroupChild as any;
 }


### PR DESCRIPTION
I noticed that the recent change in RadioButton cause an issue with the generated typings of the component. 
So I reverted the order to the original order (the one that broke the theme) 
I fixed the theme issue by hoisting the static displayName member in asRadioGroupChild