### PR TITLE
Add our private shadows presets in OS

### DIFF
--- a/generatedTypes/style/shadows.d.ts
+++ b/generatedTypes/style/shadows.d.ts
@@ -4,6 +4,72 @@ declare type Shadow = {
     bottom?: ShadowStyleIOS;
 } & ShadowStyleIOS;
 declare const _default: {
+    sh10: {
+        top: {
+            shadowColor: string;
+            shadowOpacity: number;
+            shadowRadius: number;
+            shadowOffset: {
+                height: number;
+                width: number;
+            };
+            elevation: number;
+        };
+        bottom: {
+            shadowColor: string;
+            shadowOpacity: number;
+            shadowRadius: number;
+            shadowOffset: {
+                height: number;
+                width: number;
+            };
+            elevation: number;
+        };
+    };
+    sh20: {
+        top: {
+            shadowColor: string;
+            shadowOpacity: number;
+            shadowRadius: number;
+            shadowOffset: {
+                height: number;
+                width: number;
+            };
+            elevation: number;
+        };
+        bottom: {
+            shadowColor: string;
+            shadowOpacity: number;
+            shadowRadius: number;
+            shadowOffset: {
+                height: number;
+                width: number;
+            };
+            elevation: number;
+        };
+    };
+    sh30: {
+        top: {
+            shadowColor: string;
+            shadowOpacity: number;
+            shadowRadius: number;
+            shadowOffset: {
+                height: number;
+                width: number;
+            };
+            elevation: number;
+        };
+        bottom: {
+            shadowColor: string;
+            shadowOpacity: number;
+            shadowRadius: number;
+            shadowOffset: {
+                height: number;
+                width: number;
+            };
+            elevation: number;
+        };
+    };
     white10: {
         top: {
             shadowColor: string;

--- a/src/style/shadows.ts
+++ b/src/style/shadows.ts
@@ -5,6 +5,55 @@ import Colors from './colors';
 type Shadow = {top?: ShadowStyleIOS, bottom?: ShadowStyleIOS} & ShadowStyleIOS;
 
 const Shadows = {
+  sh10: {
+    top: {
+      shadowColor: Colors.grey40,
+      shadowOpacity: 0.18,
+      shadowRadius: 5,
+      shadowOffset: {height: -1, width: 0},
+      elevation: 2
+    },
+    bottom: {
+      shadowColor: Colors.grey40,
+      shadowOpacity: 0.18,
+      shadowRadius: 5,
+      shadowOffset: {height: 1, width: 0},
+      elevation: 2
+    }
+  },
+  sh20: {
+    top: {
+      shadowColor: Colors.grey30,
+      shadowOpacity: 0.2,
+      shadowRadius: 10,
+      shadowOffset: {height: -2, width: 0},
+      elevation: 3
+    },
+    bottom: {
+      shadowColor: Colors.grey30,
+      shadowOpacity: 0.2,
+      shadowRadius: 10,
+      shadowOffset: {height: 2, width: 0},
+      elevation: 3
+    }
+  },
+  sh30: {
+    top: {
+      shadowColor: Colors.grey30,
+      shadowOpacity: 0.2,
+      shadowRadius: 12,
+      shadowOffset: {height: -5, width: 0},
+      elevation: 4
+    },
+    bottom: {
+      shadowColor: Colors.grey30,
+      shadowOpacity: 0.2,
+      shadowRadius: 12,
+      shadowOffset: {height: 5, width: 0},
+      elevation: 4
+    }
+  },
+  /* Old Presets */
   white10: {
     top: {shadowColor: Colors.dark20, shadowOpacity: 0.04, shadowRadius: 13.5},
     bottom: {shadowColor: Colors.dark10, shadowOpacity: 0.09, shadowRadius: 2, shadowOffset: {height: 2, width: 0}}


### PR DESCRIPTION
## Description
There's a mismatch between our private and publish shadows presets. 
It create issues with tests in private modules and also we can't use the right presets in our public components

## Changelog
Update Shadows presets with `Shadows.sh10`, `Shadows.sh20`, `Shadows.sh30`
