### PR TITLE
Fix Picker in multi mode not changing selection when there is a customRender

### DIFF
--- a/src/components/picker/index.js
+++ b/src/components/picker/index.js
@@ -195,7 +195,12 @@ class Picker extends Component {
           value: nextProps.value
         };
       }
-    } else if (_.isFunction(nextProps.renderPicker) && prevState.value !== nextProps.value) {
+    } else if (
+      // Allow external change of the picker's value, only applicable to single mode
+      nextProps.mode === Picker.modes.SINGLE &&
+      _.isFunction(nextProps.renderPicker) &&
+      prevState.value !== nextProps.value
+    ) {
       return {
         prevValue: prevState.value,
         value: nextProps.value


### PR DESCRIPTION
## Description
Fix Picker in multi mode not changing selection when there is a customRender

## Changelog
Fix Picker in multi mode not changing selection when there is a customRender

Fixes #1387 