### PR TITLE
Image's tintColor with null value doesn't display on Android RN63

### DIFF
--- a/src/components/button/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/button/__tests__/__snapshots__/index.spec.js.snap
@@ -855,9 +855,7 @@ exports[`Button container size should have no padding of button is an icon butto
     source={14}
     style={
       Array [
-        Object {
-          "tintColor": undefined,
-        },
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -1662,9 +1660,7 @@ exports[`Button icon should apply color on icon 1`] = `
     source={12}
     style={
       Array [
-        Object {
-          "tintColor": undefined,
-        },
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -1716,9 +1712,7 @@ exports[`Button icon should apply color on icon 2`] = `
     source={12}
     style={
       Array [
-        Object {
-          "tintColor": undefined,
-        },
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -1770,9 +1764,7 @@ exports[`Button icon should include custom iconStyle provided as a prop 1`] = `
     source={12}
     style={
       Array [
-        Object {
-          "tintColor": undefined,
-        },
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -1829,9 +1821,7 @@ exports[`Button icon should return icon style according to different variations 
     source={12}
     style={
       Array [
-        Object {
-          "tintColor": undefined,
-        },
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -1883,9 +1873,7 @@ exports[`Button icon should return icon style according to different variations 
     source={12}
     style={
       Array [
-        Object {
-          "tintColor": undefined,
-        },
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -1937,9 +1925,7 @@ exports[`Button icon should return icon style according to different variations 
     source={12}
     style={
       Array [
-        Object {
-          "tintColor": undefined,
-        },
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -2892,9 +2878,7 @@ exports[`Button labelColor should return undefined color if this is an icon butt
     source={12}
     style={
       Array [
-        Object {
-          "tintColor": undefined,
-        },
+        undefined,
         undefined,
         undefined,
         undefined,

--- a/src/components/image/index.tsx
+++ b/src/components/image/index.tsx
@@ -133,7 +133,7 @@ class Image extends PureComponent<Props> {
       // @ts-ignore
       <ImageView
         style={[
-          {tintColor},
+          tintColor && {tintColor},
           shouldFlipRTL && styles.rtlFlipped,
           cover && styles.coverImage,
           this.isGif() && styles.gifImage,


### PR DESCRIPTION
## Description
Fix issue for Android on rn63 - when passing null as tintColor to an Image, the image is not displayed

## Changelog
Fix issue for Android on rn63 - when passing null as tintColor to an Image, the image is not displayed
