### PR TITLE
Infra/use getNode in WheelPicker's FlatList

### DIFF
--- a/src/incubator/WheelPicker/index.tsx
+++ b/src/incubator/WheelPicker/index.tsx
@@ -130,7 +130,7 @@ const WheelPicker = React.memo(({
         onChange?.(items?.[index]?.value, index);
     }
     //@ts-ignore for some reason scrollToOffset isn't recognized
-    setTimeout(() => scrollView.current?.scrollToOffset({offset: index * itemHeight, animated}), 100);
+    setTimeout(() => scrollView.current?.getNode()?.scrollToOffset({offset: index * itemHeight, animated}), 100);
   };
 
   const selectItem = useCallback(index => {


### PR DESCRIPTION
## Description
Use `getNode()` in WheelPicker's FlatList to support reanimated v1

## Changelog
Use `getNode()` in WheelPicker's FlatList to support reanimated v1
