### PR TITLE
Feat/ TabController.TabBar style

### DIFF
--- a/demo/src/screens/componentScreens/TabControllerScreen/index.tsx
+++ b/demo/src/screens/componentScreens/TabControllerScreen/index.tsx
@@ -146,6 +146,7 @@ class TabControllerScreen extends Component<{}, State> {
             key={key}
             // uppercase
             // indicatorStyle={{backgroundColor: 'green', height: 3}}
+            // wideIndicator
             // labelColor={'green'}
             // selectedLabelColor={'red'}
             // labelStyle={{fontSize: 20}}

--- a/demo/src/screens/componentScreens/TabControllerScreen/index.tsx
+++ b/demo/src/screens/componentScreens/TabControllerScreen/index.tsx
@@ -147,6 +147,7 @@ class TabControllerScreen extends Component<{}, State> {
             // uppercase
             // indicatorStyle={{backgroundColor: 'green', height: 3}}
             // wideIndicator
+            // spreadItems={false}
             // labelColor={'green'}
             // selectedLabelColor={'red'}
             // labelStyle={{fontSize: 20}}

--- a/generatedTypes/components/tabController/TabBar.d.ts
+++ b/generatedTypes/components/tabController/TabBar.d.ts
@@ -23,6 +23,10 @@ export interface TabControllerBarProps {
      */
     indicatorStyle?: StyleProp<ViewStyle>;
     /**
+     * Whether the indicator should be wide (as the item)
+     */
+    wideIndicator?: boolean;
+    /**
      * custom label style
      */
     labelStyle?: TextProps;

--- a/generatedTypes/components/tabController/TabBar.d.ts
+++ b/generatedTypes/components/tabController/TabBar.d.ts
@@ -7,6 +7,10 @@ export interface TabControllerBarProps {
      */
     items?: TabControllerItemProps[];
     /**
+     * Whether the tabBar should be spread (default: true)
+     */
+    spreadItems?: boolean;
+    /**
      * Tab Bar height
      */
     height?: number;

--- a/src/components/tabController/TabBar.tsx
+++ b/src/components/tabController/TabBar.tsx
@@ -135,7 +135,7 @@ interface Props extends TabControllerBarProps, BaseComponentInjectedProps, Forwa
 const TabBar = (props: Props) => {
   const {
     items: propsItems,
-    spreadItems = true,
+    spreadItems,
     height,
     enableShadow,
     shadowStyle: propsShadowStyle,
@@ -349,7 +349,7 @@ const TabBar = (props: Props) => {
   }, [shadowStyle, containerWidth, containerStyle]);
 
   const indicatorContainerStyle = useMemo(() => {
-    return [styles.tabBar, {flex: spreadItems && 1}, !_.isUndefined(height) && {height}, {backgroundColor}];
+    return [styles.tabBar, {flex: spreadItems ? 1 : undefined}, !_.isUndefined(height) && {height}, {backgroundColor}];
   }, [height, backgroundColor]);
 
   const scrollViewContainerStyle = useMemo(() => {
@@ -381,7 +381,8 @@ TabBar.displayName = 'TabController.TabBar';
 TabBar.defaultProps = {
   labelStyle: DEFAULT_LABEL_STYLE,
   selectedLabelStyle: DEFAULT_SELECTED_LABEL_STYLE,
-  backgroundColor: DEFAULT_BACKGROUND_COLOR
+  backgroundColor: DEFAULT_BACKGROUND_COLOR,
+  spreadItems: true
 
   // containerWidth: Constants.screenWidth
 };

--- a/src/components/tabController/TabBar.tsx
+++ b/src/components/tabController/TabBar.tsx
@@ -20,7 +20,6 @@ const {Code, Value, interpolate: _interpolate, interpolateNode, block, set} = Re
 const interpolate = interpolateNode || _interpolate;
 
 const DEFAULT_HEIGHT = 48;
-const INDICATOR_INSET = Spacings.s4;
 const DEFAULT_BACKGROUND_COLOR = Colors.white;
 
 const DEFAULT_LABEL_STYLE = {
@@ -60,6 +59,10 @@ export interface TabControllerBarProps {
    * custom style for the selected indicator
    */
   indicatorStyle?: StyleProp<ViewStyle>;
+  /**
+   * Whether the indicator should be wide (as the item)
+   */
+  wideIndicator?: boolean;
   /**
    * custom label style
    */
@@ -133,6 +136,7 @@ const TabBar = (props: Props) => {
     shadowStyle: propsShadowStyle,
     // minTabsForScroll,
     indicatorStyle,
+    wideIndicator,
     labelStyle,
     selectedLabelStyle,
     labelColor,
@@ -149,6 +153,7 @@ const TabBar = (props: Props) => {
     children: propsChildren
   } = props;
 
+  const indicatorInset = wideIndicator ? 0 : Spacings.s4;
   const context = useContext(TabBarContext);
   // @ts-ignore // TODO: typescript
   const {itemStates, items: contextItems, currentPage, targetPage, registerTabItems, selectedIndex} = context;
@@ -307,7 +312,7 @@ const TabBar = (props: Props) => {
 
   const selectedIndicator =
     itemsWidths && itemsWidths.length > 0 ? (
-      <Reanimated.View style={[styles.selectedIndicator, indicatorStyle, _indicatorTransitionStyle]}/>
+      <Reanimated.View style={[styles.selectedIndicator, {marginHorizontal: indicatorInset}, indicatorStyle, _indicatorTransitionStyle]}/>
     ) : undefined;
 
   const renderCodeBlock = _.memoize(() => {
@@ -321,7 +326,7 @@ const TabBar = (props: Props) => {
     nodes.push(set(_indicatorWidth,
       interpolate(currentPage, {
         inputRange: itemsWidths.map((_v, i) => i),
-        outputRange: itemsWidths.map(v => v - 2 * INDICATOR_INSET)
+        outputRange: itemsWidths.map(v => v - 2 * indicatorInset)
       })));
 
     nodes.push(Reanimated.onChange(targetPage, Reanimated.call([targetPage], focusIndex as any)));
@@ -400,7 +405,6 @@ const styles = StyleSheet.create({
     left: 0,
     width: 70,
     height: 2,
-    marginHorizontal: INDICATOR_INSET,
     backgroundColor: Colors.primary
   },
   containerShadow: {

--- a/src/components/tabController/TabBar.tsx
+++ b/src/components/tabController/TabBar.tsx
@@ -40,6 +40,10 @@ export interface TabControllerBarProps {
    */
   items?: TabControllerItemProps[];
   /**
+   * Whether the tabBar should be spread (default: true)
+   */
+  spreadItems?: boolean;
+  /**
    * Tab Bar height
    */
   height?: number;
@@ -131,6 +135,7 @@ interface Props extends TabControllerBarProps, BaseComponentInjectedProps, Forwa
 const TabBar = (props: Props) => {
   const {
     items: propsItems,
+    spreadItems = true,
     height,
     enableShadow,
     shadowStyle: propsShadowStyle,
@@ -344,7 +349,7 @@ const TabBar = (props: Props) => {
   }, [shadowStyle, containerWidth, containerStyle]);
 
   const indicatorContainerStyle = useMemo(() => {
-    return [styles.tabBar, !_.isUndefined(height) && {height}, {backgroundColor}];
+    return [styles.tabBar, {flex: spreadItems && 1}, !_.isUndefined(height) && {height}, {backgroundColor}];
   }, [height, backgroundColor]);
 
   const scrollViewContainerStyle = useMemo(() => {
@@ -386,7 +391,6 @@ const styles = StyleSheet.create({
     zIndex: 100
   },
   tabBar: {
-    flex: 1,
     height: DEFAULT_HEIGHT,
     flexDirection: 'row',
     justifyContent: 'space-between'


### PR DESCRIPTION
## Description
Resolves https://github.com/wix/react-native-ui-lib/issues/1263
Add `wideIndicator` prop to make the indicator wider
Add `spreadItems` prop to make the items spread (default is true).

## Changelog
Add `wideIndicator` and `spreadItems` props to TabController.TabBar