### PR TITLE
[Feature] Added handling of array of undefined validations

### DIFF
--- a/src/components/inputs/BaseInput.js
+++ b/src/components/inputs/BaseInput.js
@@ -6,7 +6,6 @@ import {Colors, Typography} from '../../style';
 import {BaseComponent} from '../../commons';
 import Validators from './Validators';
 
-
 const VALIDATORS = {
   REQUIRED: 'required',
   EMAIL: 'email',
@@ -90,7 +89,7 @@ export default class BaseInput extends BaseComponent {
   onFocus = (...args) => {
     _.invoke(this.props, 'onFocus', ...args);
     this.setState({focused: true});
-  }
+  };
 
   onBlur = (...args) => {
     _.invoke(this.props, 'onBlur', ...args);
@@ -100,11 +99,11 @@ export default class BaseInput extends BaseComponent {
     if (validateOnBlur) {
       this.validate();
     }
-  }
+  };
 
   onChange = (event) => {
     _.invoke(this.props, 'onChange', event);
-  }
+  };
 
   onChangeText = (text) => {
     _.invoke(this.props, 'onChangeText', text);
@@ -114,7 +113,7 @@ export default class BaseInput extends BaseComponent {
     if (validateOnChange) {
       setImmediate(this.validate);
     }
-  }
+  };
 
   /** Actions */
   getTypography() {
@@ -142,16 +141,17 @@ export default class BaseInput extends BaseComponent {
     this.input.clear();
   }
 
-  validate = (value = _.get(this, 'state.value'), dryRun) => { // 'input.state.value'
+  validate = (value = _.get(this, 'state.value'), dryRun) => {
+    // 'input.state.value'
     const {validate} = this.props;
     const inputValidators = _.isArray(validate) ? validate : [validate];
 
-    if(_.uniq(validate).length === 1){
-      if(validate[0]){
+    if (_.uniq(validate).length === 1) {
+      if (validate[0]) {
         return;
       }
     }
-      
+
     let isValid = true;
     let failingValidatorIndex;
     // get validators

--- a/src/components/inputs/BaseInput.js
+++ b/src/components/inputs/BaseInput.js
@@ -144,14 +144,16 @@ export default class BaseInput extends BaseComponent {
 
   validate = (value = _.get(this, 'state.value'), dryRun) => { // 'input.state.value'
     const {validate} = this.props;
-    if (!validate) {
-      return;
-    }
-
-    let isValid = true;
     const inputValidators = _.isArray(validate) ? validate : [validate];
-    let failingValidatorIndex;
 
+    if(_.uniq(validate).length === 1){
+      if(validate[0]){
+        return;
+      }
+    }
+      
+    let isValid = true;
+    let failingValidatorIndex;
     // get validators
     for (let index = 0; index < inputValidators.length; index++) {
       const validator = inputValidators[index];

--- a/src/components/inputs/BaseInput.js
+++ b/src/components/inputs/BaseInput.js
@@ -144,15 +144,13 @@ export default class BaseInput extends BaseComponent {
   validate = (value = _.get(this, 'state.value'), dryRun) => {
     // 'input.state.value'
     const {validate} = this.props;
-    const inputValidators = _.isArray(validate) ? validate : [validate];
-
-    if (_.uniq(validate).length === 1) {
-      if (validate[0]) {
-        return;
-      }
+    if (!validate) {
+      return;
     }
-
+    
+    
     let isValid = true;
+    const inputValidators = _.isArray(validate) ? validate : [validate];
     let failingValidatorIndex;
     // get validators
     for (let index = 0; index < inputValidators.length; index++) {
@@ -165,7 +163,7 @@ export default class BaseInput extends BaseComponent {
       }
 
       // validate
-      if (!validatorFunction(value)) {
+      if (validatorFunction && !validatorFunction(value)) {
         isValid = false;
         failingValidatorIndex = index;
         break;


### PR DESCRIPTION
#### Issues:
* Passing `validate={[undefined, undefined]}` throws red screen;


#### Motivation:
* When having feature toggles and code that looks like this:
```
validate={[
   condition1 ? validateFunc1 : undefined,
   condition2 ? validateFunc2 : undefined
   ]}
```
The only solution is to use `() => true`, instead of `undefined`

#### Changes:
* Added handling of array of undefined;

**This only handles the situation where mutliple false returning values are the same**