### PR TITLE
Fix/Invoke onError only if exists

### DIFF
--- a/src/commons/asBaseComponent.tsx
+++ b/src/commons/asBaseComponent.tsx
@@ -33,7 +33,7 @@ function asBaseComponent<PROPS, STATICS = {}>(WrappedComponent: React.ComponentT
     };
 
     static getDerivedStateFromError(error: any) {
-      UIComponent.defaultProps?.onError && UIComponent.defaultProps.onError(error, WrappedComponent.defaultProps);
+      UIComponent.defaultProps?.onError?.(error, WrappedComponent.defaultProps);
       return {error: true};
     }
 

--- a/src/commons/asBaseComponent.tsx
+++ b/src/commons/asBaseComponent.tsx
@@ -33,7 +33,7 @@ function asBaseComponent<PROPS, STATICS = {}>(WrappedComponent: React.ComponentT
     };
 
     static getDerivedStateFromError(error: any) {
-      UIComponent.defaultProps?.onError(error, WrappedComponent.defaultProps);
+      UIComponent.defaultProps?.onError && UIComponent.defaultProps.onError(error, WrappedComponent.defaultProps);
       return {error: true};
     }
 


### PR DESCRIPTION
## Description
Invoke ErrorBoundary's onError function only if the function exists.

## Changelog
Invoke ErrorBoundary's onError function only if the function exists.
