### PR TITLE
Enabled controlled input mode in TagsInput

### DIFF
--- a/src/components/tagsInput/__tests__/index.spec.js
+++ b/src/components/tagsInput/__tests__/index.spec.js
@@ -146,4 +146,48 @@ describe('TagsInput', () => {
       expect(removeTagSpy).toHaveBeenCalledWith();
     });
   });
+
+  describe('controlled input mode', () => {
+    it('should change state.value if prop has been changed', () => {
+      uut = new TagsInput({value: 'init'});
+      uut.setState = jest.fn(state => _.assign(uut.state, state));
+      _.set(uut.state, 'tags', [{}, {}, {}]);
+
+      expect(uut.state.value).toBe('init');
+
+      _.set(uut, 'props.value', 'modified');
+      uut.UNSAFE_componentWillReceiveProps(uut.props);
+
+      expect(uut.state.value).toBe('modified');
+
+      _.set(uut, 'props.value', '');
+      uut.UNSAFE_componentWillReceiveProps(uut.props);
+
+      expect(uut.state.value).toBe('');
+    });
+
+    it('should change state.value even in case, when initial value has not been passed', () => {
+      uut = new TagsInput({value: 'init'});
+      uut.setState = jest.fn(state => _.assign(uut.state, state));
+      _.set(uut.state, 'tags', [{}, {}, {}]);
+  
+      _.set(uut, 'props.value', 'modified');
+      uut.UNSAFE_componentWillReceiveProps(uut.props);
+
+      expect(uut.state.value).toBe('modified');
+    });
+
+    it('should not reset state.value if prop is `undefined`', () => {
+      uut = new TagsInput({value: 'init'});
+      uut.setState = jest.fn(state => _.assign(uut.state, state));
+      _.set(uut.state, 'tags', [{}, {}, {}]);
+
+      expect(uut.state.value).toBe('init');
+
+      _.set(uut, 'props.value', undefined);
+      uut.UNSAFE_componentWillReceiveProps(uut.props);
+
+      expect(uut.state.value).toBe('init');
+    });
+  });
 });

--- a/src/components/tagsInput/index.js
+++ b/src/components/tagsInput/index.js
@@ -128,6 +128,10 @@ export default class TagsInput extends BaseComponent {
         tags: nextProps.tags
       });
     }
+
+    if (!_.isNil(nextProps.value) && nextProps.value !== this.state.value) {
+      this.setState({value: nextProps.value, tagIndexToRemove: undefined});
+    }
   }
 
   addTag() {


### PR DESCRIPTION
Added ability to override `state.value` by passing `value` prop.

_**The motivation:**_
I'd like to be able to use `<TagsInput />` as controlled component.

**_An example:_**
```tsx
function MyComponent() {
  const [value, setValue] = useState('');
  return (
    <>
      <TagsInput tags={...}  value={value} onChangeText={setValue}/>
      ...
     <Button onPress={() => setValue('')} /> /* this line doesn't work at the moment. TagsInput's value won't be reseted */
    </>
  );
}
```

**_Use case:_**
I have `<TagsInput />` component with [autocomplete](https://en.wikipedia.org/wiki/Autocomplete#:~:text=Autocomplete%2C%20or%20word%20completion%2C%20is,to%20accept%20one%20of%20several.).

Imagine the scenario:

- Type something in `<TagsInput />`
- Suggested autocomplete items list has appeared under the input
- Pick one of those items
- New tag has been added
- Input value is reseted (This step is not available at the moment)
