### PR TITLE
Fix Badge's size default prop

### DIFF
--- a/generatedTypes/components/badge/index.d.ts
+++ b/generatedTypes/components/badge/index.d.ts
@@ -24,7 +24,7 @@ export declare type BadgeProps = ViewProps & TouchableOpacityProps & {
     /**
      * the badge size (default, small)
      */
-    size: BadgeSizes | number;
+    size?: BadgeSizes | number;
     /**
      * Press handler
      */
@@ -91,10 +91,8 @@ export declare type BadgeProps = ViewProps & TouchableOpacityProps & {
 declare class Badge extends PureComponent<BadgeProps> {
     styles: ReturnType<typeof createStyles>;
     static displayName: string;
-    static defaultProps: {
-        size: string;
-    };
     constructor(props: BadgeProps);
+    get size(): number | "small" | "default" | "pimpleSmall" | "pimpleBig" | "pimpleHuge" | "large";
     getAccessibilityProps(): {
         accessible: boolean;
         accessibilityRole: string;
@@ -359,7 +357,7 @@ declare const _default: React.ComponentClass<ViewProps & TouchableOpacityProps &
     /**
      * the badge size (default, small)
      */
-    size: number | "small" | "default" | "pimpleSmall" | "pimpleBig" | "pimpleHuge" | "large";
+    size?: number | "small" | "default" | "pimpleSmall" | "pimpleBig" | "pimpleHuge" | "large" | undefined;
     /**
      * Press handler
      */

--- a/src/components/avatar/index.tsx
+++ b/src/components/avatar/index.tsx
@@ -232,8 +232,8 @@ class Avatar extends PureComponent<AvatarProps> {
     return _.get(this.props, 'badgeProps.backgroundColor') || statusColor || onlineColor;
   }
 
-  getBadgeSize = (): number => {
-    const badgeSize: BadgeProps['size'] = _.get(this.props, 'badgeProps.size', DEFAULT_BADGE_SIZE);
+  getBadgeSize = () => {
+    const badgeSize = this.props?.badgeProps?.size || DEFAULT_BADGE_SIZE;
 
     if (_.isString(badgeSize)) {
       return BADGE_SIZES[badgeSize] || BADGE_SIZES[DEFAULT_BADGE_SIZE];

--- a/src/components/avatar/index.tsx
+++ b/src/components/avatar/index.tsx
@@ -233,7 +233,7 @@ class Avatar extends PureComponent<AvatarProps> {
   }
 
   getBadgeSize = () => {
-    const badgeSize = this.props?.badgeProps?.size || DEFAULT_BADGE_SIZE;
+    const badgeSize = this.props?.badgeProps?.size ?? DEFAULT_BADGE_SIZE;
 
     if (_.isString(badgeSize)) {
       return BADGE_SIZES[badgeSize] || BADGE_SIZES[DEFAULT_BADGE_SIZE];

--- a/src/components/badge/index.tsx
+++ b/src/components/badge/index.tsx
@@ -48,7 +48,7 @@ export type BadgeProps = ViewProps &
     /**
      * the badge size (default, small)
      */
-    size: BadgeSizes | number;
+    size?: BadgeSizes | number;
     /**
      * Press handler
      */
@@ -117,9 +117,6 @@ class Badge extends PureComponent<BadgeProps> {
   styles: ReturnType<typeof createStyles>;
 
   static displayName = 'Badge';
-  static defaultProps = {
-    size: 'default'
-  };
 
   constructor(props: BadgeProps) {
     super(props);
@@ -128,6 +125,10 @@ class Badge extends PureComponent<BadgeProps> {
     if (props.testId) {
       console.warn('Badge prop \'testId\' is deprecated. Please use RN \'testID\' prop instead.');
     }
+  }
+
+  get size() {
+    return this.props.size || 'default';
   }
 
   getAccessibilityProps() {
@@ -142,14 +143,13 @@ class Badge extends PureComponent<BadgeProps> {
   }
 
   isSmallBadge() {
-    const {size} = this.props;
-    return size === 'small';
+    return this.size === 'small';
   }
 
   getBadgeSizeStyle() {
-    const {borderWidth, size, icon, customElement} = this.props;
+    const {borderWidth, icon, customElement} = this.props;
     const label = this.getFormattedLabel();
-    const badgeHeight = _.isNumber(size) ? size : BADGE_SIZES[size];
+    const badgeHeight = _.isNumber(this.size) ? this.size : BADGE_SIZES[this.size];
 
     const style: any = {
       paddingHorizontal: this.isSmallBadge() ? 4 : 6,


### PR DESCRIPTION
## Description
There was an issue with Badge's defaultProps that contained a default value for `size` prop. 
Because we have a default value, we declare the prop to **not** be optional. 
But it causes issues in other places that depends on `BadgeProps`
for example, an Avatar component has `badge` prop and its type is `BadgeProps`, but it doesn't know that size has a default value and it throws TS error that it is required (even though it's not)

## Changelog
Fix Badge's size default prop and make it optional 