### PR TITLE
ChispInput backspase fix for Android

### DIFF
--- a/src/components/chipsInput/__tests__/index.spec.js
+++ b/src/components/chipsInput/__tests__/index.spec.js
@@ -61,15 +61,6 @@ describe('ChipsInput', () => {
       expect(removeTagSpy).not.toHaveBeenCalled();
     });
 
-    it('should ignore key event if platform is Android', () => {
-      Constants.isAndroid = true;
-      const pressEvent = {};
-      _.set(uut.state, 'tags', [{}, {}, {}]);
-      uut.onKeyPress(pressEvent);
-      expect(uut.state.tagIndexToRemove).toBe(2);
-      Constants.isAndroid = false;
-    });
-
     it('should not update state if input value is not empty', () => {
       const pressEvent = {nativeEvent: {key: Constants.backspaceKey}};
       _.set(uut.state, 'tags', [{}, {}, {}]);

--- a/src/components/chipsInput/index.js
+++ b/src/components/chipsInput/index.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import ReactNative, {NativeModules, StyleSheet, ViewPropTypes, Image, DeviceEventEmitter} from 'react-native';
+import ReactNative, {NativeModules, StyleSheet, ViewPropTypes, Image} from 'react-native';
 import {Constants} from '../../helpers';
 import {Colors, BorderRadiuses, ThemeManager, Typography} from '../../style';
 import Assets from '../../assets';
@@ -105,14 +105,7 @@ class ChipsInput extends Component {
       const textInputHandle = ReactNative.findNodeHandle(this.input);
       if (textInputHandle && NativeModules.TextInputDelKeyHandler) {
         NativeModules.TextInputDelKeyHandler.register(textInputHandle);
-        DeviceEventEmitter.addListener('onBackspacePress', this.onKeyPress);
       }
-    }
-  }
-
-  componentWillUnmount() {
-    if (Constants.isAndroid) {
-      DeviceEventEmitter.removeListener('onBackspacePress', this.onKeyPress);
     }
   }
 
@@ -169,10 +162,10 @@ class ChipsInput extends Component {
     this.setState({tagIndexToRemove: tagIndex});
   }
 
-  onChangeText = (value) => {
+  onChangeText = _.debounce((value) => {
     this.setState({value, tagIndexToRemove: undefined});
     _.invoke(this.props, 'onChangeText', value);
-  }
+  }, 0);
 
   onTagPress(index) {
     const {onTagPress} = this.props;
@@ -212,7 +205,7 @@ class ChipsInput extends Component {
     const tagsCount = _.size(tags);
     const keyCode = _.get(event, 'nativeEvent.key');
     const hasNoValue = _.isEmpty(value);
-    const pressedBackspace = Constants.isAndroid || keyCode === Constants.backspaceKey;
+    const pressedBackspace = keyCode === Constants.backspaceKey;
     const hasTags = tagsCount > 0;
 
     if (pressedBackspace) {


### PR DESCRIPTION
## Description

There is an issue in react-native lib.  https://github.com/facebook/react-native/issues/29689 
onChangeText is called before onKeyPress on Android - state.input are empty when deleting last character. Debounce fixes execution order.

onKeyPress is called properly for backspace button. No need additional event listener.
`DeviceEventEmitter.addListener('onBackspacePress', this.onKeyPress);	` 
Found out this caused double onKeyPress events.

## Changelog

Fixed ChipsInput backspace tag removal issue on Android.