### PR TITLE
[StackAgregator] added onCollapseChanged / onCollapseWillChanged / disablePresses

### DIFF
--- a/src/components/stackAggregator/index.js
+++ b/src/components/stackAggregator/index.js
@@ -51,9 +51,13 @@ export default class StackAggregator extends PureBaseComponent {
      */
     onItemPress: PropTypes.func,
     /**
+     * A callback for collapse state will change (value is future collapsed state)
+     */
+    onCollapseWillChange: PropTypes.func,
+    /**
     * A callback for collapse state change (value is collapsed state)
     */
-    onCollapseChange: PropTypes.func,
+    onCollapseChanged: PropTypes.func,
     /**
      * A setting that disables pressability on cards
      */
@@ -110,57 +114,81 @@ export default class StackAggregator extends PureBaseComponent {
     return 1;
   }
 
-  animate = () => {
-    this.animateValues();
-    this.animateCards();
+  animate = async () => {
+    return Promise.all([this.animateValues(), this.animateCards()]);
   }
 
   animateValues() {
     const {collapsed} = this.state;
     const newValue = collapsed ? buttonStartValue : 1;
-
-    Animated.parallel([
-      Animated.timing(this.animatedOpacity, {
-        duration: DURATION,
-        toValue: Number(newValue),
-        useNativeDriver: true
-      }),
-      Animated.timing(this.animatedScale, {
-        toValue: Number(newValue),
-        easing: this.easeOut,
-        duration: DURATION,
-        useNativeDriver: true
-      }),
-      Animated.timing(this.animatedContentOpacity, {
-        toValue: Number(collapsed ? 0 : 1),
-        easing: this.easeOut,
-        duration: DURATION,
-        useNativeDriver: true
-      })
-    ]).start();
+    return new Promise((resolve) => {
+      Animated.parallel([
+        Animated.timing(this.animatedOpacity, {
+          duration: DURATION,
+          toValue: Number(newValue),
+          useNativeDriver: true
+        }),
+        Animated.timing(this.animatedScale, {
+          toValue: Number(newValue),
+          easing: this.easeOut,
+          duration: DURATION,
+          useNativeDriver: true
+        }),
+        Animated.timing(this.animatedContentOpacity, {
+          toValue: Number(collapsed ? 0 : 1),
+          easing: this.easeOut,
+          duration: DURATION,
+          useNativeDriver: true
+        })
+      ]).start(resolve);
+    })
   }
 
   animateCards() {    
+    const promises = []
     for (let index = 0; index < this.itemsCount; index++) {
       const newScale = this.getItemScale(index);
 
-      Animated.timing(this.animatedScaleArray[index], {
-        toValue: Number(newScale),
-        easing: this.easeOut,
-        duration: DURATION,
-        useNativeDriver: true
-      }).start();
+      promises.push(
+        new Promise((resolve) => {
+          Animated.timing(this.animatedScaleArray[index], {
+            toValue: Number(newScale),
+            easing: this.easeOut,
+            duration: DURATION,
+            useNativeDriver: true
+          }).start(resolve)
+        })
+      )  
     }
+    return Promise.all(promises)
   }
 
   close = () => {
-    this.setState({collapsed: true}, () => this.animate());
-    this.props.onCollapseChange && this.props.onCollapseChange(true)
+    this.setState({collapsed: true}, async () => {
+      if (this.props.onCollapseWillChange) {
+        this.props.onCollapseWillChange(true)
+      }
+      if (this.props.onCollapseChanged) {
+        await this.animate()
+        this.props.onCollapseChanged(true)
+      } else {
+        this.animate()
+      }
+    });
   }
 
   open = () => {
-    this.setState({collapsed: false}, () => this.animate());
-    this.props.onCollapseChange && this.props.onCollapseChange(false)
+    this.setState({collapsed: false}, async () => {
+      if (this.props.onCollapseWillChange) {
+        this.props.onCollapseWillChange(false)
+      }
+      if (this.props.onCollapseChanged) {
+        await this.animate()
+        this.props.onCollapseChanged(false)
+      } else {
+        this.animate()
+      }
+    });
   }
 
   getTop(index) {

--- a/src/components/stackAggregator/index.js
+++ b/src/components/stackAggregator/index.js
@@ -165,9 +165,7 @@ export default class StackAggregator extends PureBaseComponent {
 
   close = () => {
     this.setState({collapsed: true}, async () => {
-      if (this.props.onCollapseWillChange) {
-        this.props.onCollapseWillChange(true)
-      }
+      _.invoke(this.props, 'onCollapseWillChange', true);
       if (this.props.onCollapseChanged) {
         await this.animate()
         this.props.onCollapseChanged(true)
@@ -179,9 +177,7 @@ export default class StackAggregator extends PureBaseComponent {
 
   open = () => {
     this.setState({collapsed: false}, async () => {
-      if (this.props.onCollapseWillChange) {
-        this.props.onCollapseWillChange(false)
-      }
+      _.invoke(this.props, 'onCollapseWillChange', false);
       if (this.props.onCollapseChanged) {
         await this.animate()
         this.props.onCollapseChanged(false)

--- a/src/components/stackAggregator/index.js
+++ b/src/components/stackAggregator/index.js
@@ -49,7 +49,11 @@ export default class StackAggregator extends PureBaseComponent {
     /**
      * A callback for item press
      */
-    onItemPress: PropTypes.func
+    onItemPress: PropTypes.func,
+    /**
+     * A callback for collapse state change (value is collapsed state)
+     */
+    onCollapseChange: PropTypes.func
   }
 
   static defaultProps = {
@@ -146,10 +150,12 @@ export default class StackAggregator extends PureBaseComponent {
 
   close = () => {
     this.setState({collapsed: true}, () => this.animate());
+    this.props.onCollapseChange && this.props.onCollapseChange(true)
   }
 
   open = () => {
     this.setState({collapsed: false}, () => this.animate());
+    this.props.onCollapseChange && this.props.onCollapseChange(false)
   }
 
   getTop(index) {

--- a/src/components/stackAggregator/index.js
+++ b/src/components/stackAggregator/index.js
@@ -51,12 +51,17 @@ export default class StackAggregator extends PureBaseComponent {
      */
     onItemPress: PropTypes.func,
     /**
-     * A callback for collapse state change (value is collapsed state)
+    * A callback for collapse state change (value is collapsed state)
+    */
+    onCollapseChange: PropTypes.func,
+    /**
+     * A setting that disables pressability on cards
      */
-    onCollapseChange: PropTypes.func
+    disablePresses: PropTypes.boolean
   }
 
   static defaultProps = {
+    disablePresses: false,
     collapsed: true,
     itemBorderRadius: 0
   }
@@ -225,7 +230,7 @@ export default class StackAggregator extends PureBaseComponent {
       >
         <Card
           style={[contentContainerStyle, this.styles.card]}
-          onPress={() => this.onItemPress(index)}
+          onPress={this.props.disablePresses ? false : () => this.onItemPress(index)}
           borderRadius={itemBorderRadius}
           elevation={5}
         >

--- a/src/components/stackAggregator/index.js
+++ b/src/components/stackAggregator/index.js
@@ -141,11 +141,11 @@ export default class StackAggregator extends PureBaseComponent {
           useNativeDriver: true
         })
       ]).start(resolve);
-    })
+    });
   }
 
   animateCards() {    
-    const promises = []
+    const promises = [];
     for (let index = 0; index < this.itemsCount; index++) {
       const newScale = this.getItemScale(index);
 
@@ -156,21 +156,21 @@ export default class StackAggregator extends PureBaseComponent {
             easing: this.easeOut,
             duration: DURATION,
             useNativeDriver: true
-          }).start(resolve)
+          }).start(resolve);
         })
-      )  
+      );
     }
-    return Promise.all(promises)
+    return Promise.all(promises);
   }
 
   close = () => {
     this.setState({collapsed: true}, async () => {
       _.invoke(this.props, 'onCollapseWillChange', true);
       if (this.props.onCollapseChanged) {
-        await this.animate()
-        this.props.onCollapseChanged(true)
+        await this.animate();
+        this.props.onCollapseChanged(true);
       } else {
-        this.animate()
+        this.animate();
       }
     });
   }
@@ -179,10 +179,10 @@ export default class StackAggregator extends PureBaseComponent {
     this.setState({collapsed: false}, async () => {
       _.invoke(this.props, 'onCollapseWillChange', false);
       if (this.props.onCollapseChanged) {
-        await this.animate()
-        this.props.onCollapseChanged(false)
+        await this.animate();
+        this.props.onCollapseChanged(false);
       } else {
-        this.animate()
+        this.animate();
       }
     });
   }

--- a/src/components/tagsInput/index.js
+++ b/src/components/tagsInput/index.js
@@ -268,10 +268,7 @@ export default class TagsInput extends BaseComponent {
 
     if (tag.invalid) {
       return (
-        <View
-          key={index}
-          style={[styles.inValidTag, tagStyle, shouldMarkTag && styles.inValidMarkedTag]}
-        >
+        <View key={index} style={[styles.inValidTag, tagStyle, shouldMarkTag && styles.inValidMarkedTag]}>
           {this.renderLabel(tag, shouldMarkTag)}
         </View>
       );

--- a/typings/components/StackAggregator.d.ts
+++ b/typings/components/StackAggregator.d.ts
@@ -5,6 +5,7 @@ import {ButtonProps} from './Button';
 
 export interface StackAggregatorProps {
   collapsed?: boolean;
+  disablePresses?: boolean;
   containerStyle?: StyleProp<ViewStyle>;
   contentContainerStyle?: StyleProp<ViewStyle>;
   itemBorderRadius?: number;

--- a/typings/components/StackAggregator.d.ts
+++ b/typings/components/StackAggregator.d.ts
@@ -11,7 +11,8 @@ export interface StackAggregatorProps {
   itemBorderRadius?: number;
   buttonProps?: ButtonProps;
   onItemPress?: (index: number) => void;
-  onCollapseChange?: (collapsed: boolean) => void;
+  onCollapseWillChange?: (future: boolean) => void;
+  onCollapseChanged?: (collapsed: boolean) => void;
 }
 
 export class StackAggregator extends PureBaseComponent<StackAggregatorProps> {}

--- a/typings/components/StackAggregator.d.ts
+++ b/typings/components/StackAggregator.d.ts
@@ -10,6 +10,7 @@ export interface StackAggregatorProps {
   itemBorderRadius?: number;
   buttonProps?: ButtonProps;
   onItemPress?: (index: number) => void;
+  onCollapseChange?: (collapsed: boolean) => void;
 }
 
 export class StackAggregator extends PureBaseComponent<StackAggregatorProps> {}


### PR DESCRIPTION
Added the following 2 props to StackAgregator component
`onCollapseChanged` (fn): hook to respond upstream to the collapse state of the stack aggregator
`onCollapseWillChanged` (fn): hook to respond upstream to beginning of the collapse animation intent of the stack aggregator
`disablePresses` (bool) [default: false]: removes the onPress functionality / touchableopacity effect