### PR TITLE
Infra - change Dialog to use reanimated 2

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -4,7 +4,7 @@ import com.android.build.OutputFile
 
 project.ext.react = [
     entryFile: "index.js",
-    enableHermes: false,  // clean and rebuild if changing
+    enableHermes: true,  // clean and rebuild if changing
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"

--- a/android/app/src/main/java/com/rnuilib/MainApplication.java
+++ b/android/app/src/main/java/com/rnuilib/MainApplication.java
@@ -6,8 +6,10 @@ import com.facebook.react.PackageList;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.JSIModulePackage;
 import com.reactnativenavigation.NavigationApplication;
 import com.reactnativenavigation.react.NavigationReactNativeHost;
+import com.swmansion.reanimated.ReanimatedJSIModulePackage;
 import com.wix.reactnativeuilib.UiLibPackageList;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
@@ -19,6 +21,11 @@ public class MainApplication extends NavigationApplication {
         @Override
         protected String getJSMainModuleName() {
             return "demo";
+        }
+
+        @Override
+        protected JSIModulePackage getJSIModulePackage() {
+            return new ReanimatedJSIModulePackage(); // <- add
         }
 
         @Override

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,8 +1,10 @@
 module.exports = {
   env: {
     test: {
-      presets: ['module:metro-react-native-babel-preset']
+      presets: ['module:metro-react-native-babel-preset'],
+      plugins: ['react-native-reanimated/plugin']
     }
   },
-  presets: ['module:metro-react-native-babel-preset']
+  presets: ['module:metro-react-native-babel-preset'],
+  plugins: ['react-native-reanimated/plugin']
 };

--- a/generatedTypes/components/tabController/TabBarItem.d.ts
+++ b/generatedTypes/components/tabController/TabBarItem.d.ts
@@ -1,5 +1,5 @@
 import { PureComponent } from 'react';
-import { /* processColor, */ TextStyle, LayoutChangeEvent, StyleProp, ViewStyle } from 'react-native';
+import { TextStyle, LayoutChangeEvent, StyleProp, ViewStyle } from 'react-native';
 import _ from 'lodash';
 import Reanimated from 'react-native-reanimated';
 import { State } from 'react-native-gesture-handler';
@@ -107,7 +107,7 @@ export default class TabBarItem extends PureComponent<Props> {
     getItemStyle(): any[];
     getLabelStyle(): (TextStyle | _.Dictionary<Reanimated.Node<number> | Reanimated.Node<string | number | boolean> | Reanimated.Node<"normal" | "bold" | "100" | "200" | "300" | "400" | "500" | "600" | "700" | "800" | "900"> | undefined> | undefined)[];
     getIconStyle(): {
-        tintColor: Reanimated.Node<string>;
+        tintColor: Reanimated.Node<number>;
     };
     render(): JSX.Element;
 }

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "react-native-gesture-handler": "1.9.0",
     "react-native-keyboard-tracking-view": "^5.6.1",
     "react-native-navigation": "7.6.0",
-    "react-native-reanimated": "1.13.2",
+    "react-native-reanimated": "alpha",
     "react-test-renderer": "^16.13.1",
     "shell-utils": "^1.0.10",
     "typescript": "3.9.7"
@@ -108,7 +108,7 @@
     "react": ">=16.0.0",
     "react-native": ">=0.63.4",
     "react-native-gesture-handler": ">=1.9.0",
-    "react-native-reanimated": ">=1.13.2",
+    "react-native-reanimated": "alpha",
     "@react-native-community/blur": ">=3.4.1",
     "@react-native-community/datetimepicker": "^2.1.0",
     "@react-native-community/netinfo": "^5.6.2",

--- a/src/components/dialog/DialogDismissibleView.tsx
+++ b/src/components/dialog/DialogDismissibleView.tsx
@@ -1,6 +1,17 @@
 import _ from 'lodash';
-import React, {useEffect, useRef, useCallback, useContext} from 'react';
+import React, {useEffect, useRef, useCallback, useState} from 'react';
 import {StyleSheet, StyleProp, ViewStyle, LayoutChangeEvent} from 'react-native';
+import {
+  PanGestureHandler,
+  PanGestureHandlerProperties,
+  PanGestureHandlerGestureEvent,
+  FlingGestureHandler,
+  FlingGestureHandlerGestureEvent,
+  FlingGestureHandlerStateChangeEvent,
+  TapGestureHandler,
+  State,
+  Directions
+} from 'react-native-gesture-handler';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -9,18 +20,17 @@ import Animated, {
   useDerivedValue,
   interpolate,
   Easing,
-  runOnJS
+  runOnJS,
+  useWorkletCallback
 } from 'react-native-reanimated';
 import {Constants} from '../../helpers';
 import View from '../view';
-import PanningContext from '../panningViews/panningContext';
-import PanningProvider, {
+import {
   PanningDirections,
   PanAmountsProps,
   PanDirectionsProps,
   PanLocationProps
 } from '../panningViews/panningProvider';
-import PanResponderView from '../panningViews/panResponderView';
 
 const MAXIMUM_DRAGS_AFTER_SWIPE = 2;
 
@@ -64,7 +74,7 @@ interface LocationProps {
   top: number;
 }
 
-const DEFAULT_DIRECTION = PanningProvider.Directions.DOWN;
+const DEFAULT_DIRECTION = PanningDirections.DOWN;
 const TOP_INSET = Constants.isIphoneX ? Constants.getSafeAreaInsets().top : Constants.isIOS ? 20 : 0;
 const BOTTOM_INSET = Constants.isIphoneX ? Constants.getSafeAreaInsets().bottom : Constants.isIOS ? 20 : 0;
 const TIMING_ANIMATION_CONFIG: Animated.WithTimingConfig = {
@@ -74,33 +84,26 @@ const TIMING_ANIMATION_CONFIG: Animated.WithTimingConfig = {
 
 const DialogDismissibleView = (props: Props) => {
   const {direction = DEFAULT_DIRECTION, visible: propsVisible, containerStyle, style, children, onDismiss} = props;
-  // @ts-expect-error
-  const {isPanning, dragDeltas, swipeDirections} = useContext<PanContextProps>(PanningContext);
 
   const width = useRef<number>(Constants.screenWidth);
   const height = useRef<number>(Constants.screenHeight);
-  const thresholdX = useRef<number>(0);
-  const thresholdY = useRef<number>(0);
-  const counter = useRef<number>(0);
   const containerRef = useRef<typeof View>();
-  const swipe = useRef<PanDirectionsProps>({});
-  const prevDragDeltas = useRef<PanAmountsProps>();
-  const prevSwipeDirections = useRef<PanDirectionsProps>();
   const visible = useRef<boolean>(Boolean(propsVisible));
+  const [threshold, setThreshold] = useState<PanAmountsProps>({x: 0, y: 0});
 
   const getHiddenLocation = useCallback((left: number, top: number): LocationProps => {
     const result = {left: 0, top: 0};
     switch (direction) {
-      case PanningProvider.Directions.LEFT:
+      case PanningDirections.LEFT:
         result.left = -left - width.current;
         break;
-      case PanningProvider.Directions.RIGHT:
+      case PanningDirections.RIGHT:
         result.left = Constants.screenWidth - left;
         break;
-      case PanningProvider.Directions.UP:
+      case PanningDirections.UP:
         result.top = -top - height.current - TOP_INSET;
         break;
-      case PanningProvider.Directions.DOWN:
+      case PanningDirections.DOWN:
       default:
         result.top = Constants.screenHeight - top + BOTTOM_INSET;
         break;
@@ -126,12 +129,10 @@ const DialogDismissibleView = (props: Props) => {
 
   function dismissWorklet(isFinished: boolean) {
     'worklet';
-    console.log('Miki', 'dismissWorklet', isFinished);
     runOnJS(dismiss)();
   }
 
   const animateIn = useCallback(() => {
-    animationValue.value = hiddenLocation.current.top;
     animationValue.value = withTiming(0, TIMING_ANIMATION_CONFIG);
   }, []);
 
@@ -139,120 +140,90 @@ const DialogDismissibleView = (props: Props) => {
     animationValue.value = withTiming(hiddenLocation.current.top, TIMING_ANIMATION_CONFIG, dismissWorklet);
   }, [onDismiss]);
 
-  const animateTo = useCallback(() => {
-    // TODO:
-  }, []);
-
-  const isSwiping = useCallback((): boolean => {
-    return !_.isUndefined(swipe.current.x) || !_.isUndefined(swipe.current.y);
-  }, []);
-
-  const resetSwipe = useCallback(() => {
-    counter.current = 0;
-    swipe.current = {};
-  }, []);
-
-  const onDrag = useCallback(() => {
-    if (isSwiping()) {
-      if (counter.current < MAXIMUM_DRAGS_AFTER_SWIPE) {
-        counter.current += 1;
-      } else {
-        resetSwipe();
-      }
-    }
-  }, [isSwiping, resetSwipe]);
-
-  const hide = useCallback(() => {
-    // TODO:
-  }, []);
-
-  useEffect(() => {
-    if (
-      isPanning &&
-      (dragDeltas.x || dragDeltas.y) &&
-      (dragDeltas.x !== prevDragDeltas.current?.x || dragDeltas.y !== prevDragDeltas.current?.y)
-    ) {
-      onDrag();
-      prevDragDeltas.current = dragDeltas;
-    }
-  }, [isPanning, dragDeltas, onDrag, hide]);
-
-  useEffect(() => {
-    if (
-      isPanning &&
-      (swipeDirections.x || swipeDirections.y) &&
-      (swipeDirections.x !== prevSwipeDirections.current?.x || swipeDirections.y !== prevSwipeDirections.current?.y)
-    ) {
-      swipe.current = swipeDirections;
-    }
-  }, [isPanning, swipeDirections, hide]);
-
   useEffect(() => {
     if (visible.current && !propsVisible) {
-      console.log('Miki', 'useEffect', 'should hide');
       animateOut();
     }
   }, [propsVisible, animateOut]);
 
   const onLayout = useCallback((event: LayoutChangeEvent) => {
-    console.log('Miki', 'onLayout');
     // DO NOT move the width\height into the measureInWindow - it causes errors with orientation change
     const layout = event.nativeEvent.layout;
     width.current = layout.width;
     height.current = layout.height;
-    thresholdX.current = width.current / 2;
-    thresholdY.current = height.current / 2;
+    setThreshold({x: width.current / 2, y: height.current / 2});
     if (containerRef.current) {
       // @ts-ignore TODO: can we fix this on ViewProps \ View?
       containerRef.current.measureInWindow((x: number, y: number) => {
         hiddenLocation.current = getHiddenLocation(x, y);
+        animationValue.value = hiddenLocation.current.top;
         animateIn();
       });
     }
   },
-  [getHiddenLocation, animateTo]);
+  [setThreshold, getHiddenLocation, animateIn]);
 
-  const resetToShown = useCallback((left: number, top: number, direction: PanningDirections) => {
-    const toValue = [PanningProvider.Directions.LEFT, PanningProvider.Directions.RIGHT].includes(direction)
-      ? 1 + left / hiddenLocation.current.left
-      : 1 + top / hiddenLocation.current.top;
+  const isHorizontal = useCallback(() => {
+    return direction === PanningDirections.LEFT || direction === PanningDirections.RIGHT;
+  }, [direction]);
 
-    animateTo(toValue);
-  },
-  [animateTo]);
-
-  const onPanLocationChanged = useCallback(({left = 0, top = 0}: PanLocationProps) => {
-    const endValue = {x: Math.round(left), y: Math.round(top)};
-    if (isSwiping()) {
-      hide();
-    } else {
-      resetSwipe();
+  const gestureHandler = useAnimatedGestureHandler({
+    onStart: (_event, context: {start: number}) => {
+      context.start = animationValue.value;
+    },
+    onActive: (event, context) => {
+      animationValue.value = Math.max(0, context.start + event.translationY);
+    },
+    onEnd: (event, context) => {
+      const value = context.start + (isHorizontal() ? event.translationX : event.translationY);
       if (
-        (direction === PanningProvider.Directions.LEFT && endValue.x <= -thresholdX.current) ||
-          (direction === PanningProvider.Directions.RIGHT && endValue.x >= thresholdX.current) ||
-          (direction === PanningProvider.Directions.UP && endValue.y <= -thresholdY.current) ||
-          (direction === PanningProvider.Directions.DOWN && endValue.y >= thresholdY.current)
+        (direction === PanningDirections.LEFT && value <= -threshold.x) ||
+          (direction === PanningDirections.RIGHT && value >= threshold.x) ||
+          (direction === PanningDirections.UP && value <= -threshold.y) ||
+          (direction === PanningDirections.DOWN && value >= threshold.y)
       ) {
-        hide();
+        (() => {
+          'worklet';
+          runOnJS(animateOut)();
+        })();
       } else {
-        resetToShown(left, top, direction);
+        (() => {
+          'worklet';
+          runOnJS(animateIn)();
+        })();
       }
     }
   },
-  [isSwiping, hide, resetSwipe, direction, resetToShown]);
+  [threshold]);
 
-  console.log('Miki', 'render', animationValue.value);
+  // TODO: change to useAnimatedGestureHandler?
+  const flingHandler = useCallback((event: FlingGestureHandlerStateChangeEvent) => {
+    if (event.nativeEvent.state === State.ACTIVE) {
+      animateOut();
+    }
+  },
+  [animateOut]);
+
   return (
     // @ts-ignore
     <View ref={containerRef} style={containerStyle} onLayout={onLayout}>
-      <PanResponderView
-        // !visible.current && styles.hidden is done to fix a bug is iOS
-        style={[style, animatedStyle, !visible.current && styles.hidden]}
-        reanimated
-        onPanLocationChanged={onPanLocationChanged}
-      >
-        {children}
-      </PanResponderView>
+      <PanGestureHandler onGestureEvent={gestureHandler}>
+        <Animated.View
+          // !visible.current && styles.hidden is done to fix a bug is iOS
+          // Have to have two Animated.View because of this error:
+          // nesting touch handlers with native animated driver is not supported yet
+          style={[style, animatedStyle, !visible.current && styles.hidden]}
+        >
+          {/* <FlingGestureHandler onHandlerStateChange={flingHandler} direction={Directions.DOWN | Directions.UP}> */}
+          <FlingGestureHandler
+            numberOfPointers={MAXIMUM_DRAGS_AFTER_SWIPE}
+            onHandlerStateChange={flingHandler}
+            direction={Directions.DOWN}
+          >
+            <Animated.View>{children}</Animated.View>
+          </FlingGestureHandler>
+        </Animated.View>
+      </PanGestureHandler>
     </View>
   );
 };

--- a/src/components/dialog/DialogDismissibleView.tsx
+++ b/src/components/dialog/DialogDismissibleView.tsx
@@ -240,7 +240,7 @@ const DialogDismissibleView = (props: Props) => {
           style={[style, animatedStyle, !visible.current && styles.hidden]}
         >
           <FlingGestureHandler onHandlerStateChange={direction ? flingHandler : undefined} direction={getDirection()}>
-            <Animated.View>{children}</Animated.View>
+            <Animated.View style={style}>{children}</Animated.View>
           </FlingGestureHandler>
         </Animated.View>
       </PanGestureHandler>

--- a/src/components/dialog/DialogDismissibleView.tsx
+++ b/src/components/dialog/DialogDismissibleView.tsx
@@ -112,10 +112,11 @@ const DialogDismissibleView = (props: Props) => {
     onDismiss();
   }
 
-  // TODO: use isFinished?
   function dismissWorklet(isFinished: boolean) {
     'worklet';
-    runOnJS(dismiss)();
+    if (isFinished) {
+      runOnJS(dismiss)();
+    }
   }
 
   const animateIn = useCallback(() => {

--- a/src/components/dialog/DialogDismissibleView.tsx
+++ b/src/components/dialog/DialogDismissibleView.tsx
@@ -242,6 +242,7 @@ const DialogDismissibleView = (props: Props) => {
   );
 };
 
+DialogDismissibleView.displayName = 'IGNORE';
 DialogDismissibleView.defaultProps = {
   direction: DEFAULT_DIRECTION,
   onDismiss: () => {}

--- a/src/components/dialog/index.tsx
+++ b/src/components/dialog/index.tsx
@@ -8,10 +8,9 @@ import {asBaseComponent} from '../../commons/new';
 import {LogService} from '../../services';
 import Modal from '../modal';
 import View from '../view';
-import PanListenerView from '../panningViews/panListenerView';
 import DialogDismissibleView from './DialogDismissibleView';
 import OverlayFadingBackground from './OverlayFadingBackground';
-import PanningProvider, {PanningDirections} from '../panningViews/panningProvider';
+import {PanningDirections} from '../panningViews/panningProvider';
 
 // TODO: KNOWN ISSUES
 // 1. iOS pressing on the background while enter animation is happening will not call onDismiss
@@ -204,34 +203,31 @@ class Dialog extends Component<DialogProps, DialogState> {
     this.setState({dialogVisibility: false});
   };
 
-  renderPannableHeader = (directions: PanningDirections[]) => {
-    const {renderPannableHeader, pannableHeaderProps} = this.props;
-    if (renderPannableHeader) {
-      return <PanListenerView directions={directions}>{renderPannableHeader(pannableHeaderProps)}</PanListenerView>;
-    }
-  };
-
   renderDialogView = () => {
-    const {children, renderPannableHeader, panDirection = PanningProvider.Directions.DOWN, containerStyle, testID} = this.props;
+    const {
+      children,
+      renderPannableHeader,
+      pannableHeaderProps,
+      panDirection = PanningDirections.DOWN,
+      containerStyle,
+      testID
+    } = this.props;
     const {dialogVisibility} = this.state;
-    const Container = renderPannableHeader ? View : PanListenerView;
 
     return (
       <View testID={testID} style={[this.styles.dialogViewSize]} pointerEvents="box-none">
-        <PanningProvider>
-          <DialogDismissibleView
-            direction={panDirection}
-            visible={dialogVisibility}
-            onDismiss={this.onDismiss}
-            containerStyle={this.styles.flexType}
-            style={this.styles.flexType}
-          >
-            <Container directions={[panDirection]} style={[this.styles.overflow, this.styles.flexType, containerStyle]}>
-              {this.renderPannableHeader([panDirection])}
-              {children}
-            </Container>
-          </DialogDismissibleView>
-        </PanningProvider>
+        <DialogDismissibleView
+          direction={panDirection}
+          visible={dialogVisibility}
+          onDismiss={this.onDismiss}
+          containerStyle={this.styles.flexType}
+          style={this.styles.flexType}
+        >
+          <View style={[this.styles.overflow, this.styles.flexType, containerStyle]}>
+            {renderPannableHeader?.(pannableHeaderProps)}
+            {children}
+          </View>
+        </DialogDismissibleView>
       </View>
     );
   };

--- a/src/components/sharedTransition/SharedArea.js
+++ b/src/components/sharedTransition/SharedArea.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import {StyleSheet} from 'react-native';
-import Animated, {Easing} from 'react-native-reanimated';
+import Animated, {EasingNode} from 'react-native-reanimated';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import TouchableOpacity from '../touchableOpacity';
@@ -36,14 +36,14 @@ class SharedArea extends Component {
     return {
       ...StyleSheet.absoluteFillObject,
       backgroundColor: Colors.white,
-      opacity: Animated.interpolate(this.transition, {inputRange: [0, 1], outputRange: [0, 1]})
+      opacity: Animated.interpolateNode(this.transition, {inputRange: [0, 1], outputRange: [0, 1]})
     };
   }
 
   getDetailsStyle() {
     return {
       ...StyleSheet.absoluteFillObject,
-      opacity: Animated.interpolate(this.transition, {inputRange: [90, 100], outputRange: [0, 1]})
+      opacity: Animated.interpolateNode(this.transition, {inputRange: [90, 100], outputRange: [0, 1]})
     };
   }
 
@@ -52,19 +52,19 @@ class SharedArea extends Component {
     if (sourceLayout && this.transition) {
       return {
         position: 'absolute',
-        width: Animated.interpolate(this.transition, {
+        width: Animated.interpolateNode(this.transition, {
           inputRange: [0, 100],
           outputRange: [sourceLayout.width, targetLayout.width]
         }),
-        height: Animated.interpolate(this.transition, {
+        height: Animated.interpolateNode(this.transition, {
           inputRange: [0, 100],
           outputRange: [sourceLayout.height, targetLayout.height]
         }),
-        top: Animated.interpolate(this.transition, {
+        top: Animated.interpolateNode(this.transition, {
           inputRange: [0, 100],
           outputRange: [sourceLayout.y, targetLayout.y]
         }),
-        left: Animated.interpolate(this.transition, {
+        left: Animated.interpolateNode(this.transition, {
           inputRange: [0, 100],
           outputRange: [sourceLayout.x, targetLayout.x]
         })
@@ -110,7 +110,7 @@ class SharedArea extends Component {
     Animated.timing(this.transition, {
       toValue: show ? 100 : 0,
       duration: 600,
-      easing: Easing.bezier(0.19, 1, 0.22, 1),
+      easing: EasingNode.bezier(0.19, 1, 0.22, 1),
       useNativeDriver: false
     }).start(onAnimationEnd);
   }

--- a/src/components/tabController/TabBar.tsx
+++ b/src/components/tabController/TabBar.tsx
@@ -16,7 +16,7 @@ import FadedScrollView from './FadedScrollView';
 
 import {useScrollToItem} from '../../hooks';
 
-const {Code, Value, interpolate, block, set} = Reanimated;
+const {Code, Value, interpolateNode, block, set} = Reanimated;
 
 const DEFAULT_HEIGHT = 48;
 const INDICATOR_INSET = Spacings.s4;
@@ -310,12 +310,12 @@ const TabBar = (props: Props) => {
     const nodes: any[] = [];
 
     nodes.push(set(_indicatorOffset,
-      interpolate(currentPage, {
+      interpolateNode(currentPage, {
         inputRange: indicatorOffsets.map((_v, i) => i),
         outputRange: indicatorOffsets
       })));
     nodes.push(set(_indicatorWidth,
-      interpolate(currentPage, {
+      interpolateNode(currentPage, {
         inputRange: itemsWidths.map((_v, i) => i),
         outputRange: itemsWidths.map(v => v - 2 * INDICATOR_INSET)
       })));

--- a/src/components/tabController/TabBarItem.tsx
+++ b/src/components/tabController/TabBarItem.tsx
@@ -1,10 +1,9 @@
 // TODO: support commented props
 import React, {PureComponent} from 'react';
-import {StyleSheet, /* processColor, */ TextStyle, LayoutChangeEvent, StyleProp, ViewStyle} from 'react-native';
+import {StyleSheet, TextStyle, LayoutChangeEvent, StyleProp, ViewStyle} from 'react-native';
 import _ from 'lodash';
-import Reanimated from 'react-native-reanimated';
+import Reanimated, {interpolateColors, processColor} from 'react-native-reanimated';
 import {State} from 'react-native-gesture-handler';
-import {interpolateColor} from 'react-native-redash';
 import {Colors, Typography, Spacings} from '../../style';
 import Badge, {BadgeProps, BADGE_SIZES} from '../../components/badge';
 import {TouchableOpacity} from '../../incubator';
@@ -208,9 +207,9 @@ export default class TabBarItem extends PureComponent<Props> {
     const activeColor = !ignore ? selectedLabelColor || DEFAULT_SELECTED_LABEL_COLOR : inactiveColor;
 
     // Animated color
-    const color = interpolateColor(currentPage, {
+    const color = interpolateColors(currentPage, {
       inputRange: [index - 1, index, index + 1],
-      outputRange: [inactiveColor, activeColor, inactiveColor]
+      outputColorRange: [inactiveColor, activeColor, inactiveColor]
     });
 
     return [
@@ -228,12 +227,10 @@ export default class TabBarItem extends PureComponent<Props> {
   getIconStyle() {
     const {index, currentPage, iconColor, selectedIconColor, labelColor, selectedLabelColor, ignore} = this.props;
 
-    const activeColor = selectedIconColor || selectedLabelColor || DEFAULT_SELECTED_LABEL_COLOR;
-    const inactiveColor = iconColor || labelColor || DEFAULT_LABEL_COLOR;
+    const activeColor = processColor(selectedIconColor || selectedLabelColor || DEFAULT_SELECTED_LABEL_COLOR);
+    const inactiveColor = processColor(iconColor || labelColor || DEFAULT_LABEL_COLOR);
 
     const tintColor = cond(eq(currentPage, index),
-      // TODO: using processColor here broke functionality,
-      // not using it seem to not be very performant
       activeColor,
       ignore ? activeColor : inactiveColor);
 
@@ -259,6 +256,7 @@ export default class TabBarItem extends PureComponent<Props> {
         {icon && (
           <Reanimated.Image
             source={icon}
+            // @ts-expect-error TODO: not sure if this is us or reanimated
             style={[!_.isUndefined(label) && styles.tabItemIconWithLabel, this.getIconStyle()]}
           />
         )}

--- a/src/components/tabController/index.tsx
+++ b/src/components/tabController/index.tsx
@@ -32,7 +32,7 @@ const {
   Value,
   block,
   onChange,
-  interpolate,
+  interpolateNode,
   round,
   multiply
 } = Reanimated;
@@ -205,7 +205,7 @@ class TabController extends Component<TabControllerProps, StateProps> {
                 and(lessThan(_carouselOffsetDiff, round(containerWidth)), greaterThan(_carouselOffsetDiff, 0))),
               cond(not(isAnimating), [
                 set(currentPage,
-                  interpolate(round(carouselOffset), {
+                  interpolateNode(round(carouselOffset), {
                     inputRange: itemStates.map((_v, i) => round(multiply(i, containerWidth))),
                     outputRange: itemStates.map((_v, i) => i)
                   })),

--- a/src/components/view/index.tsx
+++ b/src/components/view/index.tsx
@@ -1,5 +1,6 @@
 import React, {PureComponent} from 'react';
-import {View as RNView, SafeAreaView, Animated, ViewProps as RNViewProps, StyleProp, ViewStyle} from 'react-native';
+import {View as RNView, SafeAreaView, Animated as RNAnimated, ViewProps as RNViewProps, StyleProp, ViewStyle} from 'react-native';
+import Animated from 'react-native-reanimated';
 import {
   asBaseComponent,
   forwardRef,
@@ -18,6 +19,10 @@ export interface ViewProps extends Omit<RNViewProps, 'style'>, ContainerModifier
    * Use Animate.View as a container
    */
   animated?: boolean;
+  /**
+   * Use Animate.View (from reanimated 2) as a container
+   */
+  reanimated?: boolean;
   /**
    * Turn off accessibility for this view and its nested children
    */
@@ -38,7 +43,7 @@ export interface ViewProps extends Omit<RNViewProps, 'style'>, ContainerModifier
    * Set background color
    */
   backgroundColor?: string;
-  style?: StyleProp<ViewStyle | Animated.AnimatedProps<ViewStyle>>;
+  style?: StyleProp<ViewStyle | RNAnimated.AnimatedProps<ViewStyle>>;
 }
 export type ViewPropTypes = ViewProps; //TODO: remove after ComponentPropTypes deprecation;
 
@@ -62,8 +67,10 @@ class View extends PureComponent<PropsTypes, ViewState> {
     super(props);
 
     this.Container = props.useSafeArea && Constants.isIOS ? SafeAreaView : RNView;
-    if (props.animated) {
+    if (props.reanimated) {
       this.Container = Animated.createAnimatedComponent(this.Container);
+    } else if (props.animated) {
+      this.Container = RNAnimated.createAnimatedComponent(this.Container);
     }
 
     this.state = {

--- a/src/incubator/TabController/ReanimatedObject.js
+++ b/src/incubator/TabController/ReanimatedObject.js
@@ -1,5 +1,5 @@
 // TODO: consider removing this file if no still using it
-import Reanimated, {Easing} from 'react-native-reanimated';
+import Reanimated, {EasingNode} from 'react-native-reanimated';
 
 const {Clock, Value, cond, stopClock, startClock, clockRunning, timing, block, set} = Reanimated;
 
@@ -15,7 +15,7 @@ export default class ReanimatedObject {
     this.config = {
       duration: 300,
       toValue: new Value(0),
-      easing: Easing.bezier(0.23, 1, 0.32, 1),
+      easing: EasingNode.bezier(0.23, 1, 0.32, 1),
       ...config
     };
     this.prevValue = new Value(0);

--- a/src/incubator/TabController/TabBar.js
+++ b/src/incubator/TabController/TabBar.js
@@ -2,7 +2,7 @@
 // TODO: disable scroll when content width is shorter than screen width
 import React, {PureComponent} from 'react';
 import {StyleSheet, ScrollView, ViewPropTypes, Platform, Text as RNText} from 'react-native';
-import Reanimated, {Easing} from 'react-native-reanimated';
+import Reanimated, {EasingNode} from 'react-native-reanimated';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 
@@ -27,7 +27,7 @@ const {
   cond,
   stopClock,
   startClock,
-  interpolate,
+  interpolateNode,
   Extrapolate,
   timing,
   block,
@@ -294,13 +294,13 @@ class TabBar extends PureComponent {
 
     if (asCarousel) {
       nodes.push(set(this._indicatorOffset,
-        interpolate(carouselOffset, {
+        interpolateNode(carouselOffset, {
           inputRange: itemsOffsets.map((_value, index) => index * Constants.screenWidth),
           outputRange: itemsOffsets,
           extrapolate: Extrapolate.CLAMP
         })),
       set(this._indicatorWidth,
-        interpolate(carouselOffset, {
+        interpolateNode(carouselOffset, {
           inputRange: itemsWidths.map((_value, index) => index * Constants.screenWidth),
           outputRange: itemsWidths,
           extrapolate: Extrapolate.CLAMP
@@ -399,7 +399,7 @@ function runIndicatorTimer(clock, currentPage, values) {
   const config = {
     duration: 200,
     toValue: new Value(100),
-    easing: Easing.inOut(Easing.ease)
+    easing: EasingNode.inOut(EasingNode.ease)
   };
 
   return block([
@@ -414,7 +414,7 @@ function runIndicatorTimer(clock, currentPage, values) {
     }),
     timing(clock, state, config),
     cond(state.finished, stopClock(clock)),
-    interpolate(state.position, {
+    interpolateNode(state.position, {
       inputRange: _.times(values.length),
       outputRange: values,
       extrapolate: Extrapolate.CLAMP

--- a/src/incubator/TouchableOpacity.tsx
+++ b/src/incubator/TouchableOpacity.tsx
@@ -2,7 +2,7 @@
 import React, {PureComponent} from 'react';
 import {processColor, StyleSheet, LayoutChangeEvent} from 'react-native';
 import _ from 'lodash';
-import Reanimated, {Easing} from 'react-native-reanimated';
+import Reanimated, {EasingNode} from 'react-native-reanimated';
 import {TapGestureHandler, LongPressGestureHandler, State, LongPressGestureHandlerGestureEvent} from 'react-native-gesture-handler';
 import {asBaseComponent, forwardRef, BaseComponentInjectedProps, ForwardRefInjectedProps} from '../commons/new';
 import {ViewProps} from '../components/view';
@@ -15,7 +15,7 @@ const {
   or,
   eq,
   neq,
-  interpolate,
+  interpolateNode,
   Extrapolate,
   Value,
   call,
@@ -194,7 +194,7 @@ function runTiming(clock: any, gestureState: any, initialValue: number, endValue
   const config = {
     duration: 150,
     toValue: new Value(0),
-    easing: Easing.inOut(Easing.ease)
+    easing: EasingNode.inOut(EasingNode.ease)
   };
 
   return block([
@@ -214,7 +214,7 @@ function runTiming(clock: any, gestureState: any, initialValue: number, endValue
     ]),
     timing(clock, state, config),
     cond(state.finished, stopClock(clock)),
-    interpolate(state.position, {
+    interpolateNode(state.position, {
       inputRange: [0, 1],
       outputRange: [endValue, initialValue],
       extrapolate: Extrapolate.CLAMP


### PR DESCRIPTION
## Description
Infra - change Dialog to use reanimated 2.
Note that this has `Infra/reanimated-2-part-1-refactor-dialog` set as base and not `master`.
Known issues:
Android - gestures do not work (only the animation works), this is probably because we need to add `gestureHandlerRootHOC` or `GestureHandlerRootView` somewhere (I did not find the correct way to do it).
~~Android & iOS (more visible on Android): the view is shown for a short time in the "visible location" before animating in from the "hidden location"~~ fixed with `persistentAnimationValue`, not sure if that's the best solution.
I'm not sure I've solved *all* the errors from migrating to v2.

## Changelog
Infra - change Dialog to use reanimated 2