### PR TITLE
TS/fix carousel-related typing errors

### DIFF
--- a/typings/components/Carousel.d.ts
+++ b/typings/components/Carousel.d.ts
@@ -1,4 +1,3 @@
-
 import {
   NativeScrollEvent,
   NativeSyntheticEvent,
@@ -9,7 +8,12 @@ import {
 import {BaseComponent} from '../commons';
 import {PageControlProps} from './PageControl';
 
-export type CarouselPageControlPosition = 'over' | 'under';
+type CarouselPageControlPositions = {
+  OVER: 'over';
+  UNDER: 'under';
+}
+
+export type CarouselPageControlPosition = CarouselPageControlPositions[keyof CarouselPageControlPositions];
 
 export interface CarouselProps {
   initialPage?: number;
@@ -36,4 +40,5 @@ export interface CarouselProps {
 
 export class Carousel extends BaseComponent<CarouselProps> {
   goToPage: (pageIndex: number) => void;
+  static pageControlPositions: CarouselPageControlPositions;
 }

--- a/typings/components/PageControl.d.ts
+++ b/typings/components/PageControl.d.ts
@@ -3,7 +3,8 @@ import {GestureResponderEvent, StyleProp, ViewStyle} from 'react-native';
 import {BaseComponent} from '../commons';
 import {ColorValue} from '../style/colors';
 
-export interface PageControlProps {
+export interface PageControlProps extends JSX.IntrinsicAttributes {
+  limitShownPages: boolean;
   containerStyle?: StyleProp<ViewStyle>;
   numOfPages?: number;
   currentPage?: number;

--- a/typings/components/PageControl.d.ts
+++ b/typings/components/PageControl.d.ts
@@ -4,7 +4,7 @@ import {BaseComponent} from '../commons';
 import {ColorValue} from '../style/colors';
 
 export interface PageControlProps extends JSX.IntrinsicAttributes {
-  limitShownPages: boolean;
+  limitShownPages?: boolean;
   containerStyle?: StyleProp<ViewStyle>;
   numOfPages?: number;
   currentPage?: number;


### PR DESCRIPTION
- 'limitShownPages' does not exist in type 'PageControlProps'
- 'key' does not exist in type 'PageControlProps'
- Property 'pageControlPositions' does not exist on type 'typeof Carousel'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wix/react-native-ui-lib/856)
<!-- Reviewable:end -->
