### PR TITLE
add missing event when tapping on track

### DIFF
--- a/src/components/slider/index.js
+++ b/src/components/slider/index.js
@@ -405,7 +405,7 @@ export default class Slider extends PureBaseComponent {
     if (this.props.disabled) {
       return;
     }
-    
+    this.onSeekStart();
     this.updateTrackStepAndStyle({nativeEvent});
     this.onSeekEnd();
   };


### PR DESCRIPTION
## Description
onSeekStart was missing from event-cycle when tapping to seek (as oppose to slide to seek), added so users will be able to have same events called when sliding and when tapping to seek.

## Changelog
Added missing `onSeekStart` event call, when tapping on track to seek.
