### PR TITLE
Declare customValue type for passing an arbitrary value to touchables

### DIFF
--- a/generatedTypes/components/button/index.d.ts
+++ b/generatedTypes/components/button/index.d.ts
@@ -337,6 +337,7 @@ declare const _default: React.ComponentClass<(import("react-native").TouchableOp
     } | undefined;
     activeBackgroundColor?: string | undefined;
     useNative?: boolean | undefined;
+    customValue?: any;
     ref?: any;
 } & import("../../commons/modifiers").CustomModifier & {
     /**
@@ -484,6 +485,7 @@ declare const _default: React.ComponentClass<(import("react-native").TouchableOp
     } | undefined;
     activeBackgroundColor?: string | undefined;
     useNative?: boolean | undefined;
+    customValue?: any;
     ref?: any;
 } & import("../../commons/modifiers").CustomModifier & Partial<Record<"black" | "white" | "dark10" | "dark20" | "dark30" | "dark40" | "dark50" | "dark60" | "dark70" | "dark80" | "grey10" | "grey20" | "grey30" | "grey40" | "grey50" | "grey60" | "grey70" | "grey80" | "blue10" | "blue20" | "blue30" | "blue40" | "blue50" | "blue60" | "blue70" | "blue80" | "cyan10" | "cyan20" | "cyan30" | "cyan40" | "cyan50" | "cyan60" | "cyan70" | "cyan80" | "green10" | "green20" | "green30" | "green40" | "green50" | "green60" | "green70" | "green80" | "yellow10" | "yellow20" | "yellow30" | "yellow40" | "yellow50" | "yellow60" | "yellow70" | "yellow80" | "orange10" | "orange20" | "orange30" | "orange40" | "orange50" | "orange60" | "orange70" | "orange80" | "red10" | "red20" | "red30" | "red40" | "red50" | "red60" | "red70" | "red80" | "purple10" | "purple20" | "purple30" | "purple40" | "purple50" | "purple60" | "purple70" | "purple80" | "violet10" | "violet20" | "violet30" | "violet40" | "violet50" | "violet60" | "violet70" | "violet80", boolean>> & {
     /**
@@ -631,6 +633,7 @@ declare const _default: React.ComponentClass<(import("react-native").TouchableOp
     } | undefined;
     activeBackgroundColor?: string | undefined;
     useNative?: boolean | undefined;
+    customValue?: any;
     ref?: any;
 } & Partial<Record<"text10" | "text20" | "text30" | "text40" | "text50" | "text60" | "text65" | "text70" | "text80" | "text90" | "text100" | "text10T" | "text10L" | "text10R" | "text10M" | "text10BO" | "text10H" | "text10BL" | "text20T" | "text20L" | "text20R" | "text20M" | "text20BO" | "text20H" | "text20BL" | "text30T" | "text30L" | "text30R" | "text30M" | "text30BO" | "text30H" | "text30BL" | "text40T" | "text40L" | "text40R" | "text40M" | "text40BO" | "text40H" | "text40BL" | "text50T" | "text50L" | "text50R" | "text50M" | "text50BO" | "text50H" | "text50BL" | "text60T" | "text60L" | "text60R" | "text60M" | "text60BO" | "text60H" | "text60BL" | "text65T" | "text65L" | "text65R" | "text65M" | "text65BO" | "text65H" | "text65BL" | "text70T" | "text70L" | "text70R" | "text70M" | "text70BO" | "text70H" | "text70BL" | "text80T" | "text80L" | "text80R" | "text80M" | "text80BO" | "text80H" | "text80BL" | "text90T" | "text90L" | "text90R" | "text90M" | "text90BO" | "text90H" | "text90BL" | "text100T" | "text100L" | "text100R" | "text100M" | "text100BO" | "text100H" | "text100BL", boolean>> & import("../../commons/modifiers").CustomModifier & {
     /**
@@ -778,6 +781,7 @@ declare const _default: React.ComponentClass<(import("react-native").TouchableOp
     } | undefined;
     activeBackgroundColor?: string | undefined;
     useNative?: boolean | undefined;
+    customValue?: any;
     ref?: any;
 } & Partial<Record<"text10" | "text20" | "text30" | "text40" | "text50" | "text60" | "text65" | "text70" | "text80" | "text90" | "text100" | "text10T" | "text10L" | "text10R" | "text10M" | "text10BO" | "text10H" | "text10BL" | "text20T" | "text20L" | "text20R" | "text20M" | "text20BO" | "text20H" | "text20BL" | "text30T" | "text30L" | "text30R" | "text30M" | "text30BO" | "text30H" | "text30BL" | "text40T" | "text40L" | "text40R" | "text40M" | "text40BO" | "text40H" | "text40BL" | "text50T" | "text50L" | "text50R" | "text50M" | "text50BO" | "text50H" | "text50BL" | "text60T" | "text60L" | "text60R" | "text60M" | "text60BO" | "text60H" | "text60BL" | "text65T" | "text65L" | "text65R" | "text65M" | "text65BO" | "text65H" | "text65BL" | "text70T" | "text70L" | "text70R" | "text70M" | "text70BO" | "text70H" | "text70BL" | "text80T" | "text80L" | "text80R" | "text80M" | "text80BO" | "text80H" | "text80BL" | "text90T" | "text90L" | "text90R" | "text90M" | "text90BO" | "text90H" | "text90BL" | "text100T" | "text100L" | "text100R" | "text100M" | "text100BO" | "text100H" | "text100BL", boolean>> & Partial<Record<"black" | "white" | "dark10" | "dark20" | "dark30" | "dark40" | "dark50" | "dark60" | "dark70" | "dark80" | "grey10" | "grey20" | "grey30" | "grey40" | "grey50" | "grey60" | "grey70" | "grey80" | "blue10" | "blue20" | "blue30" | "blue40" | "blue50" | "blue60" | "blue70" | "blue80" | "cyan10" | "cyan20" | "cyan30" | "cyan40" | "cyan50" | "cyan60" | "cyan70" | "cyan80" | "green10" | "green20" | "green30" | "green40" | "green50" | "green60" | "green70" | "green80" | "yellow10" | "yellow20" | "yellow30" | "yellow40" | "yellow50" | "yellow60" | "yellow70" | "yellow80" | "orange10" | "orange20" | "orange30" | "orange40" | "orange50" | "orange60" | "orange70" | "orange80" | "red10" | "red20" | "red30" | "red40" | "red50" | "red60" | "red70" | "red80" | "purple10" | "purple20" | "purple30" | "purple40" | "purple50" | "purple60" | "purple70" | "purple80" | "violet10" | "violet20" | "violet30" | "violet40" | "violet50" | "violet60" | "violet70" | "violet80", boolean>> & {
     /**

--- a/generatedTypes/components/card/index.d.ts
+++ b/generatedTypes/components/card/index.d.ts
@@ -70,6 +70,7 @@ declare const _default: React.ComponentClass<ViewPropTypes & import("react-nativ
     } | undefined;
     activeBackgroundColor?: string | undefined;
     useNative?: boolean | undefined;
+    customValue?: any;
     ref?: any;
 } & {
     /**

--- a/generatedTypes/components/touchableOpacity/index.d.ts
+++ b/generatedTypes/components/touchableOpacity/index.d.ts
@@ -25,6 +25,10 @@ export declare type TouchableOpacityProps = RNTouchableOpacityProps & ContainerM
      * Should use a more native touchable opacity component
      */
     useNative?: boolean;
+    /**
+     * Custom value of any type to pass on to TouchableOpacity and receive back in onPress callback
+     */
+    customValue?: any;
     ref?: any;
 };
 declare const _default: React.ComponentClass<RNTouchableOpacityProps & Partial<Record<import("../../commons/modifiers").AlignmentLiterals, boolean>> & Partial<Record<import("../../commons/modifiers").PositionLiterals, boolean>> & Partial<Record<"padding" | "paddingL" | "paddingT" | "paddingR" | "paddingB" | "paddingH" | "paddingV", boolean>> & Partial<Record<"margin" | "marginL" | "marginT" | "marginR" | "marginB" | "marginH" | "marginV", boolean>> & Partial<Record<"flex" | "flexG" | "flexS", boolean>> & Partial<Record<"br0" | "br10" | "br20" | "br30" | "br40" | "br50" | "br60" | "br100", boolean>> & Partial<Record<"bg", boolean>> & {
@@ -51,6 +55,10 @@ declare const _default: React.ComponentClass<RNTouchableOpacityProps & Partial<R
      * Should use a more native touchable opacity component
      */
     useNative?: boolean | undefined;
+    /**
+     * Custom value of any type to pass on to TouchableOpacity and receive back in onPress callback
+     */
+    customValue?: any;
     ref?: any;
 } & {
     useCustomTheme?: boolean | undefined;

--- a/src/components/touchableOpacity/index.tsx
+++ b/src/components/touchableOpacity/index.tsx
@@ -26,6 +26,10 @@ export type TouchableOpacityProps = RNTouchableOpacityProps & ContainerModifiers
    * Should use a more native touchable opacity component
    */
   useNative?: boolean;
+  /**
+   * Custom value of any type to pass on to TouchableOpacity and receive back in onPress callback
+   */
+  customValue?: any;
   ref?: any;
 };
 


### PR DESCRIPTION
WOAUILIB-1006
Today our TouchableOpacity's `onPress` callback support passing back the props the user pass. 
This is very useful cause it helps avoid passing inline callback 
So instead of doing this 
```
<TouchableOpacity someValue={1}  onPress={(props) => doSomething(props.someValue)} />
```
You can do
```
<TouchableOpacity someValue={1}  onPress={doSomething} />
...
doSomething({someValue}) => {...}
```

After migrating to TS this pattern has become an issue, because when a user pass an arbitrary prop like `someValue` typescript throws an error. 
The new `customValue` prop purpose is to have a dedicate prop for passing these values. 