### PR TITLE
Show migration warning only on mount

### DIFF
--- a/src/components/textField/TextFieldMigrator.tsx
+++ b/src/components/textField/TextFieldMigrator.tsx
@@ -1,4 +1,4 @@
-import React, {forwardRef} from 'react';
+import React, {useEffect, forwardRef} from 'react';
 import {mapKeys} from 'lodash';
 // @ts-ignore
 import OldTextField from './index';
@@ -53,12 +53,17 @@ function migrateProps(props: any) {
 }
 
 const TextFieldMigrator = forwardRef(({migrate = false, ...props}: any, ref) => {
+  useEffect(() => {
+    if (!migrate) {
+      LogService.warn(`RNUILib TextField component will soon be replaced with a new implementation, in order to start the migration - please pass the 'migrate' prop`);
+    }
+  }, []);
+
   if (migrate) {
     const migratedProps = migrateProps(props);
     // @ts-ignore
     return <NewTextField {...migratedProps} ref={ref}/>;
   } else {
-    LogService.warn(`RNUILib TextField component will soon be replaced with a new implementation, in order to start the migration - please pass the 'migrate' prop`);
     return <OldTextField {...props} ref={ref}/>;
   }
 });


### PR DESCRIPTION
## Description
Show migration warning only on mount

## Changelog
Fix TextField migration to show warnings only once, on mount
