### PR TITLE
Fix/ Picker item undefined value

### DIFF
--- a/src/components/picker/index.js
+++ b/src/components/picker/index.js
@@ -249,12 +249,12 @@ class Picker extends Component {
 
     const {getItemLabel = _.noop} = this.props;
     return _.chain(value)
-      .map(item => (_.isPlainObject(item) ? getItemLabel(item) || item.label : itemsByValue[item].label))
+      .map(item => (_.isPlainObject(item) ? getItemLabel(item) || item?.label : itemsByValue[item]?.label))
       .join(', ')
       .value();
   };
 
-  getLabel(value) {
+  getLabel = value => {
     const {getLabel} = this.props;
 
     if (_.isFunction(getLabel) && !_.isUndefined(getLabel(value))) {


### PR DESCRIPTION
## Description
Picker item was undefined
- add optional chaining 
- change getLabel() to be arrow function

Jira 1825

## Changelog
Fix issue with getting the picker item label
