### PR TITLE
Updated Typescript definitions inside TouchableOpacity

### DIFF
--- a/src/components/touchableOpacity/index.tsx
+++ b/src/components/touchableOpacity/index.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../commons/new';
 import IncubatorTouchableOpacity from '../../incubator/TouchableOpacity';
 
-export interface TouchableOpacityProps extends Omit<RNViewProps, 'style' | 'onPress'>, ContainerModifiers {
+export interface TouchableOpacityProps extends Omit<RNTouchableOpacityProps, 'style' | 'onPress'>, ContainerModifiers {
     /**
      * background color for TouchableOpacity
      */

--- a/src/components/touchableOpacity/index.tsx
+++ b/src/components/touchableOpacity/index.tsx
@@ -16,9 +16,7 @@ import {
 } from '../../commons/new';
 import IncubatorTouchableOpacity from '../../incubator/TouchableOpacity';
 
-
-export type TouchableOpacityProps = Omit<RNTouchableOpacityProps, 'style' | 'onPress'> &
-  ContainerModifiers & {
+export interface TouchableOpacityProps extends Omit<RNViewProps, 'style' | 'onPress'>, ContainerModifiers {
     /**
      * background color for TouchableOpacity
      */
@@ -44,8 +42,10 @@ export type TouchableOpacityProps = Omit<RNTouchableOpacityProps, 'style' | 'onP
      */
     customValue?: any;
     style?: StyleProp<ViewStyle> | Animated.AnimatedProps<StyleProp<ViewStyle>>;
-    onPress?: (props: TouchableOpacityProps) => void;
-  };
+    onPress?: () => void;
+}
+
+export type TouchableOpacityPropTypes = TouchableOpacityProps; //TODO: remove after ComponentPropTypes deprecation;
 
 type Props = BaseComponentInjectedProps &
   ForwardRefInjectedProps &

--- a/src/components/touchableOpacity/index.tsx
+++ b/src/components/touchableOpacity/index.tsx
@@ -42,7 +42,7 @@ export interface TouchableOpacityProps extends Omit<RNTouchableOpacityProps, 'st
      */
     customValue?: any;
     style?: StyleProp<ViewStyle> | Animated.AnimatedProps<StyleProp<ViewStyle>>;
-    onPress?: () => void;
+    onPress?: (props: TouchableOpacityProps) => void;
 }
 
 export type TouchableOpacityPropTypes = TouchableOpacityProps; //TODO: remove after ComponentPropTypes deprecation;


### PR DESCRIPTION
I compared the props for TouchableOpacity and also for View.

What I noticed was that View was exporting PropType, but TouchableOpacity was not.

And also, TouchableOpacity was using Type instead of Interface.

I am not sure it will resolve the issue properly or not but check it once.