### PR TITLE
fix: catch undefined StatusBarManager

### DIFF
--- a/src/helpers/Constants.ts
+++ b/src/helpers/Constants.ts
@@ -20,7 +20,7 @@ isTablet = Platform.isPad || (getAspectRatio() < 1.6 && Math.max(screenWidth, sc
 
 function setStatusBarHeight() {
   const {StatusBarManager} = NativeModules;
-  statusBarHeight = StatusBarManager.HEIGHT || 0; // So there will be a value for any case
+  statusBarHeight = StatusBarManager?.HEIGHT || 0; // So there will be a value for any case
   // statusBarHeight = isIOS ? 20 : StatusBarManager.HEIGHT;
   // if (isIOS) {
   //   // override guesstimate height with the actual height from StatusBarManager


### PR DESCRIPTION
## Description
On web there is no `StatusBarManager` so we simply catch it if it's undefined.

## Changelog
catch undefined StatusBarManager
