### PR TITLE
Enable back our TextFieldMigrator

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -92,8 +92,8 @@ export default {
   },
   get TextField() {
     // TODO: Start migration by exporting TextFieldMigrator
-    // return require('./components/textField/TextFieldMigrator').default;
-    return require('./components/textField').default;
+    return require('./components/textField/TextFieldMigrator').default;
+    // return require('./components/textField').default;
   },
   get MaskedInput() {
     return require('./components/maskedInput').default;


### PR DESCRIPTION
## Description
I'm just enabling here something we prepare some time ago. 
The TextFieldMigrator is a middleware that responsible for migrating our users from the old implementation of TextField to the new one

## Changelog
Enable TextFieldMigrator for migrating from old TextField API to the new one
