### PR TITLE
Reduce padding of top label margin bottom by 1 pixel

### DIFF
--- a/src/components/textField/index.js
+++ b/src/components/textField/index.js
@@ -772,7 +772,7 @@ function createStyles({centered, multiline, hideUnderline}, rightItemTopPadding 
       textAlign: centered ? 'center' : undefined
     },
     topLabel: {
-      marginBottom: Constants.isIOS ? (multiline ? 1 : 6) : 7
+      marginBottom: Constants.isIOS ? (multiline ? 1 : 5) : 7
     },
     bottomLabel: {
       marginTop: 9


### PR DESCRIPTION
![gif222](https://user-images.githubusercontent.com/32594043/90525467-fa9a5e80-e177-11ea-8cee-a397343d18ee.gif)

*  Currently coming from a valid state to an error state replaced the top placeholder label with an error message, and moves the whole `TextField` down because topLabel receives padding that is 1 pixel higher than default.

### Fix:
* Reduced marginBottom height of topLabel by 1.
