### PR TITLE
WizardStep - hide private props by using defaultProps

### DIFF
--- a/src/components/wizard/WizardStep.tsx
+++ b/src/components/wizard/WizardStep.tsx
@@ -28,6 +28,10 @@ interface Props extends WizardStepProps, Omit<WizardProps, 'onActiveIndexChanged
  */
 class WizardStep extends Component<Props> {
   static displayName = 'Wizard.Step';
+  static defaultProps = {
+    index: 0,
+    maxWidth: 0
+  };
 
   getProps() {
     const props = this.props;


### PR DESCRIPTION
## Description
WizardStep - hide private props by using defaultProps; although not perfect, this was the best solution I could think of.

## Changelog
WizardStep - hide private props by using defaultProps

Fixes #1496 