### PR TITLE
Fix #1133 - FeatureHighlight component doesn't use useNativeDriver

### DIFF
--- a/src/components/featureHighlight/index.js
+++ b/src/components/featureHighlight/index.js
@@ -173,7 +173,8 @@ class FeatureHighlight extends BaseComponent {
       this.state.fadeAnim, // The animated value to drive
       {
         toValue, // Animate to value
-        duration: toValue ? 100 : 0 // Make it take a while
+        duration: toValue ? 100 : 0, // Make it take a while
+        useNativeDriver: true
       },).start(); // Starts the animation
   }
 


### PR DESCRIPTION
## Description
FeatureHighlight was missing the useNativeDriver prop which now is mandatory by react-native

## Changelog
Fix issue with FeatureHighlight component not using useNativeDriver flag
