### PR TITLE
Update dateTimePicker to support Xcode 12 and iOS 14

### DIFF
--- a/src/components/dateTimePicker/index.js
+++ b/src/components/dateTimePicker/index.js
@@ -249,7 +249,7 @@ class DateTimePicker extends Component {
           is24Hour={is24Hour}
           minuteInterval={minuteInterval}
           timeZoneOffsetInMinutes={timeZoneOffsetInMinutes}
-          display={Constants.isIOS ? "inline" : "default"}
+          display={Constants.isIOS ? 'inline' : 'default'}
         />
       );
     }

--- a/src/components/dateTimePicker/index.js
+++ b/src/components/dateTimePicker/index.js
@@ -249,7 +249,7 @@ class DateTimePicker extends Component {
           is24Hour={is24Hour}
           minuteInterval={minuteInterval}
           timeZoneOffsetInMinutes={timeZoneOffsetInMinutes}
-          display={Platform.OS === "ios" ? "inline" : "default"}
+          display={Constants.isIOS ? "inline" : "default"}
         />
       );
     }

--- a/src/components/dateTimePicker/index.js
+++ b/src/components/dateTimePicker/index.js
@@ -249,6 +249,7 @@ class DateTimePicker extends Component {
           is24Hour={is24Hour}
           minuteInterval={minuteInterval}
           timeZoneOffsetInMinutes={timeZoneOffsetInMinutes}
+          display={Platform.OS === "ios" ? "inline" : "default"}
         />
       );
     }


### PR DESCRIPTION
See https://github.com/react-native-datetimepicker/datetimepicker/issues/285 for more details

## Description
Set the display mode of the DateTimePicker to 'inline' on iOS to fit the previous native style for date and time pickers, when built with Xcode 12 for iOS 14.

## Changelog
Fixes DateTimePicker component style for apps built with Xcode 12 running on iOS 14.
