### PR TITLE
Add progress type for ProgressBarProps

### DIFF
--- a/typings/components/ProgressBar.d.ts
+++ b/typings/components/ProgressBar.d.ts
@@ -1,10 +1,10 @@
-
 import {StyleProp, ViewStyle} from 'react-native';
 import {BaseComponent} from '../commons';
 import {ColorValue} from '../style/colors';
 
 export interface ProgressBarProps {
   height?: number;
+  progress?: string;
   backgroundColor?: ColorValue;
   progressBackgroundColor?: ColorValue;
   containerStyle?: StyleProp<ViewStyle>;


### PR DESCRIPTION
## Description
There's no `progress` type in [ProgressBar.d.ts](https://github.com/wix/react-native-ui-lib/blob/7a4627c757359b9fced5d361b197c1f257d18357/typings/components/ProgressBar.d.ts#L6). This PR fixes this issue.

## Changelog
Add `progress` type for ProgressBar component
