### PR TITLE
DateTimePicker - adding 'headerStyle' prop

### DIFF
--- a/src/components/dateTimePicker/index.js
+++ b/src/components/dateTimePicker/index.js
@@ -89,7 +89,11 @@ class DateTimePicker extends Component {
     /**
      * Props to pass the Dialog component
      */
-    dialogProps: PropTypes.object
+    dialogProps: PropTypes.object,
+    /**
+     * style to apply to the iOS dialog header
+     */
+    headerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number])
   };
 
   static defaultProps = {
@@ -202,10 +206,10 @@ class DateTimePicker extends Component {
   };
 
   renderHeader() {
-    const {useCustomTheme} = this.props;
+    const {useCustomTheme, headerStyle} = this.props;
 
     return (
-      <View row spread bg-white paddingH-20 style={styles.header}>
+      <View row spread bg-white paddingH-20 style={[styles.header, headerStyle]}>
         <Button
           link
           iconSource={Assets.icons.x}


### PR DESCRIPTION

## Description
DateTimePicker - adding 'headerStyle' prop to adjust iOS dialog header style.

Solves issue #1014 

## Changelog
DateTimePicker - adding 'headerStyle' prop to adjust iOS dialog header style.
