### PR TITLE
using renderInput instead renderExpandableInput was left out

### DIFF
--- a/demo/src/screens/componentScreens/DateTimePickerScreen.js
+++ b/demo/src/screens/componentScreens/DateTimePickerScreen.js
@@ -70,7 +70,7 @@ export default class DateTimePickerScreen extends Component {
           containerStyle={{marginVertical: 20}}
           title={'Date'}
           placeholder={'Select a date'}
-          renderExpandableInput={this.renderCustomInput}
+          renderInput={this.renderCustomInput}
           dateFormat={'MMM D, YYYY'}
           // value={new Date('2015-03-25T12:00:00-06:30')}
         />

--- a/src/components/dateTimePicker/index.js
+++ b/src/components/dateTimePicker/index.js
@@ -262,11 +262,13 @@ class DateTimePicker extends Component {
 
   render() {
     const textInputProps = TextField.extractOwnProps(this.props);
+    const {renderInput} = this.props;
 
     return (
       <TextField
         {...textInputProps}
         value={this.getStringValue()}
+        renderExpandableInput={renderInput}
         expandable
         renderExpandable={this.renderExpandable}
         onToggleExpandableModal={this.onToggleExpandableModal}


### PR DESCRIPTION
## Description
Fix render prop misnamed, used `renderExpandableInput` from `TextField` prop, to use `DateTimePicker` right prop name `renderInput`

## Changelog
DateTimePicker to use `renderInput` instead of `renderExpandableInput` to pass a custom input component.
