### PR TITLE
Set default supported orientations on Modal

### DIFF
--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -1,6 +1,12 @@
 import _ from 'lodash';
 import React, {Component} from 'react';
-import {StyleSheet, Modal as RNModal, ModalProps as RNModalProps, TouchableWithoutFeedback, GestureResponderEvent} from 'react-native';
+import {
+  StyleSheet,
+  Modal as RNModal,
+  ModalProps as RNModalProps,
+  TouchableWithoutFeedback,
+  GestureResponderEvent
+} from 'react-native';
 import {BlurViewPackage} from '../../optionalDependencies';
 import {Constants} from '../../helpers';
 import {asBaseComponent} from '../../commons/new';
@@ -9,33 +15,41 @@ import View from '../../components/view';
 
 const BlurView = BlurViewPackage?.BlurView;
 
+const SUPPORTED_ORIENTATIONS: RNModalProps['supportedOrientations'] = [
+  'portrait',
+  'portrait-upside-down',
+  'landscape',
+  'landscape-left',
+  'landscape-right'
+];
+
 export {ModalTopBarProps};
 export interface ModalProps extends RNModalProps {
-    /**
-     * Blurs the modal background when transparent (iOS only)
-     */
-    enableModalBlur?: boolean;
-    /**
-     * A custom view to use as a BlueView instead of the default one
-     */
-    blurView?: JSX.Element;
-    /**
-     * allow dismissing a modal when clicking on its background
-     */
-    onBackgroundPress?: (event: GestureResponderEvent) => void;
-    /**
-     * the background color of the overlay
-     */
-    overlayBackgroundColor?: string;
-    /**
-     * The modal's end-to-end test identifier
-     */
-    testID?: string;
-    /**
-     * Overrides the text that's read by the screen reader when the user interacts with the element. By default, the
-     * label is constructed by traversing all the children and accumulating all the Text nodes separated by space.
-     */
-    accessibilityLabel?: string;
+  /**
+   * Blurs the modal background when transparent (iOS only)
+   */
+  enableModalBlur?: boolean;
+  /**
+   * A custom view to use as a BlueView instead of the default one
+   */
+  blurView?: JSX.Element;
+  /**
+   * allow dismissing a modal when clicking on its background
+   */
+  onBackgroundPress?: (event: GestureResponderEvent) => void;
+  /**
+   * the background color of the overlay
+   */
+  overlayBackgroundColor?: string;
+  /**
+   * The modal's end-to-end test identifier
+   */
+  testID?: string;
+  /**
+   * Overrides the text that's read by the screen reader when the user interacts with the element. By default, the
+   * label is constructed by traversing all the children and accumulating all the Text nodes separated by space.
+   */
+  accessibilityLabel?: string;
 }
 
 /**
@@ -88,7 +102,7 @@ class Modal extends Component<ModalProps> {
     const Container: any = blurView ? blurView : defaultContainer;
 
     return (
-      <RNModal visible={Boolean(visible)} {...others}>
+      <RNModal visible={Boolean(visible)} supportedOrientations={SUPPORTED_ORIENTATIONS} {...others}>
         <Container style={{flex: 1}} blurType="light">
           {this.renderTouchableOverlay()}
           {this.props.children}


### PR DESCRIPTION
## Description
Set default supported orientations on Modal
Fix #1393

## Changelog
Set default supported orientation on Modal - supporting landscape by default (this affects dialogs as well)
