### PR TITLE
Use TS compiler to generate JS files

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build:dev": "tsc --p tsconfig.dev.json",
     "build:exports": "./node_modules/.bin/babel src --out-dir src --config-file ./src/.babelrc.json --extensions '.ts,.tsx' --ignore 'src/index.ts'",
     "build:packages": "node scripts/buildPackages.js",
-    "build": "tsc --p tsconfig.build.json && npm run build:exports && npm run build:packages",
+    "build": "tsc --p tsconfig.build.json && npm run build:packages",
     "log": "react-native log-ios | grep 'ethan -'",
     "docs:install": "(cd ./uilib-docs && rm -rf node_modules && rm -rf package-lock.json && npm install)",
     "docs:deploy": "(cd ./uilib-docs && gatsby build --prefix-paths && gh-pages -d public --branch gh-pages)",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "emitDeclarationOnly": true
+    "emitDeclarationOnly": false
   },
   "include": ["src/**/*", "typings/**/*"],
   "exclude": [ "node_modules", "src/index.ts"]


### PR DESCRIPTION
## Description
Currently our JS files that are generated from TS files are creates with ES5 syntax which makes it very painful when investigating issues in private uilib when from node_modules. 

This PR fix how we generate the JS files and use `tcs` for that instead of `babel`. 

## Changelog
Change generated JS files from TS to have ES6 syntax. 
