### PR TITLE
Use Box object to wrap usage of CustomKeyboardLayout

### DIFF
--- a/lib/android/src/main/java/com/wix/reactnativeuilib/keyboardinput/CustomKeyboardLayout.java
+++ b/lib/android/src/main/java/com/wix/reactnativeuilib/keyboardinput/CustomKeyboardLayout.java
@@ -186,4 +186,19 @@ public class CustomKeyboardLayout implements ReactSoftKeyboardMonitor.Listener, 
         }
     }
 
+    public static class Box {
+        private CustomKeyboardLayout instance;
+
+        Box() {
+            this.instance = null;
+        }
+
+        public void setInstance(CustomKeyboardLayout instance) {
+            this.instance = instance;
+        }
+
+        public CustomKeyboardLayout getInstance() {
+            return instance;
+        }
+    }
 }

--- a/lib/android/src/main/java/com/wix/reactnativeuilib/keyboardinput/CustomKeyboardRootView.java
+++ b/lib/android/src/main/java/com/wix/reactnativeuilib/keyboardinput/CustomKeyboardRootView.java
@@ -8,9 +8,9 @@ import androidx.annotation.NonNull;
 
 public class CustomKeyboardRootView extends FrameLayout {
 
-    private final CustomKeyboardLayout mLayout;
+    private final CustomKeyboardLayout.Box mLayout;
 
-    public CustomKeyboardRootView(@NonNull Context context, CustomKeyboardLayout layout) {
+    public CustomKeyboardRootView(@NonNull Context context, CustomKeyboardLayout.Box layout) {
         super(context);
         mLayout = layout;
 
@@ -20,7 +20,10 @@ public class CustomKeyboardRootView extends FrameLayout {
     @Override
     public void onViewAdded(View child) {
         if (getChildCount() == 1) {
-            mLayout.onKeyboardHasCustomContent();
+            CustomKeyboardLayout layout = mLayout.getInstance();
+            if (layout != null) {
+                layout.onKeyboardHasCustomContent();
+            }
         }
         super.onViewAdded(child);
     }

--- a/lib/android/src/main/java/com/wix/reactnativeuilib/keyboardinput/CustomKeyboardRootViewManager.java
+++ b/lib/android/src/main/java/com/wix/reactnativeuilib/keyboardinput/CustomKeyboardRootViewManager.java
@@ -6,9 +6,9 @@ import com.facebook.react.uimanager.ViewGroupManager;
 
 public class CustomKeyboardRootViewManager extends ViewGroupManager<CustomKeyboardRootView> {
 
-    private final CustomKeyboardLayout mLayout;
+    public CustomKeyboardLayout.Box mLayout;
 
-    public CustomKeyboardRootViewManager(CustomKeyboardLayout layout) {
+    public CustomKeyboardRootViewManager(CustomKeyboardLayout.Box layout) {
         mLayout = layout;
     }
 

--- a/lib/android/src/main/java/com/wix/reactnativeuilib/keyboardinput/CustomKeyboardRootViewShadow.java
+++ b/lib/android/src/main/java/com/wix/reactnativeuilib/keyboardinput/CustomKeyboardRootViewShadow.java
@@ -5,18 +5,25 @@ import com.facebook.react.uimanager.NativeViewHierarchyOptimizer;
 
 public class CustomKeyboardRootViewShadow extends LayoutShadowNode {
 
-    private final CustomKeyboardLayout mLayout;
+    private final CustomKeyboardLayout.Box mLayout;
 
-    CustomKeyboardRootViewShadow(CustomKeyboardLayout layout) {
+    CustomKeyboardRootViewShadow(CustomKeyboardLayout.Box layout) {
         setStyleHeight(0);
 
         mLayout = layout;
-        mLayout.setShadowNode(this);
+
+        CustomKeyboardLayout layoutInst = layout.getInstance();
+        if (layoutInst != null) {
+            layoutInst.setShadowNode(this);
+        }
     }
 
     @Override
     public void onBeforeLayout(NativeViewHierarchyOptimizer nativeViewHierarchyOptimizer) {
-        mLayout.setShadowNode(this);
+        CustomKeyboardLayout layoutInst = mLayout.getInstance();
+        if (layoutInst != null) {
+            layoutInst.setShadowNode(this);
+        }
     }
 
     public void setHeight(int heightPx) {

--- a/lib/android/src/main/java/com/wix/reactnativeuilib/keyboardinput/KeyboardInputModule.java
+++ b/lib/android/src/main/java/com/wix/reactnativeuilib/keyboardinput/KeyboardInputModule.java
@@ -9,9 +9,9 @@ public class KeyboardInputModule extends ReactContextBaseJavaModule {
 
     private static final String REACT_CLASS = "CustomKeyboardInputTemp";
 
-    private final CustomKeyboardLayout mLayout;
+    private final CustomKeyboardLayout.Box mLayout;
 
-    public KeyboardInputModule(ReactApplicationContext reactContext, CustomKeyboardLayout layout) {
+    public KeyboardInputModule(ReactApplicationContext reactContext, CustomKeyboardLayout.Box layout) {
         super(reactContext);
 
         mLayout = layout;
@@ -24,11 +24,17 @@ public class KeyboardInputModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void reset(Promise promise) {
-        mLayout.forceReset(promise);
+        CustomKeyboardLayout layoutInst = mLayout.getInstance();
+        if (layoutInst != null) {
+            layoutInst.forceReset(promise);
+        }
     }
 
     @ReactMethod
     public void clearFocusedView() {
-        mLayout.clearFocusedView();
+        CustomKeyboardLayout layoutInst = mLayout.getInstance();
+        if (layoutInst != null) {
+            layoutInst.clearFocusedView();
+        }
     }
 }

--- a/lib/android/src/main/java/com/wix/reactnativeuilib/keyboardinput/KeyboardInputPackage.java
+++ b/lib/android/src/main/java/com/wix/reactnativeuilib/keyboardinput/KeyboardInputPackage.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 public class KeyboardInputPackage implements ReactPackage {
 
-    private CustomKeyboardLayout mLayout;
+    private CustomKeyboardLayout.Box mLayout = new CustomKeyboardLayout.Box();
 
     public KeyboardInputPackage(Application application) {
         AppContextHolder.setApplication(application);
@@ -43,7 +43,7 @@ public class KeyboardInputPackage implements ReactPackage {
 
             final ReactScreenMonitor screenMonitor = new ReactScreenMonitor(reactContext);
             final ReactSoftKeyboardMonitor keyboardMonitor = new ReactSoftKeyboardMonitor(screenMonitor);
-            mLayout = new CustomKeyboardLayout(reactContext, keyboardMonitor, screenMonitor);
+            mLayout.setInstance(new CustomKeyboardLayout(reactContext, keyboardMonitor, screenMonitor));
         }
     }
 }


### PR DESCRIPTION
## Description
Currently there is a bug with KeyboardAccessoryView, when a custom keyboard is used on android it can't be closed (height is not set to 0) after reloading JS bundle.

The problem is that on Android, when JS bundle is reloaded, a `KeyboardInputPackage` is also reloaded, and two methods are called, first is [init](https://github.com/wix/react-native-ui-lib/blob/master/lib/android/src/main/java/com/wix/reactnativeuilib/keyboardinput/KeyboardInputPackage.java#L40) and second one is [createNativeModules](https://github.com/wix/react-native-ui-lib/blob/master/lib/android/src/main/java/com/wix/reactnativeuilib/keyboardinput/KeyboardInputPackage.java#L24). In `init` method a `CustomKeyboardLayout` is recreated with a new react context. But the [createViewManager](https://github.com/wix/react-native-ui-lib/blob/master/lib/android/src/main/java/com/wix/reactnativeuilib/keyboardinput/KeyboardInputPackage.java#L30) is not called during reload, therefore `CustomKeyboardRootViewManager` is using old pointer to `CustomKeyboardLayout`, because of that, when we trying to close custom keyboard it can't access shadow node to set height to 0.

In this PR I wrapped `CustomKeyboardLayout` with a `Box` object to have ability to use one pointer across modules and change instance dynamically.

## Changelog
Fix a bug when KeyboardAccessoryView didn't work after JS bundle reload