### PR TITLE
Stop ignoring TS files when building docs

### DIFF
--- a/uilib-docs/configurations/plugins.js
+++ b/uilib-docs/configurations/plugins.js
@@ -31,8 +31,7 @@ const componentsDocgenPlugin = [
   {
     resolve: 'gatsby-source-filesystem',
     options: {
-      path: `${__dirname}/../../src/components/`,
-      ignore: ['**/\*.tsx']
+      path: `${__dirname}/../../src/components/`
     }
   }
 ];
@@ -42,8 +41,7 @@ const incubatorComponentsDocgenPlugin = [
   {
     resolve: 'gatsby-source-filesystem',
     options: {
-      path: `${__dirname}/../../src/incubator/`,
-      ignore: ['**/\*.tsx']
+      path: `${__dirname}/../../src/incubator/`
     }
   }
 ];
@@ -53,8 +51,7 @@ const nativeComponentsDocgenPlugin = [
   {
     resolve: 'gatsby-source-filesystem',
     options: {
-      path: `${__dirname}/../../lib/components/`,
-      ignore: ['**/\*.tsx']
+      path: `${__dirname}/../../lib/components/`
     }
   }
 ];


### PR DESCRIPTION
## Description
I noticed the issue we had with building our docs out of TS files has been fixed. 
So now can build our docs (`npm run docs:deploy`) like before without having to compile the TS files into JS. 
This also fix some issues we had with missing props

## Changelog
Fix missing props in components docs 
