### PR TITLE
Feat/radio button customize styling

### DIFF
--- a/src/components/radioButton/RadioButton.tsx
+++ b/src/components/radioButton/RadioButton.tsx
@@ -77,6 +77,10 @@ export type RadioButtonProps = RadioGroupContextProps &
      * Should the content be rendered right to the button
      */
     contentOnRight?: boolean;
+    /**
+     * Additional styling for the container
+     */
+    containerStyle?: StyleProp<ViewStyle>;
   };
 export type RadioButtonPropTypes = RadioButtonProps; //TODO: remove after ComponentPropTypes deprecation;
 
@@ -245,12 +249,20 @@ class RadioButton extends PureComponent<Props, RadioButtonState> {
   }
 
   render() {
-    const {onPress, onValueChange, contentOnRight, style, ...others} = this.props;
+    const {onPress, onValueChange, contentOnRight, style, containerStyle, ...others} = this.props;
     const Container = onPress || onValueChange ? TouchableOpacity : View;
 
     return (
       // @ts-ignore
-      <Container row centerV activeOpacity={1} {...others} onPress={this.onPress} {...this.getAccessibilityProps()}>
+      <Container
+        row
+        centerV
+        activeOpacity={1}
+        style={containerStyle}
+        {...others}
+        onPress={this.onPress}
+        {...this.getAccessibilityProps()}
+      >
         {!contentOnRight && this.renderButton()}
         {this.props.iconOnRight ? this.renderLabel() : this.renderIcon()}
         {this.props.iconOnRight ? this.renderIcon() : this.renderLabel()}

--- a/src/components/radioButton/RadioButton.tsx
+++ b/src/components/radioButton/RadioButton.tsx
@@ -245,7 +245,7 @@ class RadioButton extends PureComponent<Props, RadioButtonState> {
   }
 
   render() {
-    const {onPress, onValueChange, contentOnRight, ...others} = this.props;
+    const {onPress, onValueChange, contentOnRight, style, ...others} = this.props;
     const Container = onPress || onValueChange ? TouchableOpacity : View;
 
     return (

--- a/src/components/radioButton/RadioButton.tsx
+++ b/src/components/radioButton/RadioButton.tsx
@@ -23,56 +23,57 @@ import {RadioGroupContextProps} from './RadioGroupContext';
 const DEFAULT_SIZE = 24;
 const DEFAULT_COLOR = Colors.blue30;
 
-export type RadioButtonProps = RadioGroupContextProps & ViewProps & {
-  /**
-   * The identifier value of the radio button. must be different than other RadioButtons in the same group
-   */
-  value?: string | number | boolean;
-  /**
-   * When using RadioButton without a RadioGroup, use this prop to toggle selection
-   */
-  selected?: boolean;
-  /**
-   * Invoked when pressing the button
-   */
-  onPress?: (selected: boolean) => void;
-  /**
-   * Whether the radio button should be disabled
-   */
-  disabled?: boolean;
-  /**
-   * The color of the radio button
-   */
-  color?: string;
-  /**
-   * The size of the radio button, affect both width & height
-   */
-  size?: number;
-  /**
-   * The radio button border radius
-   */
-  borderRadius?: number;
-  /**
-   * A label for the radio button description
-   */
-  label?: string;
-  /**
-   * Label style
-   */
-  labelStyle?: TextStyle;
-  /**
-   * Icon image source
-   */
-  iconSource?: ImageSourcePropType;
-  /**
-   * Icon image style
-   */
-  iconStyle?: ImageStyle;
-  /**
-   * Should the icon be on the right side of the label
-   */
-  iconOnRight?: boolean;
-   /**
+export type RadioButtonProps = RadioGroupContextProps &
+  ViewProps & {
+    /**
+     * The identifier value of the radio button. must be different than other RadioButtons in the same group
+     */
+    value?: string | number | boolean;
+    /**
+     * When using RadioButton without a RadioGroup, use this prop to toggle selection
+     */
+    selected?: boolean;
+    /**
+     * Invoked when pressing the button
+     */
+    onPress?: (selected: boolean) => void;
+    /**
+     * Whether the radio button should be disabled
+     */
+    disabled?: boolean;
+    /**
+     * The color of the radio button
+     */
+    color?: string;
+    /**
+     * The size of the radio button, affect both width & height
+     */
+    size?: number;
+    /**
+     * The radio button border radius
+     */
+    borderRadius?: number;
+    /**
+     * A label for the radio button description
+     */
+    label?: string;
+    /**
+     * Label style
+     */
+    labelStyle?: TextStyle;
+    /**
+     * Icon image source
+     */
+    iconSource?: ImageSourcePropType;
+    /**
+     * Icon image style
+     */
+    iconStyle?: ImageStyle;
+    /**
+     * Should the icon be on the right side of the label
+     */
+    iconOnRight?: boolean;
+    /**
      * Should the content be rendered right to the button
      */
     contentOnRight?: boolean;
@@ -224,7 +225,7 @@ class RadioButton extends PureComponent<Props, RadioButtonState> {
   renderIcon() {
     const {iconSource, iconStyle} = this.props;
     const style = [this.styles.image, iconStyle];
-    return iconSource && <Image style={style} source={iconSource}/>;
+    return iconSource && <Image style={style} source={iconSource} />;
   }
 
   renderButton() {
@@ -249,14 +250,7 @@ class RadioButton extends PureComponent<Props, RadioButtonState> {
 
     return (
       // @ts-ignore
-      <Container
-        row
-        centerV
-        activeOpacity={1}
-        {...others}
-        onPress={this.onPress}
-        {...this.getAccessibilityProps()}
-      >
+      <Container row centerV activeOpacity={1} {...others} onPress={this.onPress} {...this.getAccessibilityProps()}>
         {!contentOnRight && this.renderButton()}
         {this.props.iconOnRight ? this.renderLabel() : this.renderIcon()}
         {this.props.iconOnRight ? this.renderIcon() : this.renderLabel()}


### PR DESCRIPTION
## Description
The `style` property on the _RadioButton_ component was applied to both the `<Container />` component wrapping the radio button and label, and to the radio button itself. This made customizing the styling of the component less possible.

I simply added `style` to the destructuring in the `render` function, removing it from `...others` and not being applied to the `<Container />`. An option would be to also allow styling the container, by adding a `containerStyle` prop, just like in the code for the CheckBox.

Two commits, one solely for the prettier format and the 2nd containing the change

## Changelog
* The `style` prop can be used to apply customized styling to the radio button.