### PR TITLE
added `disableIconTintColor` prop to TabController.TabBarItem

### DIFF
--- a/src/components/tabController/TabBarItem.tsx
+++ b/src/components/tabController/TabBarItem.tsx
@@ -92,6 +92,10 @@ export interface TabControllerItemProps {
    * Used as a testing identifier
    */
   testID?: string;
+  /**
+   * disables icon's tint color
+   */
+  disableIconTintColor?: boolean;
 }
 
 interface Props extends TabControllerItemProps {
@@ -226,7 +230,20 @@ export default class TabBarItem extends PureComponent<Props> {
   }
 
   getIconStyle() {
-    const {index, currentPage, iconColor, selectedIconColor, labelColor, selectedLabelColor, ignore} = this.props;
+    const {
+      index,
+      currentPage,
+      iconColor,
+      selectedIconColor,
+      labelColor,
+      selectedLabelColor,
+      ignore,
+      disableIconTintColor
+    } = this.props;
+
+    if (disableIconTintColor) {
+      return {};
+    }
 
     const activeColor = selectedIconColor || selectedLabelColor || DEFAULT_SELECTED_LABEL_COLOR;
     const inactiveColor = iconColor || labelColor || DEFAULT_LABEL_COLOR;

--- a/src/components/tabController/TabBarItem.tsx
+++ b/src/components/tabController/TabBarItem.tsx
@@ -242,7 +242,7 @@ export default class TabBarItem extends PureComponent<Props> {
     } = this.props;
 
     if (disableIconTintColor) {
-      return {};
+      return undefined;
     }
 
     const activeColor = selectedIconColor || selectedLabelColor || DEFAULT_SELECTED_LABEL_COLOR;


### PR DESCRIPTION
## Description
Added prop to disable icon's tint color on `TabController.TabBarItem` as per #1156

## Changelog
- added `disableIconTintColor` prop to TabController.TabBarItem
