### PR TITLE
NativePicker - remove panning

### DIFF
--- a/src/components/picker/NativePicker.js
+++ b/src/components/picker/NativePicker.js
@@ -63,7 +63,7 @@ class NativePicker extends BaseComponent {
       <PickerDialog
         {...this.getThemeProps()}
         visible={showDialog}
-        disablePan
+        panDirection={null}
         onDismiss={this.onCancel}
         onValueChange={this.onValueChange}
         selectedValue={selectedValue}


### PR DESCRIPTION
NativePicker - remove panning (it was enabled by mistake in the Dialog migration)