### PR TITLE
Fix issue with TabController not handling dynamic items size

### DIFF
--- a/demo/src/screens/componentScreens/TabControllerScreen/index.tsx
+++ b/demo/src/screens/componentScreens/TabControllerScreen/index.tsx
@@ -73,7 +73,10 @@ class TabControllerScreen extends Component<{}, State> {
   }
 
   onAddItem = () => {
-    console.warn('Add Item');
+    const {items} = this.state;
+    let newItems = items.slice(0, -1) as TabControllerItemProps[];
+    newItems = [...newItems, {label: `New Item # ${newItems.length + 1}`}, items[items.length - 1]];
+    this.setState({items: newItems});
   };
 
   toggleItemsCount = () => {

--- a/generatedTypes/components/tabController2/index.d.ts
+++ b/generatedTypes/components/tabController2/index.d.ts
@@ -30,7 +30,7 @@ export interface TabControllerProps {
  * @important: On Android, if using react-native-navigation, make sure to wrap your screen with gestureHandlerRootHOC
  * @importantLink: https://kmagiera.github.io/react-native-gesture-handler/docs/getting-started.html#with-wix-react-native-navigation-https-githubcom-wix-react-native-navigation
  */
-declare function TabController({ selectedIndex, asCarousel, items, onChangeIndex, carouselPageWidth, children }: PropsWithChildren<TabControllerProps>): JSX.Element | null;
+declare function TabController({ selectedIndex, asCarousel, items, onChangeIndex, carouselPageWidth, children }: PropsWithChildren<TabControllerProps>): JSX.Element;
 declare namespace TabController {
     var TabBar: React.ComponentClass<import("./TabBar").TabControllerBarProps & {
         useCustomTheme?: boolean | undefined;

--- a/src/components/tabController2/TabBar.tsx
+++ b/src/components/tabController2/TabBar.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo, useRef, useContext, ReactNode} from 'react';
+import React, {useMemo, useContext, ReactNode} from 'react';
 import {StyleSheet, Platform, StyleProp, ViewStyle} from 'react-native';
 import Reanimated, {runOnJS, useAnimatedReaction, useAnimatedStyle, interpolate} from 'react-native-reanimated';
 import _ from 'lodash';
@@ -141,14 +141,11 @@ const TabBar = (props: Props) => {
     spreadItems,
     indicatorInsets = Spacings.s4,
     containerStyle,
-    testID,
-    children: propsChildren
+    testID
   } = props;
 
   const context = useContext(TabBarContext);
   const {items: contextItems, currentPage, targetPage, selectedIndex} = context;
-
-  const children = useRef<Props['children']>(_.filter(propsChildren, (child: ChildProps) => !!child));
 
   const containerWidth: number = useMemo(() => {
     return propsContainerWidth || Constants.screenWidth;
@@ -157,8 +154,6 @@ const TabBar = (props: Props) => {
   const items = useMemo(() => {
     return contextItems || propsItems;
   }, [contextItems, propsItems]);
-
-  const itemsCount = useRef<number>(items ? _.size(items) : React.Children.count(children.current));
 
   const {
     scrollViewRef: tabBar,
@@ -171,7 +166,7 @@ const TabBar = (props: Props) => {
     onContentSizeChange,
     onLayout
   } = useScrollToItem({
-    itemsCount: itemsCount.current,
+    itemsCount: items?.length || 0,
     selectedIndex,
     offsetType: centerSelected ? useScrollToItem.offsetType.CENTER : useScrollToItem.offsetType.DYNAMIC
   });

--- a/src/components/tabController2/TabBarItem.tsx
+++ b/src/components/tabController2/TabBarItem.tsx
@@ -139,9 +139,12 @@ export default function TabBarItem({
   }, []);
 
   const onPress = useCallback(() => {
-    currentPage.value = index;
+    if (!ignore) {
+      currentPage.value = index;
+    }
+
     props.onPress?.(index);
-  }, [index, props.onPress]);
+  }, [index, props.onPress, ignore]);
 
   const onLayout = useCallback((event: LayoutChangeEvent) => {
     const {width} = event.nativeEvent.layout;

--- a/src/components/tabController2/index.tsx
+++ b/src/components/tabController2/index.tsx
@@ -45,7 +45,7 @@ export interface TabControllerProps {
 function TabController({
   selectedIndex = 0,
   asCarousel = false,
-  items = [],
+  items,
   onChangeIndex = _.noop,
   carouselPageWidth,
   children
@@ -93,10 +93,6 @@ function TabController({
       onChangeIndex
     };
   }, [/* selectedIndex,*/asCarousel, items, onChangeIndex]);
-
-  if (items.length === 0) {
-    return null;
-  }
 
   return <TabBarContext.Provider value={context}>{children}</TabBarContext.Provider>;
 }


### PR DESCRIPTION
## Description
This PR fix two issues with new implementation of TabController (2)
- Fix issue with "ignored" tab item not being ignored
- Fix issue when items size change, the TabBar didn't rebuild itself with the new items
- Fix backward compatibility for passing items prop directly to TabController.TabBar (instead of TabController)

## Changelog
Fix TabController2 issue with rebuilding TabBar items when their count changes 