### PR TITLE
Fix - first item selection is not being updated

### DIFF
--- a/src/components/tabBar/index.tsx
+++ b/src/components/tabBar/index.tsx
@@ -104,7 +104,7 @@ class TabBar extends Component<TabBarProps, State> {
     // between this.props and nextProps (basically the meaning of selectedIndex should be initialIndex)
     const isIndexManuallyChanged =
       nextProps.selectedIndex !== this.state.currentIndex && this.props.selectedIndex !== nextProps.selectedIndex;
-    if (isIndexManuallyChanged) {
+    if (isIndexManuallyChanged && nextProps.selectedIndex) {
       this.updateIndicator(nextProps.selectedIndex);
     }
   }

--- a/src/components/tabBar/index.tsx
+++ b/src/components/tabBar/index.tsx
@@ -104,7 +104,7 @@ class TabBar extends Component<TabBarProps, State> {
     // between this.props and nextProps (basically the meaning of selectedIndex should be initialIndex)
     const isIndexManuallyChanged =
       nextProps.selectedIndex !== this.state.currentIndex && this.props.selectedIndex !== nextProps.selectedIndex;
-    if (isIndexManuallyChanged && nextProps.selectedIndex) {
+    if (isIndexManuallyChanged && nextProps.selectedIndex !== undefined) {
       this.updateIndicator(nextProps.selectedIndex);
     }
   }

--- a/src/components/tabBar/index.tsx
+++ b/src/components/tabBar/index.tsx
@@ -125,13 +125,11 @@ class TabBar extends Component<TabBarProps, State> {
     return _.get(child, 'props.ignore');
   }
 
-  updateIndicator(index?: number) {
-    if (index) {
-      if (!this.isIgnored(index)) {
-        this.setState({currentIndex: index}, () => {
-          this.scrollToSelected();
-        });
-      }
+  updateIndicator(index: number) {
+    if (!this.isIgnored(index)) {
+      this.setState({currentIndex: index}, () => {
+        this.scrollToSelected();
+      });
     }
   }
 


### PR DESCRIPTION
With the move to typescript, condition on an optional number type, like index, will fail when has the value of 0 (zero) since that is equal to false/undefined. 
Removing the optional for the number type will error if undefined is passed to it and remove the need for the value chack while passing when passing the value 0.