### PR TITLE
Feat/add IgnoreBackgroundPress prop

### DIFF
--- a/demo/src/screens/componentScreens/DialogScreen.js
+++ b/demo/src/screens/componentScreens/DialogScreen.js
@@ -55,7 +55,8 @@ export default class DialogScreen extends Component {
       scroll: this.SCROLL_TYPE.NONE,
       showHeader: true,
       isRounded: true,
-      showDialog: false
+      showDialog: false,
+      ignoreBackgroundPress: false
     };
   }
 
@@ -90,6 +91,12 @@ export default class DialogScreen extends Component {
   toggleIsRounded = () => {
     this.setState({
       isRounded: !this.state.isRounded
+    });
+  };
+
+  toggleIgnoreBackgroundPress = () => {
+    this.setState({
+      ignoreBackgroundPress: !this.state.ignoreBackgroundPress
     });
   };
 
@@ -222,7 +229,7 @@ Scroll: ${scroll}`;
   };
 
   renderDialog = () => {
-    const {showDialog, panDirection, position, scroll, showHeader, isRounded} = this.state;
+    const {showDialog, panDirection, position, scroll, showHeader, isRounded, ignoreBackgroundPress} = this.state;
     const renderPannableHeader = showHeader ? this.renderPannableHeader : undefined;
     const height = scroll !== this.SCROLL_TYPE.NONE ? '70%' : undefined;
 
@@ -241,6 +248,7 @@ Scroll: ${scroll}`;
         renderPannableHeader={renderPannableHeader}
         pannableHeaderProps={this.pannableTitle}
         supportedOrientations={this.supportedOrientations}
+        ignoreBackgroundPress={ignoreBackgroundPress}
       >
         {this.renderContent()}
       </Dialog>
@@ -248,7 +256,7 @@ Scroll: ${scroll}`;
   };
 
   render() {
-    const {panDirection, position, scroll, showHeader, isRounded} = this.state;
+    const {panDirection, position, scroll, showHeader, isRounded, ignoreBackgroundPress} = this.state;
 
     return (
       <ScrollView>
@@ -294,6 +302,11 @@ Scroll: ${scroll}`;
           <View row marginT-20 centerV>
             <Text>Add some style:</Text>
             <Switch value={isRounded} onValueChange={this.toggleIsRounded} marginL-10/>
+          </View>
+
+          <View row marginT-20 centerV>
+            <Text>Ignore Background Press:</Text>
+            <Switch value={ignoreBackgroundPress} onValueChange={this.toggleIgnoreBackgroundPress} marginL-10/>
           </View>
 
           <Button marginT-50 label={'Show dialog'} onPress={this.showDialog}/>

--- a/generatedTypes/components/dialog/index.d.ts
+++ b/generatedTypes/components/dialog/index.d.ts
@@ -14,6 +14,10 @@ export interface DialogProps extends AlignmentModifiers, RNPartialProps {
      */
     onDismiss?: (props: any) => void;
     /**
+     * Whether or not to ignore background press
+     */
+    ignoreBackgroundPress?: boolean;
+    /**
      * The color of the overlay background
      */
     overlayBackgroundColor?: string;

--- a/src/components/dialog/index.tsx
+++ b/src/components/dialog/index.tsx
@@ -289,7 +289,7 @@ class Dialog extends Component<DialogProps, DialogState> {
         visible={modalVisibility}
         animationType={'none'}
         onBackgroundPress={onBackgroundPress}
-        onRequestClose={this.hideDialogView}
+        onRequestClose={onBackgroundPress}
         // onDismiss={this.onModalDismissed}
         supportedOrientations={supportedOrientations}
         accessibilityLabel={accessibilityLabel}

--- a/src/components/dialog/index.tsx
+++ b/src/components/dialog/index.tsx
@@ -33,6 +33,10 @@ export interface DialogProps extends AlignmentModifiers, RNPartialProps {
      */
     onDismiss?: (props: any) => void;
     /**
+     * Whether or not to ignore background press
+     */
+    ignoreBackgroundPress?: boolean;
+    /**
      * The color of the overlay background
      */
     overlayBackgroundColor?: string;
@@ -274,7 +278,8 @@ class Dialog extends Component<DialogProps, DialogState> {
 
   render = () => {
     const {orientationKey, modalVisibility} = this.state;
-    const {testID, supportedOrientations, accessibilityLabel} = this.props;
+    const {testID, supportedOrientations, accessibilityLabel, ignoreBackgroundPress} = this.props;
+    const onBackgroundPress = !ignoreBackgroundPress ? this.hideDialogView : undefined;
 
     return (
       <Modal
@@ -283,7 +288,7 @@ class Dialog extends Component<DialogProps, DialogState> {
         transparent
         visible={modalVisibility}
         animationType={'none'}
-        onBackgroundPress={this.hideDialogView}
+        onBackgroundPress={onBackgroundPress}
         onRequestClose={this.hideDialogView}
         // onDismiss={this.onModalDismissed}
         supportedOrientations={supportedOrientations}


### PR DESCRIPTION
## Description
Add IgnoreBackgroundPress prop to Dialog component to support not dismissing the dialog on background press 
Add example in DialogScreen
relevant issue - https://github.com/wix/react-native-ui-lib/issues/1262

## Changelog
Add IgnoreBackgroundPress prop to Dialog component