### PR TITLE
checkbox variant - outline

### DIFF
--- a/generatedTypes/components/checkbox/index.d.ts
+++ b/generatedTypes/components/checkbox/index.d.ts
@@ -18,6 +18,10 @@ export interface CheckboxProps extends TouchableOpacityProps {
      */
     color?: string;
     /**
+     * alternative Checkbox outline style
+     */
+    outline?: boolean;
+    /**
      * The size of the checkbox. affect both width and height
      */
     size?: number;

--- a/src/components/checkbox/index.tsx
+++ b/src/components/checkbox/index.tsx
@@ -166,11 +166,20 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
     }
   };
 
-  getColor = () => this.props.disabled ? DEFAULT_DISABLED_COLOR : this.props.color || DEFAULT_COLOR;
+  getColor = () => (this.props.disabled ? DEFAULT_DISABLED_COLOR : this.props.color || DEFAULT_COLOR);
 
-  getBackgroundColor = () => this.props.outline ? 'transparent' : this.getColor();
+  getBackgroundColor = () => (this.props.outline ? 'transparent' : this.getColor());
 
-  getTintColor = () => this.props.outline ? this.getColor() : DEFAULT_ICON_COLOR;
+  getTintColor = () => {
+    const {outline, disabled, iconColor} = this.props;
+    if (outline) {
+      if (disabled) return DEFAULT_DISABLED_COLOR;
+      else return iconColor || DEFAULT_COLOR;
+    } else {
+      if (disabled) return Colors.white;
+      else return iconColor || Colors.white;
+    }
+  };
 
   getBorderStyle() {
     const borderColor = {borderColor: this.getColor()};
@@ -231,7 +240,12 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
 }
 
 function createStyles(props: CheckboxProps) {
-  const {color = DEFAULT_COLOR, iconColor = DEFAULT_ICON_COLOR, size = DEFAULT_SIZE, borderRadius = DEFAULT_BORDER_RADIUS} = props;
+  const {
+    color = DEFAULT_COLOR,
+    iconColor = DEFAULT_ICON_COLOR,
+    size = DEFAULT_SIZE,
+    borderRadius = DEFAULT_BORDER_RADIUS
+  } = props;
 
   return StyleSheet.create({
     container: {

--- a/src/components/checkbox/index.tsx
+++ b/src/components/checkbox/index.tsx
@@ -15,6 +15,9 @@ const DEFAULT_COLOR = Colors.blue30;
 const DEFAULT_ICON_COLOR = Colors.white;
 const DEFAULT_DISABLED_COLOR = Colors.grey50;
 
+const DEFAULT_BORDER_WIDTH = 2;
+const DEFAULT_BORDER_RADIUS = 8;
+
 export interface CheckboxProps extends TouchableOpacityProps {
   /**
    * The value of the Checkbox. If true the switch will be turned on. Default value is false.
@@ -163,31 +166,21 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
     }
   };
 
-  getColor() {
-    const {color, disabled} = this.props;
-    return disabled ? DEFAULT_DISABLED_COLOR : color || DEFAULT_COLOR;
-  }
+  getColor = () => this.props.disabled ? DEFAULT_DISABLED_COLOR : this.props.color || DEFAULT_COLOR;
+
+  getBackgroundColor = () => this.props.outline ? 'transparent' : this.getColor();
+
+  getTintColor = () => this.props.outline ? this.getColor() : DEFAULT_ICON_COLOR;
 
   getBorderStyle() {
     const borderColor = {borderColor: this.getColor()};
-    const borderStyle = [this.styles.container, {borderWidth: 2}, borderColor];
+    const borderStyle = [this.styles.container, {borderWidth: DEFAULT_BORDER_WIDTH}, borderColor];
 
     return borderStyle;
   }
 
   renderCheckbox() {
-    const {
-      selectedIcon,
-      color,
-      iconColor,
-      label,
-      disabled,
-      testID,
-      style,
-      containerStyle,
-      outline = false,
-      ...others
-    } = this.props;
+    const {selectedIcon, color, iconColor, label, disabled, testID, style, containerStyle, ...others} = this.props;
 
     return (
       //@ts-ignore
@@ -203,16 +196,15 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
           <Animated.View
             style={[
               this.styles.container,
-              {backgroundColor: outline ? 'transparent' : disabled ? DEFAULT_DISABLED_COLOR : this.getColor()},
-              {opacity: this.animationStyle.opacity}
+              {opacity: this.animationStyle.opacity},
+              {backgroundColor: this.getBackgroundColor()}
             ]}
           >
             <Animated.Image
               style={[
                 this.styles.selectedIcon,
-                color && {tintColor: outline ? this.getColor() : DEFAULT_ICON_COLOR},
                 {transform: this.animationStyle.transform},
-                disabled && {tintColor: outline ? DEFAULT_DISABLED_COLOR : DEFAULT_ICON_COLOR}
+                {tintColor: this.getTintColor()}
               ]}
               source={selectedIcon || Assets.icons.checkSmall}
               testID={`${testID}.selected`}
@@ -239,19 +231,19 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
 }
 
 function createStyles(props: CheckboxProps) {
-  const {color = DEFAULT_COLOR, iconColor = DEFAULT_ICON_COLOR, size = DEFAULT_SIZE, borderRadius, outline, disabled} = props;
+  const {color = DEFAULT_COLOR, iconColor = DEFAULT_ICON_COLOR, size = DEFAULT_SIZE, borderRadius = DEFAULT_BORDER_RADIUS} = props;
 
   return StyleSheet.create({
     container: {
       width: size,
       height: size,
-      borderRadius: borderRadius || 8,
+      borderRadius: borderRadius,
       alignItems: 'center',
       justifyContent: 'center',
       borderColor: color
     },
     selectedIcon: {
-      tintColor:  disabled ? DEFAULT_DISABLED_COLOR : outline ? color : iconColor,
+      tintColor: iconColor,
       alignItems: 'center',
       justifyContent: 'center'
     },

--- a/src/components/checkbox/index.tsx
+++ b/src/components/checkbox/index.tsx
@@ -33,6 +33,10 @@ export interface CheckboxProps extends TouchableOpacityProps {
    */
   color?: string;
   /**
+   * alternative Checkbox outline style
+   */
+  outline?: boolean;
+  /**
    * The size of the checkbox. affect both width and height
    */
   size?: number;
@@ -172,7 +176,18 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
   }
 
   renderCheckbox() {
-    const {selectedIcon, color, iconColor, label, disabled, testID, style, containerStyle, ...others} = this.props;
+    const {
+      selectedIcon,
+      color,
+      iconColor,
+      label,
+      disabled,
+      testID,
+      style,
+      containerStyle,
+      outline = false,
+      ...others
+    } = this.props;
 
     return (
       //@ts-ignore
@@ -186,14 +201,18 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
       >
         {
           <Animated.View
-            style={[this.styles.container, {backgroundColor: this.getColor()}, {opacity: this.animationStyle.opacity}]}
+            style={[
+              this.styles.container,
+              {backgroundColor: outline ? 'transparent' : disabled ? DEFAULT_DISABLED_COLOR : this.getColor()},
+              {opacity: this.animationStyle.opacity}
+            ]}
           >
             <Animated.Image
               style={[
                 this.styles.selectedIcon,
-                color && {tintColor: iconColor},
+                color && {tintColor: outline ? this.getColor() : DEFAULT_ICON_COLOR},
                 {transform: this.animationStyle.transform},
-                disabled && {tintColor: DEFAULT_ICON_COLOR}
+                disabled && {tintColor: outline ? DEFAULT_DISABLED_COLOR : DEFAULT_ICON_COLOR}
               ]}
               source={selectedIcon || Assets.icons.checkSmall}
               testID={`${testID}.selected`}
@@ -220,7 +239,7 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
 }
 
 function createStyles(props: CheckboxProps) {
-  const {color = DEFAULT_COLOR, iconColor = DEFAULT_ICON_COLOR, size = DEFAULT_SIZE, borderRadius} = props;
+  const {color = DEFAULT_COLOR, iconColor = DEFAULT_ICON_COLOR, size = DEFAULT_SIZE, borderRadius, outline, disabled} = props;
 
   return StyleSheet.create({
     container: {
@@ -232,7 +251,7 @@ function createStyles(props: CheckboxProps) {
       borderColor: color
     },
     selectedIcon: {
-      tintColor: iconColor,
+      tintColor:  disabled ? DEFAULT_DISABLED_COLOR : outline ? color : iconColor,
       alignItems: 'center',
       justifyContent: 'center'
     },


### PR DESCRIPTION
## Description

Alternative style for checkbox that wasn't possible with basic styling and theming alone.

<img width="508" alt="Screenshot 2020-12-08 at 19 11 57" src="https://user-images.githubusercontent.com/1291776/101523989-a49d3100-3989-11eb-9e3a-76f662f23bba.png">
<img width="502" alt="Screenshot 2020-12-08 at 19 11 52" src="https://user-images.githubusercontent.com/1291776/101523994-a7982180-3989-11eb-8a47-fe971d5cca34.png">


## Changelog
Added optional boolean outline prop.  The checkbox acts normal when false and by default.


