### PR TITLE
Dialog - RN63 broke Modal's onDismiss method, this fixes our API

### DIFF
--- a/generatedTypes/components/dialog/OverlayFadingBackground.d.ts
+++ b/generatedTypes/components/dialog/OverlayFadingBackground.d.ts
@@ -4,9 +4,10 @@ interface Props {
     dialogVisibility?: boolean;
     modalVisibility?: boolean;
     overlayBackgroundColor?: string;
+    onFadeDone?: () => void;
 }
 declare const OverlayFadingBackground: {
-    ({ testID, dialogVisibility, modalVisibility, overlayBackgroundColor }: Props): JSX.Element;
+    ({ testID, dialogVisibility, modalVisibility, overlayBackgroundColor, onFadeDone }: Props): JSX.Element;
     displayName: string;
 };
 export default OverlayFadingBackground;

--- a/src/components/dialog/OverlayFadingBackground.tsx
+++ b/src/components/dialog/OverlayFadingBackground.tsx
@@ -7,13 +7,15 @@ interface Props {
   dialogVisibility?: boolean;
   modalVisibility?: boolean;
   overlayBackgroundColor?: string;
+  onFadeDone?: () => void;
 }
 
 const OverlayFadingBackground = ({
   testID,
   dialogVisibility,
   modalVisibility,
-  overlayBackgroundColor
+  overlayBackgroundColor,
+  onFadeDone
 }: Props) => {
   const fadeAnimation = useRef(new Animated.Value(0)).current;
 
@@ -22,8 +24,8 @@ const OverlayFadingBackground = ({
       toValue,
       duration: 400,
       useNativeDriver: true
-    }).start();
-  }, [fadeAnimation]);
+    }).start(onFadeDone);
+  }, [fadeAnimation, onFadeDone]);
 
   useEffect(() => {
     if (!dialogVisibility) {

--- a/src/components/dialog/index.tsx
+++ b/src/components/dialog/index.tsx
@@ -162,7 +162,7 @@ class Dialog extends Component<DialogProps, DialogState> {
   }
 
   onFadeDone = () => {
-    if (Constants.isIOS && !this.state.modalVisibility) {
+    if (!this.state.modalVisibility) {
       setTimeout(() => { // unfortunately this is needed if a modal needs to open on iOS 
         _.invoke(this.props, 'onDialogDismissed', this.props);
         _.invoke(this.props, 'onModalDismissed', this.props);
@@ -230,6 +230,7 @@ class Dialog extends Component<DialogProps, DialogState> {
     const {useSafeArea, bottom, overlayBackgroundColor, testID} = this.props;
     const addBottomSafeArea = Constants.isIphoneX && (useSafeArea && bottom);
     const bottomInsets = Constants.getSafeAreaInsets().bottom - 8; // TODO: should this be here or in the input style?
+    const onFadeDone = Constants.isIOS ? this.onFadeDone : undefined;
 
     return (
       <View
@@ -242,7 +243,7 @@ class Dialog extends Component<DialogProps, DialogState> {
           modalVisibility={modalVisibility}
           dialogVisibility={dialogVisibility}
           overlayBackgroundColor={overlayBackgroundColor}
-          onFadeDone={this.onFadeDone}
+          onFadeDone={onFadeDone}
         />
         {this.renderDialogView()}
         {addBottomSafeArea && <View style={{marginTop: bottomInsets}}/>}

--- a/src/components/dialog/index.tsx
+++ b/src/components/dialog/index.tsx
@@ -161,6 +161,15 @@ class Dialog extends Component<DialogProps, DialogState> {
     }
   }
 
+  onFadeDone = () => {
+    if (Constants.isIOS && !this.state.modalVisibility) {
+      setTimeout(() => { // unfortunately this is needed if a modal needs to open on iOS 
+        _.invoke(this.props, 'onDialogDismissed', this.props);
+        _.invoke(this.props, 'onModalDismissed', this.props);
+      }, 50);
+    }
+  }
+
   onDismiss = () => {
     this.setState({modalVisibility: false}, () => {
       const props = this.props;
@@ -233,6 +242,7 @@ class Dialog extends Component<DialogProps, DialogState> {
           modalVisibility={modalVisibility}
           dialogVisibility={dialogVisibility}
           overlayBackgroundColor={overlayBackgroundColor}
+          onFadeDone={this.onFadeDone}
         />
         {this.renderDialogView()}
         {addBottomSafeArea && <View style={{marginTop: bottomInsets}}/>}
@@ -253,7 +263,7 @@ class Dialog extends Component<DialogProps, DialogState> {
         animationType={'none'}
         onBackgroundPress={this.hideDialogView}
         onRequestClose={this.hideDialogView}
-        onDismiss={this.onModalDismissed}
+        // onDismiss={this.onModalDismissed}
         supportedOrientations={supportedOrientations}
         accessibilityLabel={accessibilityLabel}
       >

--- a/src/components/dialog/index.tsx
+++ b/src/components/dialog/index.tsx
@@ -161,9 +161,10 @@ class Dialog extends Component<DialogProps, DialogState> {
     }
   }
 
+  // TODO: revert adding this workaround once RN fixes https://github.com/facebook/react-native/issues/29455
   onFadeDone = () => {
     if (!this.state.modalVisibility) {
-      setTimeout(() => { // unfortunately this is needed if a modal needs to open on iOS 
+      setTimeout(() => { // unfortunately this is needed if a modal needs to open on iOS
         _.invoke(this.props, 'onDialogDismissed', this.props);
         _.invoke(this.props, 'onModalDismissed', this.props);
       }, 50);


### PR DESCRIPTION
## Description
Dialog - RN63 broke Modal's onDismiss method, this fixes our API
We're somewhat relying here on the fact that the fade animation takes longer (400) than the dismiss animation (300), although when I've tested it seemed to work with the same length on animation.

## Changelog
Dialog - RN63 broke Modal's onDismiss method, this fixes our API
