### PR TITLE
Fix an exception with hard coded color rule

### DIFF
--- a/eslint-rules/lib/rules/no-hard-coded-color.js
+++ b/eslint-rules/lib/rules/no-hard-coded-color.js
@@ -40,7 +40,7 @@ module.exports = {
                     .invert()
                     .value();
                   const invertedColorsDict = _.assign({}, validColorsDic, extraColors);
-                  const lowerCaseColorString = colorString.toLowerCase().replace(/ /g, '');
+                  const lowerCaseColorString = (colorString ? colorString.toLowerCase() : '').replace(/ /g, '');
                   if (invertedColorsDict[lowerCaseColorString]) {
                     return fixer.replaceText(node, `Colors.${invertedColorsDict[lowerCaseColorString]}`);
                   }
@@ -78,7 +78,7 @@ module.exports = {
 
     const colorExceptions = ['transparent'];
 
-    function isColorException(colorString) {
+    function isColorException(colorString = '') {
       const lowerCaseColorString = colorString.toLowerCase();
       return colorExceptions.indexOf(lowerCaseColorString) !== -1;
     }


### PR DESCRIPTION
## Description
Our hard-coded-color rule threw the following exception in our report 
`Error: TypeError: Cannot read property 'toLowerCase' of undefined`
this PR fix the issue

## Changelog
Fix our eslint plugin hard-coded-color rule not handling undefined colors 
