### PR TITLE
Added 'index' to Wizard.Step

### DIFF
--- a/generatedTypes/src/components/wizard/types.d.ts
+++ b/generatedTypes/src/components/wizard/types.d.ts
@@ -45,6 +45,10 @@ export interface WizardStepProps {
      */
     icon?: ImageProps;
     /**
+     * Index of the step
+     */
+    index: number;
+    /**
      * Additional styles for the index's label (when icon is not provided)
      */
     indexLabelStyle?: StyleProp<TextStyle>;


### PR DESCRIPTION
This pull request fixes a typescript error for the Wizard.Step component

## Description
Added the missing property 'index' to the Wizard.Step component to prevent errors when used

## Changelog
Added the index property to the Wizard.Step component