### PR TITLE
[Bug] Passing validate prop to input as array makes that input required

### DIFF
--- a/src/components/inputs/BaseInput.js
+++ b/src/components/inputs/BaseInput.js
@@ -198,7 +198,7 @@ export default class BaseInput extends BaseComponent {
   isRequiredField() {
     const {validate} = this.props;
     if (_.isArray(validate)) {
-      return validate.indexOf[VALIDATORS.REQUIRED] !== -1;
+      return validate.indexOf(VALIDATORS.REQUIRED) !== -1;
     }
     return validate === VALIDATORS.REQUIRED;
   }


### PR DESCRIPTION
#### Issues:
* Passing `validate={[...]}`, makes that input **required** and adds and additional `*` to placeholder.

#### Changes:
* Fixed wrong parentheses which always returned undefined and always made input **required**.