### PR TITLE
KeyboardInput - rename RCTCustomKeyboardViewController --> RCTCustomKeyboardViewControllerTemp

### DIFF
--- a/lib/ios/reactnativeuilib.xcodeproj/project.pbxproj
+++ b/lib/ios/reactnativeuilib.xcodeproj/project.pbxproj
@@ -10,10 +10,10 @@
 		1054385623BBA1C200D04E48 /* ObservingInputAccessoryViewTemp.m in Sources */ = {isa = PBXBuildFile; fileRef = 1054385523BBA1C200D04E48 /* ObservingInputAccessoryViewTemp.m */; };
 		1054385923BBA27900D04E48 /* UIResponder+FirstResponderTemp.m in Sources */ = {isa = PBXBuildFile; fileRef = 1054385823BBA27900D04E48 /* UIResponder+FirstResponderTemp.m */; };
 		1054385C23BC748700D04E48 /* KeyboardTrackingViewTempManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 1054385A23BC748700D04E48 /* KeyboardTrackingViewTempManager.m */; };
+		1054776424B47EA800D2026D /* RCTCustomKeyboardViewControllerTemp.m in Sources */ = {isa = PBXBuildFile; fileRef = 1054776324B47EA800D2026D /* RCTCustomKeyboardViewControllerTemp.m */; };
 		10823FBE23B0BAA200429E9A /* Color+Interpolation.m in Sources */ = {isa = PBXBuildFile; fileRef = 10823FBD23B0BAA200429E9A /* Color+Interpolation.m */; };
 		10823FC223B0BE9100429E9A /* LNInterpolable.m in Sources */ = {isa = PBXBuildFile; fileRef = 10823FC123B0BE9100429E9A /* LNInterpolable.m */; };
 		10823FC623B0BF0C00429E9A /* NSValue+Interpolation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 10823FC523B0BF0C00429E9A /* NSValue+Interpolation.mm */; };
-		10823FCD23B0BFAC00429E9A /* RCTCustomKeyboardViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 10823FCC23B0BFAC00429E9A /* RCTCustomKeyboardViewController.m */; };
 		1098BE4B246034EB0020440A /* LNAnimatorTemp.m in Sources */ = {isa = PBXBuildFile; fileRef = 1098BE4A246034EB0020440A /* LNAnimatorTemp.m */; };
 		1098BE4E246035090020440A /* RCTCustomInputControllerTemp.m in Sources */ = {isa = PBXBuildFile; fileRef = 1098BE4D246035090020440A /* RCTCustomInputControllerTemp.m */; };
 		D8AFAC9F204E004D00D28FED /* SafeAreaSpacerViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = D8AFAC99204E004C00D28FED /* SafeAreaSpacerViewManager.m */; };
@@ -44,6 +44,8 @@
 		1054385823BBA27900D04E48 /* UIResponder+FirstResponderTemp.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIResponder+FirstResponderTemp.m"; sourceTree = "<group>"; };
 		1054385A23BC748700D04E48 /* KeyboardTrackingViewTempManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KeyboardTrackingViewTempManager.m; sourceTree = "<group>"; };
 		1054385B23BC748700D04E48 /* KeyboardTrackingViewTempManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KeyboardTrackingViewTempManager.h; sourceTree = "<group>"; };
+		1054776324B47EA800D2026D /* RCTCustomKeyboardViewControllerTemp.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTCustomKeyboardViewControllerTemp.m; sourceTree = "<group>"; };
+		1054776524B47EB800D2026D /* RCTCustomKeyboardViewControllerTemp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTCustomKeyboardViewControllerTemp.h; sourceTree = "<group>"; };
 		10823FB823B0B9D000429E9A /* Color+Interpolation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Color+Interpolation.h"; sourceTree = "<group>"; };
 		10823FBA23B0B9ED00429E9A /* LNInterpolable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LNInterpolable.h; sourceTree = "<group>"; };
 		10823FBB23B0B9FA00429E9A /* LNInterpolation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LNInterpolation.h; sourceTree = "<group>"; };
@@ -51,8 +53,6 @@
 		10823FBD23B0BAA200429E9A /* Color+Interpolation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "Color+Interpolation.m"; sourceTree = "<group>"; };
 		10823FC123B0BE9100429E9A /* LNInterpolable.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LNInterpolable.m; sourceTree = "<group>"; };
 		10823FC523B0BF0C00429E9A /* NSValue+Interpolation.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = "NSValue+Interpolation.mm"; sourceTree = "<group>"; };
-		10823FCB23B0BF9600429E9A /* RCTCustomKeyboardViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTCustomKeyboardViewController.h; sourceTree = "<group>"; };
-		10823FCC23B0BFAC00429E9A /* RCTCustomKeyboardViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTCustomKeyboardViewController.m; sourceTree = "<group>"; };
 		1098BE49246034EB0020440A /* LNAnimatorTemp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LNAnimatorTemp.h; sourceTree = "<group>"; };
 		1098BE4A246034EB0020440A /* LNAnimatorTemp.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LNAnimatorTemp.m; sourceTree = "<group>"; };
 		1098BE4C246035090020440A /* RCTCustomInputControllerTemp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTCustomInputControllerTemp.h; sourceTree = "<group>"; };
@@ -128,8 +128,8 @@
 			children = (
 				1098BE4C246035090020440A /* RCTCustomInputControllerTemp.h */,
 				1098BE4D246035090020440A /* RCTCustomInputControllerTemp.m */,
-				10823FCB23B0BF9600429E9A /* RCTCustomKeyboardViewController.h */,
-				10823FCC23B0BFAC00429E9A /* RCTCustomKeyboardViewController.m */,
+				1054776324B47EA800D2026D /* RCTCustomKeyboardViewControllerTemp.m */,
+				1054776524B47EB800D2026D /* RCTCustomKeyboardViewControllerTemp.h */,
 			);
 			path = rctcustomInputcontroller;
 			sourceTree = "<group>";
@@ -246,7 +246,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				10823FCD23B0BFAC00429E9A /* RCTCustomKeyboardViewController.m in Sources */,
 				1054385923BBA27900D04E48 /* UIResponder+FirstResponderTemp.m in Sources */,
 				1098BE4B246034EB0020440A /* LNAnimatorTemp.m in Sources */,
 				D8AFACA2204E004D00D28FED /* SafeAreaSpacerView.m in Sources */,
@@ -258,6 +257,7 @@
 				D8D93E7620161B1F00A39331 /* HighlighterViewManager.m in Sources */,
 				1054385623BBA1C200D04E48 /* ObservingInputAccessoryViewTemp.m in Sources */,
 				D8E5A538204C4F170000DA01 /* SafeAreaManager.m in Sources */,
+				1054776424B47EA800D2026D /* RCTCustomKeyboardViewControllerTemp.m in Sources */,
 				D8AFAC9F204E004D00D28FED /* SafeAreaSpacerViewManager.m in Sources */,
 				D8AFACA1204E004D00D28FED /* SafeAreaSpacerViewLocalData.m in Sources */,
 				10823FBE23B0BAA200429E9A /* Color+Interpolation.m in Sources */,

--- a/lib/ios/reactnativeuilib/keyboardinput/rctcustomInputcontroller/RCTCustomInputControllerTemp.m
+++ b/lib/ios/reactnativeuilib/keyboardinput/rctcustomInputcontroller/RCTCustomInputControllerTemp.m
@@ -6,7 +6,7 @@
 //
 
 #import "RCTCustomInputControllerTemp.h"
-#import "RCTCustomKeyboardViewController.h"
+#import "RCTCustomKeyboardViewControllerTemp.h"
 
 #import <React/RCTUIManager.h>
 #import <objc/runtime.h>
@@ -141,7 +141,7 @@ RCT_EXPORT_METHOD(presentCustomInputComponent:(nonnull NSNumber*)inputFieldTag p
     self.customInputComponentPresented = NO;
     
     BOOL useSafeArea = [self shouldUseSafeAreaFrom:params];
-    RCTCustomKeyboardViewController* customKeyboardController = [[RCTCustomKeyboardViewController alloc] initWithUsingSafeArea:useSafeArea];
+    RCTCustomKeyboardViewControllerTemp* customKeyboardController = [[RCTCustomKeyboardViewControllerTemp alloc] initWithUsingSafeArea:useSafeArea];
     customKeyboardController.rootView = rv;
     
     _WXInputHelperView* helperView = [[_WXInputHelperView alloc] initWithFrame:CGRectZero];
@@ -235,8 +235,8 @@ RCT_EXPORT_METHOD(dismissKeyboard)
         _WXInputHelperView* helperView = [inputField.superview viewWithTag:kHlperViewTag];
         if(helperView != nil)
         {
-            [((RCTCustomKeyboardViewController*)helperView.inputViewController) setAllowsSelfSizing:YES];
-            ((RCTCustomKeyboardViewController*)helperView.inputViewController).heightConstraint.constant = newHeight;
+            [((RCTCustomKeyboardViewControllerTemp*)helperView.inputViewController) setAllowsSelfSizing:YES];
+            ((RCTCustomKeyboardViewControllerTemp*)helperView.inputViewController).heightConstraint.constant = newHeight;
             
             UIInputView *inputView = helperView.inputViewController.inputView;
             [inputView setNeedsUpdateConstraints];
@@ -295,7 +295,7 @@ RCT_EXPORT_METHOD(expandFullScreenForInput:(nonnull NSNumber*)inputFieldTag)
             
             helperView.keepInSuperviewOnResign = YES;
             
-            RCTCustomKeyboardViewController *customKeyboardViewController = (RCTCustomKeyboardViewController*)helperView.inputViewController;
+            RCTCustomKeyboardViewControllerTemp *customKeyboardViewController = (RCTCustomKeyboardViewControllerTemp*)helperView.inputViewController;
             RCTRootView *rv = customKeyboardViewController.rootView;
             UIInputView *inputView = helperView.inputViewController.inputView;
             
@@ -369,7 +369,7 @@ RCT_EXPORT_METHOD(resetSizeForInput:(nonnull NSNumber*)inputFieldTag)
                                    animations:@[[LNViewAnimation animationWithView:_fullScreenWindow keyPath:@"frame" toValue:[NSValue valueWithCGRect:keyboardTargetFrame]]]
                             completionHandler:^(BOOL completed)
             {
-                RCTCustomKeyboardViewController *customKeyboardViewController = (RCTCustomKeyboardViewController*)helperView.inputViewController;
+                RCTCustomKeyboardViewControllerTemp *customKeyboardViewController = (RCTCustomKeyboardViewControllerTemp*)helperView.inputViewController;
                 RCTRootView *rv = (RCTRootView*)_fullScreenWindow.rootViewController.view;
                 
                 [UIView performWithoutAnimation:^{

--- a/lib/ios/reactnativeuilib/keyboardinput/rctcustomInputcontroller/RCTCustomKeyboardViewControllerTemp.h
+++ b/lib/ios/reactnativeuilib/keyboardinput/rctcustomInputcontroller/RCTCustomKeyboardViewControllerTemp.h
@@ -1,5 +1,5 @@
 //
-//  RCTCustomKeyboardViewController.h
+//  RCTCustomKeyboardViewControllerTemp.h
 //
 //  Created by Leo Natan (Wix) on 12/12/2016.
 //  Copyright © 2016 Leo Natan. All rights reserved.
@@ -13,7 +13,7 @@
 #import "RCTRootView.h"
 #endif
 
-@interface RCTCustomKeyboardViewController : UIInputViewController
+@interface RCTCustomKeyboardViewControllerTemp : UIInputViewController
 
 - (void) setAllowsSelfSizing:(BOOL)allowsSelfSizing;
 - (instancetype)initWithUsingSafeArea:(BOOL)useSafeArea;

--- a/lib/ios/reactnativeuilib/keyboardinput/rctcustomInputcontroller/RCTCustomKeyboardViewControllerTemp.m
+++ b/lib/ios/reactnativeuilib/keyboardinput/rctcustomInputcontroller/RCTCustomKeyboardViewControllerTemp.m
@@ -1,22 +1,22 @@
 //
-//  RCTCustomKeyboardViewController.m
+//  RCTCustomKeyboardViewControllerTemp.m
 //
 //  Created by Leo Natan (Wix) on 12/12/2016.
 //  Copyright © 2016 Leo Natan. All rights reserved.
 //
 
-#import "RCTCustomKeyboardViewController.h"
+#import "RCTCustomKeyboardViewControllerTemp.h"
 
 #if __has_include(<KeyboardTrackingView/ObservingInputAccessoryViewTemp.h>)
 #import <KeyboardTrackingView/ObservingInputAccessoryViewTemp.h>
 #define ObservingInputAccessoryViewTemp_IsAvailable true
 #endif
 
-@interface RCTCustomKeyboardViewController ()
+@interface RCTCustomKeyboardViewControllerTemp ()
 @property (nonatomic, assign, getter=isUsingSafeArea) BOOL useSafeArea;
 @end
 
-@implementation RCTCustomKeyboardViewController
+@implementation RCTCustomKeyboardViewControllerTemp
 
 - (instancetype)initWithUsingSafeArea:(BOOL)useSafeArea
 {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uilib-native",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "homepage": "https://github.com/wix/react-native-ui-lib",
   "description": "uilib native components (separated from js components)",
   "main": "components/index.js",


### PR DESCRIPTION
We want to allow for the libs we imported to co-exist until we migrate fully to our internal keyboards (here), so we have to rename to temp, it seems this was missed (hopefully nothing else)