### PR TITLE
Fix/tab controller transition

### DIFF
--- a/src/components/tabController/PageCarousel.tsx
+++ b/src/components/tabController/PageCarousel.tsx
@@ -40,13 +40,20 @@ class PageCarousel extends PureComponent {
     }
   };
 
-  renderCodeBlock = () => {
+  renderCodeBlock = _.memoize(() => {
     const {targetPage, containerWidth} = this.context;
-    return block([
-      Animated.onChange(targetPage, [call([targetPage], this.onTabChange)]),
-      Animated.onChange(containerWidth, [call([targetPage], this.onTabChange)])
-    ]);
-  };
+
+    return (
+      <Code>
+        {() =>
+          block([
+            Animated.onChange(targetPage, [call([targetPage], this.onTabChange)]),
+            Animated.onChange(containerWidth, [call([targetPage], this.onTabChange)])
+          ])
+        }
+      </Code>
+    );
+  });
 
   render() {
     const {selectedIndex, pageWidth} = this.context;
@@ -63,7 +70,7 @@ class PageCarousel extends PureComponent {
           contentOffset={{x: selectedIndex * pageWidth, y: 0}} // iOS only
         />
 
-        <Code>{this.renderCodeBlock}</Code>
+        {this.renderCodeBlock()}
       </>
     );
   }

--- a/src/components/tabController/TabBar.tsx
+++ b/src/components/tabController/TabBar.tsx
@@ -353,7 +353,7 @@ class TabBar extends PureComponent<Props, State> {
     const {itemsWidths} = this.state;
     const {indicatorStyle} = this.props;
     if (itemsWidths.length > 0) {
-      return <Reanimated.View style={[styles.selectedIndicator, indicatorStyle, this._indicatorTransitionStyle]} />;
+      return <Reanimated.View style={[styles.selectedIndicator, indicatorStyle, this._indicatorTransitionStyle]}/>;
     }
   }
 
@@ -428,31 +428,23 @@ class TabBar extends PureComponent<Props, State> {
     }
   }
 
-  renderCodeBlock = () => {
+  renderCodeBlock = _.memoize(() => {
     const {currentPage, targetPage} = this.context;
     const {itemsWidths, itemsOffsets} = this.state;
     const nodes = [];
 
-    nodes.push(
-      set(
-        this._indicatorOffset,
-        interpolate(currentPage, {
-          inputRange: itemsOffsets.map((_v, i) => i),
-          outputRange: itemsOffsets
-        })
-      )
-    );
-    nodes.push(
-      set(
-        this._indicatorWidth,
-        interpolate(currentPage, {inputRange: itemsWidths.map((_v, i) => i), outputRange: itemsWidths})
-      )
-    );
+    nodes.push(set(this._indicatorOffset,
+      interpolate(currentPage, {
+        inputRange: itemsOffsets.map((_v, i) => i),
+        outputRange: itemsOffsets
+      })));
+    nodes.push(set(this._indicatorWidth,
+      interpolate(currentPage, {inputRange: itemsWidths.map((_v, i) => i), outputRange: itemsWidths})));
 
     nodes.push(Reanimated.onChange(targetPage, Reanimated.call([targetPage], this.focusSelected)));
 
-    return block(nodes);
-  };
+    return <Code>{() => block(nodes)}</Code>;
+  });
 
   getShadowStyle() {
     const {enableShadow, shadowStyle} = this.props;
@@ -487,9 +479,9 @@ class TabBar extends PureComponent<Props, State> {
           </View>
           {this.renderSelectedIndicator()}
         </ScrollView>
-        {_.size(itemsWidths) > 1 && <Code>{this.renderCodeBlock}</Code>}
-        <ScrollBarGradient left visible={fadeLeft} />
-        <ScrollBarGradient visible={fadeRight} />
+        {_.size(itemsWidths) > 1 && this.renderCodeBlock()}
+        <ScrollBarGradient left visible={fadeLeft}/>
+        <ScrollBarGradient visible={fadeRight}/>
       </View>
     );
   }

--- a/src/components/tabController/TabPage.tsx
+++ b/src/components/tabController/TabPage.tsx
@@ -68,16 +68,25 @@ export default class TabPage extends PureComponent<TabPageProps> {
     }, this.props.lazyLoadTime); // tab bar indicator transition time
   };
 
-  renderCodeBlock = () => {
+  renderCodeBlock = _.memoize(() => {
     const {targetPage} = this.context;
     const {index, lazy} = this.props;
-    return block([
-      cond(and(eq(targetPage, index), Number(lazy), eq(this._loaded, 0)), [set(this._loaded, 1), call([], this.lazyLoad)]),
-      cond(eq(targetPage, index),
-        [set(this._opacity, 1), set(this._zIndex, 1)],
-        [set(this._opacity, 0), set(this._zIndex, 0)])
-    ]);
-  };
+    return (
+      <Code>
+        {() =>
+          block([
+            cond(and(eq(targetPage, index), Number(lazy), eq(this._loaded, 0)), [
+              set(this._loaded, 1),
+              call([], this.lazyLoad)
+            ]),
+            cond(eq(targetPage, index),
+              [set(this._opacity, 1), set(this._zIndex, 1)],
+              [set(this._opacity, 0), set(this._zIndex, 0)])
+          ])
+        }
+      </Code>
+    );
+  });
 
   render() {
     const {renderLoading, testID} = this.props;
@@ -87,9 +96,7 @@ export default class TabPage extends PureComponent<TabPageProps> {
       <Reanimated.View style={this._pageStyle} testID={testID}>
         {!loaded && renderLoading?.()}
         {loaded && this.props.children}
-        <Code>
-          {this.renderCodeBlock}
-        </Code>
+        {this.renderCodeBlock()}
       </Reanimated.View>
     );
   }

--- a/src/components/tabController/index.tsx
+++ b/src/components/tabController/index.tsx
@@ -24,6 +24,7 @@ const {
   diff,
   eq,
   floor,
+  greaterThan,
   lessThan,
   neq,
   not,
@@ -167,6 +168,8 @@ class TabController extends Component<TabControllerProps, StateProps> {
     const toPage = new Value(selectedIndex);
     const isAnimating = new Value(0);
     const isScrolling = new Value(0);
+    // temps
+    const _carouselOffsetDiff = new Value(0);
 
     return block([
       /* Page change by TabBar */
@@ -198,15 +201,18 @@ class TabController extends Component<TabControllerProps, StateProps> {
 
       /* Page change by Carousel scroll */
       onChange(carouselOffset, [
-        set(isScrolling, lessThan(round(abs(diff(carouselOffset))), round(containerWidth))),
+        set(_carouselOffsetDiff, round(abs(diff(carouselOffset)))),
+        set(isScrolling,
+          and(
+            lessThan(_carouselOffsetDiff, round(containerWidth)),
+            greaterThan(_carouselOffsetDiff, 0))
+          ),
         cond(not(isAnimating), [
-          set(
-            currentPage,
+          set(currentPage,
             interpolate(round(carouselOffset), {
               inputRange: itemStates.map((_v, i) => round(multiply(i, containerWidth))),
               outputRange: itemStates.map((_v, i) => i)
-            })
-          ),
+            })),
           set(toPage, currentPage)
         ])
       ]),


### PR DESCRIPTION
## Description
Fix animation issues in TabController, there are two commits here
**Notice this PR branched from your PR (with all the TS changes, so there won't be any conflicts) - so merging it, will update your PR.** 

The First:
Fix the issue with the first time you press a tab bar item - there's no response

The second:
Fix a bigger issue. 
Apparently they fixed something in reanimated@13.1 that expose a bug on our end. 
It seems the `<Code>....</Code>` blocks kept re-rendering while they should have been monetized. 
Re-redner the `Code` block on state change cause the animation declarations to reset - which caused a huge problem. 

## Changelog
Fix TabController animation issues with reanimated@13.1
