### PR TITLE
Change how we extract a component props

### DIFF
--- a/src/commons/modifiers.ts
+++ b/src/commons/modifiers.ts
@@ -304,6 +304,7 @@ export function extractModifierProps(props: Dictionary<any>) {
   return modifierProps;
 }
 
+// TODO: should not be used anymore
 export function extractOwnProps(props: Dictionary<any>, ignoreProps: string[]) {
   //@ts-ignore
   const ownPropTypes = this.propTypes;
@@ -313,6 +314,16 @@ export function extractOwnProps(props: Dictionary<any>, ignoreProps: string[]) {
     .value();
 
   return ownProps;
+}
+
+export function extractComponentProps(component: any, props: Dictionary<any>, ignoreProps: string[]) {
+  const componentPropTypes = component.propTypes;
+  const componentProps = _.chain(props)
+    .pickBy((_value, key) => _.includes(Object.keys(componentPropTypes), key))
+    .omit(ignoreProps)
+    .value();
+
+  return componentProps;
 }
 
 //@ts-ignore

--- a/src/commons/modifiers.ts
+++ b/src/commons/modifiers.ts
@@ -304,7 +304,10 @@ export function extractModifierProps(props: Dictionary<any>) {
   return modifierProps;
 }
 
-// TODO: should not be used anymore
+/**
+ * TODO:
+ * @deprecated switch to Modifiers#extractComponentProps
+ */
 export function extractOwnProps(props: Dictionary<any>, ignoreProps: string[]) {
   //@ts-ignore
   const ownPropTypes = this.propTypes;

--- a/src/components/picker/PickerDialog.android.js
+++ b/src/components/picker/PickerDialog.android.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import _ from 'lodash';
 
 import {BaseComponent} from '../../commons';
+import {extractComponentProps} from '../../commons/modifiers';
 import Dialog from '../dialog';
 import View from '../view';
 import Text from '../text';
@@ -80,7 +81,7 @@ class PickerDialog extends BaseComponent {
   }
 
   render() {
-    const dialogProps = Dialog.extractOwnProps(this.props);
+    const dialogProps = extractComponentProps(Dialog, this.props);
     return (
       <Dialog {...dialogProps} migrate height="50%" width="77%">
         <View style={styles.dialog}>

--- a/src/components/picker/PickerDialog.ios.js
+++ b/src/components/picker/PickerDialog.ios.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import _ from 'lodash';
 
 import {BaseComponent} from '../../commons';
+import {extractComponentProps} from '../../commons/modifiers';
 import Dialog from '../dialog';
 import View from '../view';
 import Text from '../text';
@@ -51,7 +52,7 @@ class PickerDialog extends BaseComponent {
   }
 
   render() {
-    const dialogProps = Dialog.extractOwnProps(this.props);
+    const dialogProps = extractComponentProps(Dialog, this.props);
     return (
       <Dialog {...dialogProps} height={250} width="100%" migrate bottom animationConfig={{duration: 300}}>
         <View flex bg-white>


### PR DESCRIPTION
## Description
- There was an issue in PickerDialog components (ios and android) with the usage of `Dialog.extractOwnProps` due to the migration to `asBaseComponent` 
- I added a new methods in `Modifiers` class - `extractComponentProps` which should replace `extractOwnProps`

## Changelog
Fix issue with Picker when passing the `useNativePicker` prop an error was thrown. 
