### PR TITLE
fix firstLoad logic in floatingButton

### DIFF
--- a/src/components/floatingButton/index.tsx
+++ b/src/components/floatingButton/index.tsx
@@ -64,10 +64,6 @@ class FloatingButton extends PureComponent<FloatingButtonProps> {
     this.firstLoad = true;
   }
 
-  componentDidMount() {
-    this.firstLoad = false;
-  }
-
   onAnimationEnd = () => {
     this.setState({animating: false});
   };
@@ -116,6 +112,9 @@ class FloatingButton extends PureComponent<FloatingButtonProps> {
   render() {
     const {withoutAnimation, secondaryButton, visible} = this.props;
     const Container = !withoutAnimation ? AnimatableView : View;
+
+    // NOTE: keep this.firstLoad as true as long as the visibility changed to true
+    this.firstLoad && !visible ? this.firstLoad = true : this.firstLoad = false;
 
     // NOTE: On first load, don't show if it should not be visible
     if (this.firstLoad === true && !this.initialVisibility) {


### PR DESCRIPTION
## Description
Bug: floatingButton component shows briefly when visible=false.
Fix: update the firstLoad logic to keep `this.firstLoad` as true, until the first time that `visible` is set to true

## Changelog
Fix floatingButton visibility bug when visible is initialised to false