### PR TITLE
Picker - fix type of `selection` in iOS (boolean and not object)

### DIFF
--- a/src/components/picker/index.js
+++ b/src/components/picker/index.js
@@ -448,7 +448,7 @@ class Picker extends Component {
         expandable
         renderExpandable={this.renderExpandableModal}
         onToggleExpandableModal={this.toggleExpandableModal}
-        selection={Constants.isAndroid && {start: 0}}
+        selection={Constants.isAndroid ? {start: 0} : undefined}
       />
     );
   }


### PR DESCRIPTION
## Description
Picker - fix type of `selection` in iOS (boolean and not object)

## Changelog
Picker - fix type of `selection` in iOS (boolean and not object)