### PR TITLE
Picker Dependency Deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@react-native-community/datetimepicker": "^2.1.0",
     "@react-native-community/eslint-config": "^1.1.0",
     "@react-native-community/netinfo": "^5.6.2",
-    "@react-native-community/picker": "^1.6.5",
+    "@react-native-picker/picker": "^1.9.3",
     "@testing-library/react-hooks": "^3.4.2",
     "@types/lodash": "^4.0.0",
     "@types/prop-types": "^15.5.3",


### PR DESCRIPTION
@react-natve-community/picker is deprecated

## Description
*Enter description to help the reviewer understand what's the change about...*

## Changelog
*Add a quick message for our users about this change*
