### PR TITLE
Add eslint-plugin-react-hooks (per React's recommendation)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ['plugin:@typescript-eslint/recommended', 'wix/react-native'],
+  extends: ['plugin:@typescript-eslint/recommended', 'wix/react-native', 'plugin:react-hooks/recommended'],
   parser: '@typescript-eslint/parser',
   rules: {
     'arrow-parens': 'off',

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "babel-preset-react-native": "*",
     "eslint": "^5.16.0",
     "eslint-config-wix": "^1.1.28",
+    "eslint-plugin-react-hooks": "^4.0.4",
     "eslint-plugin-uilib": "file:./eslint-rules",
     "gatsby": "^2.21.21",
     "gh-pages": "^1.1.0",


### PR DESCRIPTION
See https://reactjs.org/docs/hooks-reference.html#usecallback.
See the "Note" at the end:

> We recommend using the exhaustive-deps rule as part of our eslint-plugin-react-hooks package. It warns when dependencies are specified incorrectly and suggests a fix.

