### PR TITLE
Changed `useSafeArea` default value

### DIFF
--- a/demo/src/screens/nativeComponentScreens/keyboardInput/KeyboardInputViewScreen.js
+++ b/demo/src/screens/nativeComponentScreens/keyboardInput/KeyboardInputViewScreen.js
@@ -38,7 +38,7 @@ export default class KeyboardInputViewScreen extends PureComponent {
       initialProps: undefined
     },
     receivedKeyboardData: undefined,
-    useSafeArea: true,
+    useSafeArea: false,
     keyboardOpenState: false
   };
 

--- a/lib/components/Keyboard/KeyboardInput/CustomKeyboardView.ios.js
+++ b/lib/components/Keyboard/KeyboardInput/CustomKeyboardView.ios.js
@@ -17,7 +17,7 @@ export default class CustomKeyboardView extends CustomKeyboardViewBase {
   };
 
   static defaultProps = {
-    useSafeArea: true
+    useSafeArea: false
   };
 
   constructor(props) {

--- a/lib/components/Keyboard/KeyboardTracking/KeyboardTrackingView.ios.js
+++ b/lib/components/Keyboard/KeyboardTracking/KeyboardTrackingView.ios.js
@@ -36,7 +36,6 @@ class KeyboardTrackingView extends PureComponent {
     useSafeArea: PropTypes.bool
   };
 
-  /** V6 should be change to default false */
   static defaultProps = {
     useSafeArea: true
   };


### PR DESCRIPTION
## Description
CustomKeyboard had a fix some time ago, to remove the safe area (annoying grey part at the bottom).
In order to avoid migration back at the time, I've set `useSafeArea` default value to `true` although other UILib components set it to `false` by default. 
In this PR it fixed, and moved to be `false` by default

## Changelog
When using `KeyboardAccessoryView`, `useSafeArea` default value has changed from `true` to `false`, to match all other UILib's api that by default it is `false`.
