### PR TITLE
add select scheme method

### DIFF
--- a/generatedTypes/style/colors.d.ts
+++ b/generatedTypes/style/colors.d.ts
@@ -8,6 +8,7 @@ declare type Schemes = {
         [key: string]: string;
     };
 };
+declare type CurrentScheme = 'default' | 'light' | 'dark'
 export declare class Colors {
     [key: string]: any;
     schemes: Schemes;
@@ -20,6 +21,12 @@ export declare class Colors {
     loadColors(colors: {
         [key: string]: string;
     }): void;
+    /**
+     * Set color scheme for app
+     * arguments:
+     * scheme - color scheme e.g light/dark/default
+     */
+    setScheme(scheme: CurrentScheme): void;
     /**
      * Load set of schemes for light/dark mode
      * arguments:
@@ -46,7 +53,7 @@ export declare class Colors {
     isValidHex(string: string): boolean;
     getHexString(color: string): string;
     getHSL(color?: string): tinycolor.ColorFormats.HSLA;
-    isTransparent(color?: string): boolean | "" | undefined;
+    isTransparent(color?: string): boolean | '' | undefined;
     areEqual(colorA: string, colorB: string): boolean;
 }
 declare const colorObject: Colors & {

--- a/src/commons/modifiers.ts
+++ b/src/commons/modifiers.ts
@@ -97,8 +97,8 @@ export type ContainerModifiers =
   BackgroundColorModifier;
 
 export function extractColorValue(props: Dictionary<any>) {
-  const scheme = Appearance.getColorScheme() || 'light';
-  const schemeColors = Colors.schemes[scheme];
+  const scheme = Colors.currentScheme === 'default' ? Appearance.getColorScheme() : Colors.currentScheme;
+  const schemeColors = Colors.schemes[scheme || 'light'];
   const allColorsKeys: Array<keyof typeof Colors> = [..._.keys(Colors), ..._.keys(schemeColors)];
   const colorPropsKeys = _.chain(props)
     .keys()
@@ -110,8 +110,8 @@ export function extractColorValue(props: Dictionary<any>) {
 
 export function extractBackgroundColorValue(props: Dictionary<any>) {
   let backgroundColor;
-  const scheme = Appearance.getColorScheme() || 'light';
-  const schemeColors = Colors.schemes[scheme];
+  const scheme = Colors.currentScheme === 'default' ? Appearance.getColorScheme() : Colors.currentScheme;
+  const schemeColors = Colors.schemes[scheme || 'light'];
 
   const keys = Object.keys(props);
   const bgProp = _.findLast(keys, prop => Colors.getBackgroundKeysPattern().test(prop) && !!props[prop])!;

--- a/src/style/colors.ts
+++ b/src/style/colors.ts
@@ -8,17 +8,21 @@ import {colorsPalette, themeColors} from './colorsPalette';
 import ColorName from './colorName';
 
 type Schemes = {light: {[key: string]: string}; dark: {[key: string]: string}};
+type CurrentScheme = 'default' | 'light' | 'dark'
 
 export class Colors {
   [key: string]: any;
   schemes: Schemes = {light: {}, dark: {}};
+  currentScheme: CurrentScheme = 'default';
 
   constructor() {
     const colors = Object.assign(colorsPalette, themeColors);
     Object.assign(this, colors);
 
     Appearance.addChangeListener(({colorScheme}: Appearance.AppearancePreferences) => {
-      Object.assign(this, this.schemes[colorScheme ?? 'light']);
+      if (this.currentScheme === 'default') {
+        Object.assign(this, this.schemes[colorScheme ?? 'light']);
+      };
     });
   }
   /**
@@ -46,8 +50,22 @@ export class Colors {
     }
 
     this.schemes = schemes;
-    const colorScheme = Appearance.getColorScheme();
+    const colorScheme = this.currentScheme === 'default' ? Appearance.getColorScheme() : this.currentScheme;
     Object.assign(this, this.schemes[colorScheme ?? 'light']);
+  }
+
+  /**
+   * Set color scheme for app
+   * arguments:
+   * scheme - color scheme e.g light/dark/default
+   */
+  setScheme(scheme: CurrentScheme) {
+    if (!['light', 'dark', 'default'].includes(scheme)) {
+      throw new Error(`${scheme} is invalid colorScheme, please use 'light' | 'dark' | 'default'`)
+    }
+    this.currentScheme = scheme;
+    const colorScheme = this.currentScheme === 'default' ? Appearance.getColorScheme() : this.currentScheme;
+    Object.assign(this, this.schemes[colorScheme ?? 'light'])
   }
 
   /**


### PR DESCRIPTION
## Description
Currently, this lib can change dark/light mode base on system setting. However, most of the time, user want to change the theme directly on the app. This PR allow app developer to change theme directly without depending on user's appearance preferences

## Changelog
Add `selectScheme` to change the color scheme manually 
