### PR TITLE
use PropsWithChildren in Carousel

### DIFF
--- a/generatedTypes/components/carousel/CarouselPresenter.d.ts
+++ b/generatedTypes/components/carousel/CarouselPresenter.d.ts
@@ -1,13 +1,9 @@
-import { ReactNode } from 'react';
+import { PropsWithChildren } from 'react';
 import { CarouselProps, CarouselState } from './types';
-declare type PropsWithChildren = CarouselProps & {
-    children?: ReactNode;
-};
-export declare function getChildrenLength(props: PropsWithChildren): number;
+export declare function getChildrenLength(props: PropsWithChildren<CarouselProps>): number;
 export declare function calcOffset(props: CarouselProps, state: Omit<CarouselState, 'initialOffset' | 'prevProps'>): {
     x: number;
     y: number;
 };
 export declare function calcPageIndex(offset: number, props: CarouselProps, pageSize: number): number;
 export declare function isOutOfBounds(offset: number, props: CarouselProps, pageWidth: number): boolean;
-export {};

--- a/src/components/carousel/CarouselPresenter.ts
+++ b/src/components/carousel/CarouselPresenter.ts
@@ -1,10 +1,8 @@
-import React, {ReactNode} from 'react';
+import React, {PropsWithChildren} from 'react';
 import _ from 'lodash';
 import {CarouselProps, CarouselState} from './types';
 
-type PropsWithChildren = CarouselProps & { children?: ReactNode }
-
-export function getChildrenLength(props: PropsWithChildren): number {
+export function getChildrenLength(props: PropsWithChildren<CarouselProps>): number {
   return React.Children.count(props.children);
 }
 


### PR DESCRIPTION
## Description
This is not a fix, just a small refactor.
React provides `PropsWithChildren` to decorate any interface with the `children` type

## Changelog
use PropsWithChildren in Carousel