### PR TITLE
Do not notify the user for the fake page (autoscroll on Android)

### DIFF
--- a/src/components/carousel/index.js
+++ b/src/components/carousel/index.js
@@ -326,9 +326,12 @@ class Carousel extends Component {
     const {currentStandingPage, currentPage} = this.state;
     const index = this.getCalcIndex(currentPage);
 
-    this.setState({currentStandingPage: index});
-    if (currentStandingPage !== index) {
-      _.invoke(this.props, 'onChangePage', index, currentStandingPage);
+    const pagesCount = presenter.getChildrenLength(this.props);
+    if (index < pagesCount) {
+      this.setState({currentStandingPage: index});
+      if (currentStandingPage !== index) {
+        _.invoke(this.props, 'onChangePage', index, currentStandingPage);
+      }
     }
   };
 


### PR DESCRIPTION
## Description
Do not notify the user (`onPageChange`) for the fake page, affects `autoscroll={true}` (on Android)

## Changelog
Fix autoscroll on Android notifies (onPageChange) on a page that does not exist.