### PR TITLE
Infra/tab controller2 initial index

### DIFF
--- a/generatedTypes/components/tabController2/TabBarContext.d.ts
+++ b/generatedTypes/components/tabController2/TabBarContext.d.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import Reanimated from 'react-native-reanimated';
 interface TabControllerContext {
+    initialIndex?: number;
     selectedIndex?: number;
     items?: any[];
     asCarousel?: boolean;

--- a/generatedTypes/components/tabController2/index.d.ts
+++ b/generatedTypes/components/tabController2/index.d.ts
@@ -9,7 +9,11 @@ export interface TabControllerProps {
     /**
      * Initial selected index
      */
-    selectedIndex: number;
+    initialIndex?: number;
+    /**
+     * DEPRECATED: use initialIndex instead
+     */
+     selectedIndex?: number;
     /**
      * callback for when index has change (will not be called on ignored items)
      */

--- a/generatedTypes/components/tabController2/index.d.ts
+++ b/generatedTypes/components/tabController2/index.d.ts
@@ -13,7 +13,7 @@ export interface TabControllerProps {
     /**
      * DEPRECATED: use initialIndex instead
      */
-     selectedIndex?: number;
+    selectedIndex?: number;
     /**
      * callback for when index has change (will not be called on ignored items)
      */
@@ -34,7 +34,7 @@ export interface TabControllerProps {
  * @important: On Android, if using react-native-navigation, make sure to wrap your screen with gestureHandlerRootHOC
  * @importantLink: https://kmagiera.github.io/react-native-gesture-handler/docs/getting-started.html#with-wix-react-native-navigation-https-githubcom-wix-react-native-navigation
  */
-declare function TabController({ selectedIndex, asCarousel, items, onChangeIndex, carouselPageWidth, children }: PropsWithChildren<TabControllerProps>): JSX.Element;
+declare function TabController({ initialIndex, selectedIndex, asCarousel, items, onChangeIndex, carouselPageWidth, children }: PropsWithChildren<TabControllerProps>): JSX.Element;
 declare namespace TabController {
     var TabBar: React.ComponentClass<import("./TabBar").TabControllerBarProps & {
         useCustomTheme?: boolean | undefined;

--- a/src/components/tabController2/TabBarContext.ts
+++ b/src/components/tabController2/TabBarContext.ts
@@ -2,6 +2,8 @@ import React from 'react';
 import Reanimated from 'react-native-reanimated';
 
 interface TabControllerContext {
+  initialIndex?: number;
+  // DEPRECATED: use initialIndex instead
   selectedIndex?: number;
   items?: any[];
   asCarousel?: boolean;

--- a/src/components/tabController2/index.tsx
+++ b/src/components/tabController2/index.tsx
@@ -64,6 +64,7 @@ function TabController({
     return _.filter<TabControllerItemProps[]>(items, (item: TabControllerItemProps) => item.ignore);
   }, [items]);
 
+  /* backwards compatibility for `selectedIndex` prop. this line eventually should be removed */
   initialIndex = selectedIndex || initialIndex;
 
   /* currentPage - static page index */


### PR DESCRIPTION
## Description
Add `initialIndex` controlled prop to `TabBarController2` that is deprecate the current `selectedIndex` prop.

## Changelog
Added a new `initialIndex` prop to `TabBarController2` that now controlling the current `TabBarController2` current page, this will deprecated `selectedIndex`