### PR TITLE
Add support to initialValue in WheelPicker

### DIFF
--- a/demo/src/configurations.js
+++ b/demo/src/configurations.js
@@ -22,7 +22,8 @@ Typography.loadTypographies({
   h1: {...Typography.text40},
   h2: {...Typography.text50},
   h3: {...Typography.text60},
-  body: Typography.text70
+  body: Typography.text70,
+  bodySmall: Typography.text80
 });
 
 Spacings.loadSpacings({

--- a/demo/src/screens/incubatorScreens/WheelPickerScreen.tsx
+++ b/demo/src/screens/incubatorScreens/WheelPickerScreen.tsx
@@ -75,9 +75,6 @@ export default () => {
     showDialog
   } = useData('February', undefined, 5);
 
-  const [initialYear, setInitialYear] = useState(2021);
-  const resetInitialYear = useCallback(() => setInitialYear(2020), []);
-
   return (
     <View flex padding-page>
       <Text h1>Wheel Picker</Text>
@@ -93,10 +90,7 @@ export default () => {
           selectedValue={selectedMonth}
         />
 
-        <View row bottom marginT-s5>
-          <Text h3>Years</Text>
-          <Button bodySmall marginL-s2 link label="Reset" size={Button.sizes.xSmall} onPress={resetInitialYear}/>
-        </View>
+        <Text h3>Years</Text>
         <Text bodySmall grey30>
           (Uncontrolled, initialValue passed)
         </Text>
@@ -104,7 +98,7 @@ export default () => {
           <Incubator.WheelPicker
             onChange={onYearChange}
             numberOfVisibleRows={3}
-            initialValue={initialYear}
+            initialValue={2021}
             items={yearItems}
           />
         </View>

--- a/demo/src/screens/incubatorScreens/WheelPickerScreen.tsx
+++ b/demo/src/screens/incubatorScreens/WheelPickerScreen.tsx
@@ -1,9 +1,8 @@
-import React, {useCallback, useMemo, useState} from 'react';
+import React, {useCallback, useState, useEffect} from 'react';
 import {View, Text, Incubator, Colors, Typography, Button, Dialog} from 'react-native-ui-lib';
 import _ from 'lodash';
 
-// Months
-const months = [
+const monthItems = _.map([
   'January',
   'February',
   'March',
@@ -16,16 +15,17 @@ const months = [
   'October',
   'November',
   'December'
-];
+],
+item => ({label: item, value: item}));
 
-// Years
-const years = _.times(2020, i => i);
-
-const days = _.times(365, i => i + 1);
+const yearItems = _.times(2030, i => i)
+  .reverse()
+  .map(item => ({label: `${item}`, value: item}));
+const dayItems = _.times(31, i => i + 1).map(day => ({label: `${day}`, value: day}));
 
 const useData = (initialMonth?: string, initialYear?: string, initialDays?: number) => {
   const [selectedMonth, setMonth] = useState<string | undefined>(initialMonth);
-  const [selectedYear, setYear] = useState<string | undefined>(initialYear);
+  const [, setYear] = useState<string | undefined>(initialYear);
   const [selectedDays, setDays] = useState<number | undefined>(initialDays);
   const [showDialog, setShowDialog] = useState(false);
 
@@ -37,39 +37,23 @@ const useData = (initialMonth?: string, initialYear?: string, initialDays?: numb
     setShowDialog(false);
   }, []);
 
-  const onMonthChange = useCallback((item: string | undefined, _: number) => {
-    setMonth(item);
+  const onMonthChange = useCallback((item: string | number, _: number) => {
+    setMonth(item as string);
   }, []);
 
-  const onYearChange = useCallback((item: string | undefined, _: number) => {
-    setYear(item);
+  const onYearChange = useCallback((item: string | number, _: number) => {
+    setYear(item as string);
   }, []);
 
-  const onDaysChange = useCallback((item: number | undefined, _: number) => {
-    setDays(item);
-  }, []);
-
-  const monthItems = useMemo(() => {
-    return _.map(months, item => ({label: item, value: item}));
-  }, []);
-
-  const yearItems = useMemo(() => {
-    return _.map(years, item => ({label: '' + item, value: item}));
-  }, []);
-
-  const dayItems = useMemo(() => {
-    return _.map(days, item => ({label: '' + item, value: item}));
+  const onDaysChange = useCallback((item: string | number, _: number) => {
+    setDays(item as number);
   }, []);
 
   return {
-    monthItems,
-    yearItems,
-    dayItems,
     onMonthChange,
     onYearChange,
     onDaysChange,
     selectedMonth,
-    selectedYear,
     selectedDays,
     onPickDaysPress,
     onDialogDismissed,
@@ -81,26 +65,24 @@ export default () => {
   const {
     selectedMonth,
     onMonthChange,
-    monthItems,
-    selectedYear,
     onYearChange,
-    yearItems,
     selectedDays,
     onDaysChange,
-    dayItems,
     onPickDaysPress,
     onDialogDismissed,
     showDialog
   } = useData('February', undefined, 5);
 
+  const [initialYear, setInitialYear] = useState(2021);
+  const resetInitialYear = useCallback(() => setInitialYear(2020), []);
+
   return (
     <View flex padding-page>
       <Text h1>Wheel Picker</Text>
 
-      <View flex marginT-20 centerH>
+      <View marginT-s5 centerH>
         <Text h3>Months</Text>
         <Incubator.WheelPicker
-          style={{width: '100%'}}
           onChange={onMonthChange}
           activeTextColor={Colors.primary}
           inactiveTextColor={Colors.grey20}
@@ -109,16 +91,24 @@ export default () => {
           selectedValue={selectedMonth}
         />
 
-        <Text h3>Years</Text>
-        <View width={'100%'}>
+        <View row bottom marginT-s5>
+          <Text h3>Years</Text>
+          <Button bodySmall marginL-s2 link label="Reset" size={Button.sizes.xSmall} onPress={resetInitialYear}/>
+        </View>
+        <Text bodySmall grey30>
+          (Uncontrolled, initialValue passed)
+        </Text>
+        <View width={'100%'} marginT-s3>
           <Incubator.WheelPicker
             onChange={onYearChange}
             numberOfVisibleRows={3}
-            selectedValue={selectedYear}
+            initialValue={initialYear}
             items={yearItems}
           />
         </View>
+      </View>
 
+      <View marginB-s10>
         <Button marginT-40 label={'Pick Days'} marginH-100 onPress={onPickDaysPress}/>
         <Dialog width={'90%'} height={260} bottom visible={showDialog} onDismiss={onDialogDismissed}>
           <Incubator.WheelPicker onChange={onDaysChange} selectedValue={selectedDays} label={'Days'} items={dayItems}/>

--- a/demo/src/screens/incubatorScreens/WheelPickerScreen.tsx
+++ b/demo/src/screens/incubatorScreens/WheelPickerScreen.tsx
@@ -1,6 +1,8 @@
-import React, {useCallback, useState, useEffect} from 'react';
+import React, {useCallback, useState} from 'react';
 import {View, Text, Incubator, Colors, Typography, Button, Dialog} from 'react-native-ui-lib';
 import _ from 'lodash';
+
+type WheelPickerValue = Incubator.WheelPickerProps['initialValue'];
 
 const monthItems = _.map([
   'January',
@@ -24,9 +26,9 @@ const yearItems = _.times(2030, i => i)
 const dayItems = _.times(31, i => i + 1).map(day => ({label: `${day}`, value: day}));
 
 const useData = (initialMonth?: string, initialYear?: string, initialDays?: number) => {
-  const [selectedMonth, setMonth] = useState<string | undefined>(initialMonth);
-  const [, setYear] = useState<string | undefined>(initialYear);
-  const [selectedDays, setDays] = useState<number | undefined>(initialDays);
+  const [selectedMonth, setMonth] = useState<WheelPickerValue>(initialMonth);
+  const [, setYear] = useState<WheelPickerValue>(initialYear);
+  const [selectedDays, setDays] = useState<WheelPickerValue>(initialDays);
   const [showDialog, setShowDialog] = useState(false);
 
   const onPickDaysPress = useCallback(() => {
@@ -37,16 +39,16 @@ const useData = (initialMonth?: string, initialYear?: string, initialDays?: numb
     setShowDialog(false);
   }, []);
 
-  const onMonthChange = useCallback((item: string | number, _: number) => {
-    setMonth(item as string);
+  const onMonthChange = useCallback((item: WheelPickerValue, _: number) => {
+    setMonth(item);
   }, []);
 
-  const onYearChange = useCallback((item: string | number, _: number) => {
-    setYear(item as string);
+  const onYearChange = useCallback((item: WheelPickerValue, _: number) => {
+    setYear(item);
   }, []);
 
-  const onDaysChange = useCallback((item: string | number, _: number) => {
-    setDays(item as number);
+  const onDaysChange = useCallback((item: WheelPickerValue, _: number) => {
+    setDays(item);
   }, []);
 
   return {

--- a/generatedTypes/incubator/WheelPicker/index.d.ts
+++ b/generatedTypes/incubator/WheelPicker/index.d.ts
@@ -4,6 +4,14 @@ import { ItemProps } from './Item';
 import { TextProps } from '../../components/text';
 export interface WheelPickerProps {
     /**
+     * Initial value (doesn't work with selectedValue)
+     */
+    initialValue?: ItemProps | number | string;
+    /**
+     * The current selected value
+     */
+    selectedValue?: ItemProps | number | string;
+    /**
      * Data source for WheelPicker
      */
     items?: ItemProps[];
@@ -53,11 +61,7 @@ export interface WheelPickerProps {
      * Support passing items as children props
      */
     children?: JSX.Element | JSX.Element[];
-    /**
-     * WheelPicker initial value, can be ItemProps.value, number as index
-     */
-    selectedValue: ItemProps | number | string;
     testID?: string;
 }
-declare const WheelPicker: React.MemoExoticComponent<({ items: propItems, itemHeight, numberOfVisibleRows, activeTextColor, inactiveTextColor, textStyle, label, labelStyle, labelProps, onChange, style, children, selectedValue, testID }: WheelPickerProps) => JSX.Element>;
+declare const WheelPicker: React.MemoExoticComponent<({ items: propItems, itemHeight, numberOfVisibleRows, activeTextColor, inactiveTextColor, textStyle, label, labelStyle, labelProps, onChange, style, children, initialValue, selectedValue, testID }: WheelPickerProps) => JSX.Element>;
 export default WheelPicker;

--- a/generatedTypes/incubator/WheelPicker/usePresenter.d.ts
+++ b/generatedTypes/incubator/WheelPicker/usePresenter.d.ts
@@ -2,7 +2,8 @@
 import { ItemProps } from './Item';
 export declare type ItemValueTypes = ItemProps | number | string;
 declare type PropTypes = {
-    selectedValue: ItemValueTypes;
+    initialValue?: ItemValueTypes;
+    selectedValue?: ItemValueTypes;
     children?: JSX.Element | JSX.Element[];
     items?: ItemProps[];
     itemHeight: number;
@@ -19,5 +20,5 @@ interface Presenter {
     height: number;
     getRowItemAtOffset: (offset: number) => RowItem;
 }
-declare const usePresenter: ({ selectedValue, children, items: propItems, itemHeight, preferredNumVisibleRows }: PropTypes) => Presenter;
+declare const usePresenter: ({ initialValue, selectedValue, children, items: propItems, itemHeight, preferredNumVisibleRows }: PropTypes) => Presenter;
 export default usePresenter;

--- a/src/incubator/WheelPicker/usePresenter.ts
+++ b/src/incubator/WheelPicker/usePresenter.ts
@@ -6,7 +6,8 @@ import useMiddleIndex from './helpers/useListMiddleIndex';
 export type ItemValueTypes = ItemProps | number | string;
 
 type PropTypes = {
-  selectedValue: ItemValueTypes;
+  initialValue?: ItemValueTypes;
+  selectedValue?: ItemValueTypes;
   children?: JSX.Element | JSX.Element[];
   items?: ItemProps[];
   itemHeight: number;
@@ -27,13 +28,14 @@ interface Presenter {
 }
 
 const usePresenter = ({
+  initialValue,
   selectedValue,
   children,
   items: propItems,
   itemHeight,
   preferredNumVisibleRows
 }: PropTypes): Presenter => {
-  
+  const value = !_.isUndefined(selectedValue) ? selectedValue : initialValue;
   const extractItemsFromChildren = (): ItemProps[] => {
     const items = React.Children.map(children, child => {
       const childAsType: ItemProps = {value: child?.props.value, label: child?.props.label};
@@ -45,15 +47,18 @@ const usePresenter = ({
   const items = useRef<ItemProps[]>(children ? extractItemsFromChildren() : propItems!).current;
   const middleIndex = useMiddleIndex({itemHeight, listSize: items.length});
 
-  const getSelectedValueIndex = (): number => {
-    if (_.isString(selectedValue) || _.isNumber(selectedValue)) {
-      return _.findIndex(items, {value: selectedValue});
+  const getSelectedValueIndex = () => {
+    if (_.isString(value) || _.isNumber(value)) {
+      return _.findIndex(items, {value});
     }
-    return _.findIndex(items, {value: selectedValue?.value});
+    return _.findIndex(items, {value: (value as ItemProps)?.value});
   };
 
   const shouldControlComponent = (offset: number): boolean => {
-    return offset >= 0 && selectedValue !== getRowItemAtOffset(offset).value;
+    if (!_.isUndefined(selectedValue)) {
+      return offset >= 0 && selectedValue !== getRowItemAtOffset(offset).value;
+    }
+    return false;
   };
 
   const getRowItemAtOffset = (offset: number): RowItem => {

--- a/src/incubator/WheelPicker/usePresenter.ts
+++ b/src/incubator/WheelPicker/usePresenter.ts
@@ -51,7 +51,7 @@ const usePresenter = ({
     if (_.isString(value) || _.isNumber(value)) {
       return _.findIndex(items, {value});
     }
-    return _.findIndex(items, {value: (value as ItemProps)?.value});
+    return _.findIndex(items, {value: (value)?.value});
   };
 
   const shouldControlComponent = (offset: number): boolean => {


### PR DESCRIPTION
## Description
I added a new prop `initialValue` to Incubator.WheelPicker. 
`initialValue` doesn't work together with `selectedValue` prop
The first (initialValue) makes the picker uncontrolled in a way the user doesn't need to pass it on every change. 
The second (selectedValue) is completely controlled 

Notice that passing a new `initialValue` will reset the value and index of the picker. 


## Changelog
Add `initialValue` prop to Incubator.WheelPicker