### PR TITLE
Feat/use did update hook

### DIFF
--- a/generatedTypes/hooks/index.d.ts
+++ b/generatedTypes/hooks/index.d.ts
@@ -1,1 +1,2 @@
 export { default as useToggleValue } from './useToggleValue';
+export { default as useDidUpdate } from './useDidUpdate';

--- a/generatedTypes/hooks/useDidUpdate/index.d.ts
+++ b/generatedTypes/hooks/useDidUpdate/index.d.ts
@@ -1,0 +1,5 @@
+/**
+ * This hook avoid calling useEffect on the initial value of his dependency array
+ */
+declare const useDidUpdate: (action: () => void, dep: [any]) => void;
+export default useDidUpdate;

--- a/generatedTypes/index.d.ts
+++ b/generatedTypes/index.d.ts
@@ -21,8 +21,7 @@ export {
   PaddingModifiers,
   TypographyModifiers,
   ColorsModifiers,
-  BackgroundColorModifier,
-  useToggleValue
+  BackgroundColorModifier
 } from './commons/new';
 export {default as ActionBar, ActionBarProps} from './components/actionBar';
 export {default as Avatar, AvatarPropTypes, AvatarProps} from './components/avatar';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export {default as useToggleValue} from './useToggleValue';
+export {default as useDidUpdate} from './useDidUpdate';

--- a/src/hooks/useDidUpdate/__tests__/useDidUpdate.spec.js
+++ b/src/hooks/useDidUpdate/__tests__/useDidUpdate.spec.js
@@ -1,0 +1,69 @@
+import {renderHook, act} from '@testing-library/react-hooks';
+import useDidUpdate from '../index';
+
+describe('useDidUpdate hook tests', () => {
+  it('Expect action to not be called when the dependencies array value hasn\'t change', () => {
+    const action = jest.fn();
+    const dependencies = [false, 'false'];
+    const {rerender} = renderHook(() => useDidUpdate(action, dependencies));
+
+    rerender();
+    rerender();
+    rerender();
+    expect(action.mock.calls.length).toBe(0);
+  });
+
+  it('Expect action to be called when dependencies array has change', () => {
+    const action = jest.fn();
+    let dependencies = [false, 'YES YES', 1];
+    const {rerender} = renderHook(() => useDidUpdate(action, dependencies));
+
+    dependencies = [false, 'NO NO', 1];
+    rerender();
+    expect(action.mock.calls.length).toBe(1);
+  });
+
+  it('Expect action to be called when dependencies array has change', () => {
+    const action = jest.fn();
+    let dependencies = [false, 'YES YES', 1];
+    const {rerender} = renderHook(() => useDidUpdate(action, dependencies));
+
+    dependencies = [false, 'NO NO', 1];
+    rerender();
+    expect(action.mock.calls.length).toBe(1);
+  });
+
+  it('Expect action to be called when dependencies array has change', () => {
+    const action = jest.fn();
+    let dependencies = [false, 'YES YES', 1];
+    const {rerender} = renderHook(() => useDidUpdate(action, dependencies));
+
+    dependencies = [false, 'NO NO', 1];
+    rerender();
+    expect(action.mock.calls.length).toBe(1);
+  });
+
+  it('Expect action to be called when object value in dependencies array has change', () => {
+    const action = jest.fn();
+    let dependencies = [false, [1, 2], {name: 'AAA', address: {number: 10}}];
+    const {rerender} = renderHook(() => useDidUpdate(action, dependencies));
+
+    dependencies = [false, [1, 2], {name: 'BBB'}];
+    rerender();
+    expect(action.mock.calls.length).toBe(1);
+    
+    dependencies = [false, [1, 2], {name: 'AAA', address: {number: 20}}];
+    rerender();
+    expect(action.mock.calls.length).toBe(2);
+  });
+
+  it('Expect action to be called when value in array dependencies array has change', () => {
+    const action = jest.fn();
+    let dependencies = [false, [1, [2]], {name: 'AAA'}];
+    const {rerender} = renderHook(() => useDidUpdate(action, dependencies));
+
+    dependencies = [false, [1, [3]], {name: 'AAA', address: {number: 20}}];
+    rerender();
+    expect(action.mock.calls.length).toBe(1);
+  });
+});

--- a/src/hooks/useDidUpdate/__tests__/useDidUpdate.spec.js
+++ b/src/hooks/useDidUpdate/__tests__/useDidUpdate.spec.js
@@ -1,4 +1,4 @@
-import {renderHook, act} from '@testing-library/react-hooks';
+import {renderHook} from '@testing-library/react-hooks';
 import useDidUpdate from '../index';
 
 describe('useDidUpdate hook tests', () => {

--- a/src/hooks/useDidUpdate/index.ts
+++ b/src/hooks/useDidUpdate/index.ts
@@ -1,0 +1,24 @@
+import {useEffect, useRef, useCallback} from 'react';
+import _ from 'lodash';
+
+/**
+ * This hook avoid calling useEffect on the initial value of his dependency array
+ */
+const useDidUpdate = (action: () => void, dep: [any]) => {
+  const _dep = useRef<[any] | undefined>(dep);
+
+  const isDataChanged = useCallback(() => {
+    return !_.isEqual(_dep.current, dep);
+  }, [dep]);
+
+  useEffect(() => {
+    if (!isDataChanged()) {
+      return;
+    }
+    _dep.current = dep;
+
+    action();
+  }, [dep]);
+};
+
+export default useDidUpdate;


### PR DESCRIPTION
## Description
Added new hook tool - `useDidUpdate` to avoid getting side effect calls on initial value.

## Changelog
Introduce new `useDidUpdate` hook, that will skip update on initial value.
