### PR TITLE
Update statusBarHeight calculation

### DIFF
--- a/src/helpers/Constants.ts
+++ b/src/helpers/Constants.ts
@@ -20,12 +20,12 @@ isTablet = Platform.isPad || (getAspectRatio() < 1.6 && Math.max(screenWidth, sc
 
 function setStatusBarHeight() {
   const {StatusBarManager} = NativeModules;
-  statusBarHeight = 0; // so there will be a value for any case
-  statusBarHeight = isIOS ? 20 : StatusBarManager.HEIGHT;
-  if (isIOS) {
-    // override guesstimate height with the actual height from StatusBarManager
-    StatusBarManager.getHeight((data: any) => (statusBarHeight = data.height));
-  }
+  statusBarHeight = StatusBarManager.HEIGHT || 0; // So there will be a value for any case
+  // statusBarHeight = isIOS ? 20 : StatusBarManager.HEIGHT;
+  // if (isIOS) {
+  //   // override guesstimate height with the actual height from StatusBarManager
+  //   StatusBarManager.getHeight((data: any) => (statusBarHeight = data.height));
+  // }
 }
 
 function getAspectRatio() {


### PR DESCRIPTION
## Description
I Simplified the logic for setting statusBarHeight constants. 
I noticed that the previous logic created flakiness with the layout of `Modal.TopBar` component. 
My guess is that in earlier versions of react-native it was more complicated to extract this value, but now
It seems like `NativeModules.StatusBarManager` initially return the correct value for all platforms (checked iPhoneX, 8, iPad and Android) 

Anyway, kept the old logic in a comment in case I missed something and in case we'll get a weird issue in the near future. 

## Changelog
Fix statusBarHeight constant value and how it affect Modal.TopBar layout. 
