### PR TITLE
Allow picker to work in landscape mode on iOS

### DIFF
--- a/src/components/picker/PickerDialog.ios.js
+++ b/src/components/picker/PickerDialog.ios.js
@@ -52,7 +52,7 @@ class PickerDialog extends BaseComponent {
   render() {
     const dialogProps = Dialog.extractOwnProps(this.props);
     return (
-      <Dialog {...dialogProps} height={250} width="100%" migrate bottom animationConfig={{duration: 300}}>
+      <Dialog {...dialogProps} height={250} width="100%" migrate bottom animationConfig={{duration: 300}} supportedOrientations={['portrait', 'portrait-upside-down', 'landscape', 'landscape-left', 'landscape-right']}>
         <View flex bg-white>
           {this.renderHeader()}
           <View centerV flex>

--- a/src/components/picker/PickerModal.js
+++ b/src/components/picker/PickerModal.js
@@ -86,6 +86,7 @@ class PickerModal extends BaseComponent {
         enableModalBlur={Constants.isIOS && enableModalBlur}
         visible={visible}
         onRequestClose={topBarProps.onCancel}
+        supportedOrientations={['portrait', 'portrait-upside-down', 'landscape', 'landscape-left', 'landscape-right']}
       >
         <Modal.TopBar {...topBarProps}/>
         {this.renderSearchInput()}


### PR DESCRIPTION
## Description
Currently, when the phone is in landscape mode the picker still tries to open in portrait mode. This allows the picker to work in landscape mode. 

Closes this issue: https://github.com/wix/react-native-ui-lib/issues/1393

supportedOrientations is only used by iOS (it's ignored on android).

