### PR TITLE
Fix typescript migration bug, code should enter here to calcylate tip…

### DIFF
--- a/src/components/hint/index.tsx
+++ b/src/components/hint/index.tsx
@@ -363,13 +363,15 @@ class Hint extends Component<HintProps, HintState> {
       tipPositionStyle.top = this.hintOffset - this.tipSize.height;
     }
 
-    if (this.targetLayout?.width && this.targetLayout?.x) {
-      const targetMidWidth = this.targetLayout.width / 2;
+    const layoutWidth = this.targetLayout?.width || 0;
+
+    if (this.targetLayout?.x) {
+      const targetMidWidth = layoutWidth / 2;
       const tipMidWidth = this.tipSize.width / 2;
 
       const leftPosition = this.useSideTip ? this.targetLayout.x : this.targetLayout.x + targetMidWidth - tipMidWidth;
       const rightPosition = this.useSideTip
-        ? this.containerWidth - this.targetLayout.x - this.targetLayout.width
+        ? this.containerWidth - this.targetLayout.x - layoutWidth
         : this.containerWidth - this.targetLayout.x - targetMidWidth - tipMidWidth;
       const targetPositionOnScreen = this.getTargetPositionOnScreen();
 


### PR DESCRIPTION
## Description
Fixed issue caused when we migrated Hint to typescript, some code that calculated the hint-tip position wasn't executed when `targetFrame` with `x` is equal to 0. 
Fixed it by casted to 0 back when no `x` passed or passed `0` (typescript translated to 

## Changelog
Fix `Hint` tip pointing issue when passing custom `targetFrame` where the `width` and `hight` is 0.
