### PR TITLE
Fix/tint color for svg image

### DIFF
--- a/src/components/image/SvgImage.tsx
+++ b/src/components/image/SvgImage.tsx
@@ -5,10 +5,11 @@ const SvgXml = SvgPackage?.SvgXml;
 
 export interface SvgImageProps {
   data: any; // TODO: I thought this should be string | React.ReactNode but it doesn't work properly
+  fill?: string; // fill works on files if SVGR is configured appropriately, see https://github.com/kristerkari/react-native-svg-transformer/blob/f10c8d579490826227d1bcfa84ba6eabc124b70a/README.md#changing-svg-fill-color-in-js-code
 }
 
 function SvgImage(props: SvgImageProps) {
-  const {data, ...others} = props;
+  const {data, fill, ...others} = props;
 
   if (!SvgXml) {
     // eslint-disable-next-line max-len
@@ -17,10 +18,11 @@ function SvgImage(props: SvgImageProps) {
   }
 
   if (typeof data === 'string') {
+    // TODO can fill be applied here too?
     return <SvgXml xml={data} {...others}/>;
   } else if (data) {
     const File = data; // Must be with capital letter
-    return <File {...others}/>;
+    return <File fill={fill} {...others}/>;
   }
 
   return null;

--- a/src/components/image/index.tsx
+++ b/src/components/image/index.tsx
@@ -158,8 +158,8 @@ class Image extends PureComponent<Props, State> {
   }
 
   renderSvg = () => {
-    const {source, ...others} = this.props;
-    return <SvgImage data={source} {...others}/>;
+    const {source, tintColor, ...others} = this.props;
+    return <SvgImage data={source} fill={tintColor} {...others}/>;
   }
 
   renderRegularImage() {

--- a/src/components/image/index.tsx
+++ b/src/components/image/index.tsx
@@ -33,7 +33,7 @@ export type ImageProps = RNImageProps & MarginModifiers & {
    */
   assetGroup?: string;
   /**
-   * the asset tint
+   * the asset tint. For SVG support see note above.
    */
   tintColor?: string;
   /**
@@ -80,7 +80,9 @@ type State = {
  * @extendsLink: https://reactnative.dev/docs/image
  * @notes: please note that for SVG support you need to add both
  * `react-native-svg` and `react-native-svg-transformer`,
- * and also configure them (see `metro.config.js`)
+ * and also configure them (see `metro.config.js`).
+ * The tintColor prop depends on the fill prop in `react-native-svg-transformer`,
+ * see https://github.com/kristerkari/react-native-svg-transformer#changing-svg-fill-color-in-js-code
  */
 class Image extends PureComponent<Props, State> {
   static displayName = 'Image';


### PR DESCRIPTION
## Description
- The `Image` component supports SVGs (since https://github.com/wix/react-native-ui-lib/releases/tag/5.23.0), but the `tintColor` prop didn't work
- react-native-svg-transformer has a documented configuration to replace a specified fill color in SVG components
- in components such as `TabBarItem` where Icons are based on the `Image` component, `tintColor` is applied automatically, which also caused an error with SVGs

![Bildschirmfoto 2021-07-08 um 15 06 10](https://user-images.githubusercontent.com/1328782/126285211-db6c2632-f60a-4ae5-b36d-d67522590604.png)

## Changelog
Added `tintColor` support for SVGs in Image component, if react-native-svg-transformer is configured to replace fill color
