### PR TITLE
DateTimePicker - Implement renderInput prop

### DIFF
--- a/src/components/dateTimePicker/index.js
+++ b/src/components/dateTimePicker/index.js
@@ -262,7 +262,14 @@ class DateTimePicker extends Component {
 
   render() {
     const textInputProps = TextField.extractOwnProps(this.props);
-
+    if (_.isFunction(this.props.renderInput)) {
+            return (
+                <>
+                    {this.props.renderInput({ ...this.props, formattedDate: this.getStringValue() }, this.onToggleExpandableModal)}
+                    {this.renderExpandable()}
+                </>
+            )
+        }
     return (
       <TextField
         {...textInputProps}


### PR DESCRIPTION
The renderInput prop was missing, it was mentioned in the documentation however wasnt used in the code.

## Description
The renderInput prop wasnt used in the codebase for the DateTimePicker, however it was mentioned in the documentation therefore it wasn't able to let the user to provide with their own custom input component instead of a default TextField

## Changelog
Abillity to use renderInput prop with the DateTimePicker component that was missing.
