### PR TITLE
TextField element positioning to be centered with the TextField.

### DIFF
--- a/src/components/inputs/TextField.js
+++ b/src/components/inputs/TextField.js
@@ -778,13 +778,14 @@ function createStyles({centered, multiline, hideUnderline}) {
     rightIcon: {
       position: 'absolute',
       right: 0,
-      alignSelf: 'flex-end',
-      paddingBottom: hideUnderline ? undefined : 8
+      alignSelf: 'flex-start',
+      paddingTop: Constants.isIOS ? 22 : 28
     },
     rightButton: {
       position: 'absolute',
       right: 0,
-      alignSelf: 'center'
+      alignSelf: 'flex-start',
+      paddingTop: Constants.isIOS ? 22 : 28
     },
     rightButtonImage: {
       width: ICON_SIZE,


### PR DESCRIPTION
TextField's right element (icon and button) position fixed (center).
Behaviour changed - right element keeps the starting position on multiline TextField.