### PR TITLE
Commons - exporting props

### DIFF
--- a/src/commons/index.js
+++ b/src/commons/index.js
@@ -27,5 +27,14 @@ module.exports = {
   },
   get withScrollReached() {
     return require('./withScrollReached').default;
+  },
+  get BaseComponentInjectedProps() {
+    return require('./asBaseComponent').BaseComponentInjectedProps;
+  },
+  get ForwardRefInjectedProps() {
+    return require('./forwardRef').ForwardRefInjectedProps;
+  },
+  get ModifiersProps() {
+    return require('./modifiers').default;
   }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -226,6 +226,15 @@ export default {
   get withScrollReached() {
     return require('./commons').withScrollReached;
   },
+  get BaseComponentInjectedProps() {
+    return require('./commons').BaseComponentInjectedProps;
+  },
+  get ForwardRefInjectedProps() {
+    return require('./commons').ForwardRefInjectedProps;
+  },
+  get ModifiersProps() {
+    return require('./commons').default;
+  },
 
   // Helpers
   get AvatarHelper() {


### PR DESCRIPTION
#863  Description
Exporting BaseComponentInjectedProps, ForwardRefInjectedProps and ModifiersProps (to extract sub-modifiers props, like MarginModifiers).

## Changelog
Commons - exporting props.