### PR TITLE
ColorPicker - 'value' and 'dialogProps' props deprecations

### DIFF
--- a/demo/src/screens/componentScreens/ColorPickerScreen.js
+++ b/demo/src/screens/componentScreens/ColorPickerScreen.js
@@ -84,7 +84,7 @@ export default class ColorPickerScreen extends Component {
             onDismiss={this.onDismiss}
             onSubmit={this.onSubmit}
             onValueChange={this.onValueChange}
-            selectedValue={pickerValue}
+            value={pickerValue}
             // animatedIndex={0}
           />
         </View>

--- a/demo/src/screens/componentScreens/ColorPickerScreen.js
+++ b/demo/src/screens/componentScreens/ColorPickerScreen.js
@@ -84,7 +84,7 @@ export default class ColorPickerScreen extends Component {
             onDismiss={this.onDismiss}
             onSubmit={this.onSubmit}
             onValueChange={this.onValueChange}
-            value={pickerValue}
+            selectedValue={pickerValue}
             // animatedIndex={0}
           />
         </View>

--- a/src/components/colorPicker/ColorPickerDialog.js
+++ b/src/components/colorPicker/ColorPickerDialog.js
@@ -4,6 +4,7 @@ import React, {PureComponent} from 'react';
 import {LayoutAnimation, StyleSheet, Keyboard, TextInput, PixelRatio, I18nManager} from 'react-native';
 import {Constants} from '../../helpers';
 import {asBaseComponent} from '../../commons';
+import {extractComponentProps} from '../../commons/modifiers';
 import Assets from '../../assets';
 import {Colors, Typography} from '../../style';
 import View from '../view';
@@ -36,7 +37,7 @@ class ColorPickerDialog extends PureComponent {
      */
     onSubmit: PropTypes.func,
     /**
-     * Props to pass the Dialog component // TODO: deprecate 'dialogProps' prop
+     * Props to pass the Dialog component // TODO: remove 'dialogProps' prop after deprecation
      */
     dialogProps: PropTypes.object,
     /**
@@ -294,11 +295,11 @@ class ColorPickerDialog extends PureComponent {
   }
 
   renderDialog() {
-    const {visible, dialogProps, testID} = this.props;
+    const {dialogProps, testID} = this.props;
+    const dialogProp = extractComponentProps(Dialog, this.props);
 
     return (
       <Dialog
-        visible={visible} //TODO: pass all Dialog props instead
         width="100%"
         height={null}
         bottom
@@ -309,6 +310,7 @@ class ColorPickerDialog extends PureComponent {
         testID={`${testID}.dialog`}
         supportedOrientations={['portrait', 'landscape', 'landscape-left', 'landscape-right']} // iOS only
         {...dialogProps}
+        {...dialogProp}
       >
         {this.renderHeader()}
         {this.renderPreview()}

--- a/src/components/colorPicker/index.js
+++ b/src/components/colorPicker/index.js
@@ -35,10 +35,9 @@ class ColorPicker extends PureComponent {
      */
     colors: PropTypes.arrayOf(PropTypes.string),
     /**
-     * The value of the selected swatch // TODO: remove after migration to 'selectedValue'
+     * The value of the selected swatch
      */
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
-    selectedValue: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     /**
      * The index of the item to animate at first render (default is last)
      */
@@ -75,9 +74,6 @@ class ColorPicker extends PureComponent {
       show: false
     };
 
-    if (props.value) {
-      LogService.deprecationWarn({component: 'ColorPicker', oldProp: 'value', newProp: 'selectedValue'});
-    }
     if (props.dialogProps) {
       LogService.warn(`ColorPicker's 'dialogProps' is deprecated. Please do NOT wrap Dialog props inside an object.`);
     }
@@ -100,13 +96,13 @@ class ColorPicker extends PureComponent {
   }
 
   render() {
-    const {initialColor, colors, value, selectedValue, testID, accessibilityLabels} = this.props;
+    const {initialColor, colors, value, testID, accessibilityLabels} = this.props;
     const {show} = this.state;
 
     return (
       <View row testID={testID}>
         <ColorPalette
-          value={selectedValue || value}
+          value={value}
           colors={colors}
           style={styles.palette}
           usePagination={false}

--- a/src/components/colorPicker/index.js
+++ b/src/components/colorPicker/index.js
@@ -2,13 +2,14 @@ import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React, {PureComponent} from 'react';
 import {StyleSheet} from 'react-native';
-import ColorPalette from './ColorPalette';
-import {SWATCH_MARGIN, SWATCH_SIZE} from './ColorSwatch';
+import {LogService} from '../../services';
 import {asBaseComponent} from '../../commons';
 import Assets from '../../assets';
 import {Colors} from '../../style';
 import View from '../view';
 import Button from '../button';
+import {SWATCH_MARGIN, SWATCH_SIZE} from './ColorSwatch';
+import ColorPalette from './ColorPalette';
 import ColorPickerDialog from './ColorPickerDialog';
 
 
@@ -34,9 +35,10 @@ class ColorPicker extends PureComponent {
      */
     colors: PropTypes.arrayOf(PropTypes.string),
     /**
-     * The value of the selected swatch // TODO: rename prop 'selectedValue'
+     * The value of the selected swatch // TODO: remove after migration to 'selectedValue'
      */
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+    selectedValue: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     /**
      * The index of the item to animate at first render (default is last)
      */
@@ -72,6 +74,13 @@ class ColorPicker extends PureComponent {
     this.state = {
       show: false
     };
+
+    if (props.value) {
+      LogService.deprecationWarn({component: 'ColorPicker', oldProp: 'value', newProp: 'selectedValue'});
+    }
+    if (props.dialogProps) {
+      LogService.warn(`ColorPicker's 'dialogProps' is deprecated. Please do NOT wrap Dialog props inside an object.`);
+    }
   }
 
   get animatedIndex() {
@@ -91,13 +100,13 @@ class ColorPicker extends PureComponent {
   }
 
   render() {
-    const {initialColor, colors, value, testID, accessibilityLabels} = this.props;
+    const {initialColor, colors, value, selectedValue, testID, accessibilityLabels} = this.props;
     const {show} = this.state;
 
     return (
       <View row testID={testID}>
         <ColorPalette
-          value={value}
+          value={selectedValue || value}
           colors={colors}
           style={styles.palette}
           usePagination={false}


### PR DESCRIPTION
## Description
deprecating 'value' in favor of 'selectedValue' prop.
deprecating 'dialogProps' prop.

## Changelog
ColorPicker - 'value' (pass 'selectedValue' instead) and 'dialogProps' deprecation (pass Dialog props without object wrapper).