### PR TITLE
Fix/text highlight special char

### DIFF
--- a/src/components/text/__tests__/index.spec.js
+++ b/src/components/text/__tests__/index.spec.js
@@ -30,5 +30,29 @@ describe('Text', () => {
       const result = uut.getTextPartsByHighlight('Dancing in the Dark', 'da');
       expect(result).toEqual(['Da', 'ncing in the ', 'Da', 'rk']);
     });
+
+    it('Should handle special characters @', () => {
+      const uut = new Text({});
+      const result = uut.getTextPartsByHighlight('@ancing in the @ark', '@a');
+      expect(result).toEqual(['@a', 'ncing in the ', '@a', 'rk']);
+    });
+
+    it('Should handle special characters !', () => {
+      const uut = new Text({});
+      const result = uut.getTextPartsByHighlight('!ancing in the !ark', '!a');
+      expect(result).toEqual(['!a', 'ncing in the ', '!a', 'rk']);
+    });
+
+    it('Should handle special characters starts with @', () => {
+      const uut = new Text({});
+      const result = uut.getTextPartsByHighlight('uilib@wix.com', '@wix');
+      expect(result).toEqual(['uilib', '@wix', '.com']);
+    });
+
+    it('Should handle empty string .', () => {
+      const uut = new Text({});
+      const result = uut.getTextPartsByHighlight('@ancing in the @ark', '');
+      expect(result).toEqual(['@ancing in the @ark']);
+    });
   });
 });

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -70,7 +70,7 @@ class Text extends PureComponent<PropsTypes> {
     let highlightIndex;
 
     do {
-      highlightIndex = _.lowerCase(targetString).indexOf(_.lowerCase(highlightString));
+      highlightIndex = targetString.toLowerCase().indexOf(highlightString.toLowerCase());
       if (highlightIndex !== -1) {
         if (highlightIndex > 0) {
           textParts.push(targetString.substring(0, highlightIndex));


### PR DESCRIPTION
## Description
Fix issue caused by using `lodash` `lowerCase` function, that is not recognizing some special characters ('@' '.' and maybe more). 
The outcome was when passing `highlightString` prop to `Text` component with special char, it entered a endless loop.

## Changelog
Fix `Text` prop - `highlightString` issue with special characters leading to an infinite loop.
