### PR TITLE
Allow setting windowSoftInputMode

### DIFF
--- a/lib/android/src/main/java/com/wix/reactnativeuilib/keyboardinput/CustomKeyboardLayout.java
+++ b/lib/android/src/main/java/com/wix/reactnativeuilib/keyboardinput/CustomKeyboardLayout.java
@@ -24,6 +24,8 @@ public class CustomKeyboardLayout implements ReactSoftKeyboardMonitor.Listener, 
     private final InputMethodManager mInputMethodManager;
     private final ReactSoftKeyboardMonitor mKeyboardMonitor;
     private WeakReference<CustomKeyboardRootViewShadow> mShadowNode = new WeakReference<>(null);
+    private int mSoftInputMode;
+    private boolean mIsShown = false;
 
     public CustomKeyboardLayout(ReactContext reactContext, ReactSoftKeyboardMonitor keyboardMonitor, ReactScreenMonitor screenMonitor) {
         mKeyboardMonitor = keyboardMonitor;
@@ -31,6 +33,18 @@ public class CustomKeyboardLayout implements ReactSoftKeyboardMonitor.Listener, 
 
         mKeyboardMonitor.setListener(this);
         screenMonitor.addListener(this);
+    }
+
+    public void setShown(boolean isShown) {
+        mIsShown = isShown;
+        Window window = getWindow();
+        if (window != null) {
+            if (mIsShown) {
+                mSoftInputMode = window.getAttributes().softInputMode;
+            } else {
+                window.setSoftInputMode(mSoftInputMode);
+            }
+        }
     }
 
     @Override
@@ -167,16 +181,20 @@ public class CustomKeyboardLayout implements ReactSoftKeyboardMonitor.Listener, 
     }
 
     private void setKeyboardOverlayMode() {
-        Window window = getWindow();
-        if (window != null) {
-            window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN);
+        if (mIsShown) {
+            Window window = getWindow();
+            if (window != null) {
+                window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN);
+            }
         }
     }
 
     private void clearKeyboardOverlayMode() {
-        Window window = getWindow();
-        if (window != null) {
-            window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
+        if (mIsShown) {
+            Window window = getWindow();
+            if (window != null) {
+                window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
+            }
         }
     }
 

--- a/lib/android/src/main/java/com/wix/reactnativeuilib/keyboardinput/CustomKeyboardRootView.java
+++ b/lib/android/src/main/java/com/wix/reactnativeuilib/keyboardinput/CustomKeyboardRootView.java
@@ -24,4 +24,16 @@ public class CustomKeyboardRootView extends FrameLayout {
         }
         super.onViewAdded(child);
     }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        mLayout.setShown(true);
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        mLayout.setShown(false);
+        super.onDetachedFromWindow();
+    }
 }


### PR DESCRIPTION
## Description
Currently our `CustomKeyboardLayout` is forcing the app to have `windowSoftInputMode=SOFT_INPUT_ADJUST_RESIZE` even if you did not use a `KeyboardAccessoryView` in your app.
This fix changes this behaviour to only occur if a `KeyboardAccessoryView` is loaded (even in a different tab etc).

@ethanshar, I've tested on both public and private demo apps, but I think it isn't without risk, what's your opinion?

## Changelog
Do not force SOFT_INPUT_ADJUST_RESIZE on Android apps.

Fixes #1360 
