### PR TITLE
[Typo] "screed" should be "screen"

### DIFF
--- a/generatedTypes/components/carousel/index.d.ts
+++ b/generatedTypes/components/carousel/index.d.ts
@@ -9,7 +9,7 @@ declare type DefaultProps = Partial<CarouselProps>;
  * @example: https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/CarouselScreen.tsx
  * @extends: ScrollView
  * @extendsLink: https://facebook.github.io/react-native/docs/scrollview
- * @notes: This is screed width Component
+ * @notes: This is screen width Component
  */
 declare class Carousel extends Component<CarouselProps, CarouselState> {
     static displayName: string;

--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -19,7 +19,7 @@ type DefaultProps = Partial<CarouselProps>
  * @example: https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/CarouselScreen.tsx
  * @extends: ScrollView
  * @extendsLink: https://facebook.github.io/react-native/docs/scrollview
- * @notes: This is screed width Component
+ * @notes: This is screen width Component
  */
 class Carousel extends Component<CarouselProps, CarouselState> {
   static displayName = 'Carousel';


### PR DESCRIPTION
## Description
*Whilst browsing the documentation I noticed there was a typo on the following page: https://wix.github.io/react-native-ui-lib/docs/Carousel/

![](https://user-images.githubusercontent.com/996430/105968968-a0cf8600-607f-11eb-979f-777c17ec0736.png) 

## Changelog
* Updating the typo of `"screed"` and correcting it to `"screen"`
