### PR TITLE
fix docs code link error - component carousel

### DIFF
--- a/generatedTypes/components/carousel/index.d.ts
+++ b/generatedTypes/components/carousel/index.d.ts
@@ -6,7 +6,7 @@ declare type DefaultProps = Partial<CarouselProps>;
 /**
  * @description: Carousel for scrolling pages horizontally
  * @gif: https://media.giphy.com/media/l0HU7f8gjpRlMRhKw/giphy.gif, https://media.giphy.com/media/3oFzmcjX9OhpyckhcQ/giphy.gif
- * @example: https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/CarouselScreen.js
+ * @example: https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/CarouselScreen.tsx
  * @extends: ScrollView
  * @extendsLink: https://facebook.github.io/react-native/docs/scrollview
  * @notes: This is screed width Component


### PR DESCRIPTION
## Description
The original link points to the wrong

## Changelog
fix docs code link error
