### PR TITLE
Avoid passing overlayContent in CardSecion

### DIFF
--- a/src/components/card/CardSection.tsx
+++ b/src/components/card/CardSection.tsx
@@ -66,6 +66,10 @@ class CardSection extends PureComponent<Props> {
 
   renderContent = () => {
     const {content, leadingIcon, trailingIcon, contentStyle, testID} = this.props;
+    if (!leadingIcon && !trailingIcon && _.isEmpty(content)) {
+      return;
+    }
+
     return (
       <>
         {leadingIcon && <Image testID={`${testID}.leadingIcon`} {...leadingIcon}/>}


### PR DESCRIPTION
## Description
Avoid passing overlayContent to Card.Section's Image when not needed
This leads to use `ImageBackground` instead of `Image` which works a little different

## Changelog
Avoid passing overlayContent to Card.Section's Image when not needed