### PR TITLE
Infra/no import rule multiple

### DIFF
--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -9,6 +9,8 @@ module.exports = {
     'function-deprecation': require('./lib/rules/function-deprecation'),
     'prop-value-shape-deprecation': require('./lib/rules/prop-value-shape-deprecation'),
     // for duplicate rules usage
+    'no-direct-import_warn': require('./lib/rules/no-direct-import'),
+    'no-direct-import_error': require('./lib/rules/no-direct-import'),
     'component-deprecation_warn': require('./lib/rules/component-deprecation'),
     'component-prop-deprecation_warn': require('./lib/rules/component-prop-deprecation'),
     'assets-deprecation_warn': require('./lib/rules/assets-deprecation'),

--- a/eslint-rules/package.json
+++ b/eslint-rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-uilib",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "description": "uilib set of eslint rules",
   "keywords": [
     "eslint",

--- a/eslint-rules/tests/lib/rules/no-direct-import.js
+++ b/eslint-rules/tests/lib/rules/no-direct-import.js
@@ -1,7 +1,18 @@
 const RuleTester = require('eslint').RuleTester;
 const rule = require('../../../lib/rules/no-direct-import');
 
-const ruleOptions = [{origin: 'some-module', destination: 'another-module', applyAutofix: true}];
+const ruleOptions = [
+  {origin: 'some-module', destination: 'another-module', applyAutofix: true}
+];
+
+const ruleOptionsArray = [
+  {
+    rules: [
+      {origin: 'some-module', destination: 'another-module', applyAutofix: true},
+      {origin: 'old-module', destination: 'new-module', applyAutofix: true}
+    ]
+  }
+];
 
 RuleTester.setDefaultConfig({
   parser: 'babel-eslint',
@@ -10,23 +21,53 @@ RuleTester.setDefaultConfig({
 
 const ruleTester = new RuleTester();
 
-const validExample = `import {Component} from 'another-module';`;
-const invalidExample = `import {Component} from 'some-module';`;
+const validExample1 = `import {Component} from 'another-module';`;
+const validExample2 = `import {Component} from 'new-module';`;
+
+const invalidExample1 = `import {Component} from 'some-module';`;
+const invalidExample2 = `import {Component} from 'old-module';`;
+
+const error1 = `Do not import directly from 'some-module'. Please use 'another-module' (autofix available).`;
+const error2 = `Do not import directly from 'old-module'. Please use 'new-module' (autofix available).`;
 
 ruleTester.run('no-direct-import', rule, {
   valid: [
     {
       options: ruleOptions,
-      code: validExample
+      code: validExample1 
+    },
+    {
+      options: ruleOptionsArray,
+      code: validExample1
+    },
+    {
+      options: ruleOptionsArray,
+      code: validExample2 
     }
   ],
   invalid: [
     {
       options: ruleOptions,
-      code: invalidExample,
+      code: invalidExample1,
       output: `import {Component} from 'another-module';`,
       errors: [
-        {message: `Do not import directly from 'some-module'. Please use 'another-module' (autofix available).`}
+        {message: error1}
+      ]
+    },
+    {
+      options: ruleOptionsArray,
+      code: invalidExample1,
+      output: `import {Component} from 'another-module';`,
+      errors: [
+        {message: error1}
+      ]
+    },
+    {
+      options: ruleOptionsArray,
+      code: invalidExample2,
+      output: `import {Component} from 'new-module';`,
+      errors: [
+        {message: error2}
       ]
     }
   ]


### PR DESCRIPTION
## Description
Add support for multiple rules in `no-direct-import`.

## Changelog
Support having multiple eslint rules passed as array in `no-direct-import` rule.
