### PR TITLE
Feat/tab controller 2 orientation - incomplete

### DIFF
--- a/demo/src/screens/componentScreens/TabControllerScreen/index.tsx
+++ b/demo/src/screens/componentScreens/TabControllerScreen/index.tsx
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import {ActivityIndicator, StyleSheet} from 'react-native';
-import {Assets, TabController, Colors, View, Text, Button, TabControllerItemProps} from 'react-native-ui-lib';
+import {Assets, TabController2 as TabController, Colors, View, Text, Button, TabControllerItemProps} from 'react-native-ui-lib';
 import {gestureHandlerRootHOC} from 'react-native-gesture-handler';
 import _ from 'lodash';
 

--- a/generatedTypes/src/components/tabController2/TabBarContext.d.ts
+++ b/generatedTypes/src/components/tabController2/TabBarContext.d.ts
@@ -6,7 +6,8 @@ interface TabControllerContext {
     items?: any[];
     asCarousel?: boolean;
     containerWidth: Reanimated.SharedValue<number>;
-    pageWidth?: number;
+    pageWidth: number;
+    screenWidth: number;
     /** static page index */
     currentPage: Reanimated.SharedValue<number>;
     /** transition page index (can be a fraction when transitioning between pages) */

--- a/generatedTypes/src/components/tabController2/TabBarContext.d.ts
+++ b/generatedTypes/src/components/tabController2/TabBarContext.d.ts
@@ -5,7 +5,6 @@ interface TabControllerContext {
     selectedIndex?: number;
     items?: any[];
     asCarousel?: boolean;
-    containerWidth: Reanimated.SharedValue<number>;
     pageWidth: number;
     screenWidth: number;
     /** static page index */

--- a/generatedTypes/src/components/tabController2/useScrollToItem.d.ts
+++ b/generatedTypes/src/components/tabController2/useScrollToItem.d.ts
@@ -18,6 +18,10 @@ export declare type ScrollToItemProps<T extends ScrollToSupportedViews> = {
      */
     selectedIndex?: number;
     /**
+     * The screen width, should update on orientation change
+     */
+    screenWidth: number;
+    /**
      * Where would the item be located (default to CENTER)
      */
     offsetType?: OffsetType;

--- a/src/components/tabController2/PageCarousel.tsx
+++ b/src/components/tabController2/PageCarousel.tsx
@@ -8,7 +8,6 @@ import Reanimated, {
   useSharedValue,
   withTiming
 } from 'react-native-reanimated';
-import {Constants} from 'helpers';
 
 /**
  * @description: TabController's Page Carousel
@@ -21,7 +20,7 @@ function PageCarousel({...props}) {
     currentPage,
     targetPage,
     selectedIndex = 0,
-    pageWidth = Constants.screenWidth,
+    pageWidth,
     carouselOffset
   } = useContext(TabBarContext);
   const contentOffset = useMemo(() => ({x: selectedIndex * pageWidth, y: 0}), [selectedIndex, pageWidth]);

--- a/src/components/tabController2/PageCarousel.tsx
+++ b/src/components/tabController2/PageCarousel.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useContext, useMemo} from 'react';
+import React, {useCallback, useContext, useMemo, useEffect} from 'react';
 import TabBarContext from './TabBarContext';
 import Reanimated, {
   runOnJS,
@@ -60,6 +60,11 @@ function PageCarousel({...props}) {
       runOnJS(scrollToItem)(currIndex);
     }
   });
+
+  useEffect(() => {
+    // @ts-expect-error
+    carousel.current?.scrollTo({x: currentPage.value * pageWidth, animated: false});
+  }, [pageWidth]);
 
   return (
     <Reanimated.ScrollView

--- a/src/components/tabController2/TabBar.tsx
+++ b/src/components/tabController2/TabBar.tsx
@@ -8,7 +8,6 @@ import TabBarItem, {TabControllerItemProps} from './TabBarItem';
 import {asBaseComponent, forwardRef, BaseComponentInjectedProps, ForwardRefInjectedProps} from '../../commons/new';
 import View from '../view';
 import {Colors, Spacings, Typography} from '../../style';
-import {Constants} from '../../helpers';
 import FadedScrollView from './FadedScrollView';
 
 import useScrollToItem from './useScrollToItem';
@@ -145,11 +144,11 @@ const TabBar = (props: Props) => {
   } = props;
 
   const context = useContext(TabBarContext);
-  const {items: contextItems, currentPage, targetPage, selectedIndex} = context;
+  const {items: contextItems, currentPage, targetPage, selectedIndex, screenWidth} = context;
 
   const containerWidth: number = useMemo(() => {
-    return propsContainerWidth || Constants.screenWidth;
-  }, [propsContainerWidth]);
+    return propsContainerWidth || screenWidth;
+  }, [propsContainerWidth, screenWidth]);
 
   const items = useMemo(() => {
     return contextItems || propsItems;
@@ -168,6 +167,7 @@ const TabBar = (props: Props) => {
   } = useScrollToItem({
     itemsCount: items?.length || 0,
     selectedIndex,
+    screenWidth,
     offsetType: centerSelected ? useScrollToItem.offsetType.CENTER : useScrollToItem.offsetType.DYNAMIC
   });
 
@@ -282,9 +282,6 @@ const styles = StyleSheet.create({
     height: DEFAULT_HEIGHT,
     flexDirection: 'row',
     justifyContent: 'space-between'
-  },
-  tabBarScrollContent: {
-    minWidth: Constants.screenWidth
   },
   tab: {
     flex: 1,

--- a/src/components/tabController2/TabBarContext.ts
+++ b/src/components/tabController2/TabBarContext.ts
@@ -7,7 +7,6 @@ interface TabControllerContext {
   selectedIndex?: number;
   items?: any[];
   asCarousel?: boolean;
-  containerWidth: Reanimated.SharedValue<number>;
   pageWidth: number;
   screenWidth: number;
   /** static page index */

--- a/src/components/tabController2/TabBarContext.ts
+++ b/src/components/tabController2/TabBarContext.ts
@@ -8,7 +8,8 @@ interface TabControllerContext {
   items?: any[];
   asCarousel?: boolean;
   containerWidth: Reanimated.SharedValue<number>;
-  pageWidth?: number;
+  pageWidth: number;
+  screenWidth: number;
   /** static page index */
   currentPage: Reanimated.SharedValue<number>;
   /** transition page index (can be a fraction when transitioning between pages) */

--- a/src/components/tabController2/TabBarItem.tsx
+++ b/src/components/tabController2/TabBarItem.tsx
@@ -201,6 +201,7 @@ export default function TabBarItem({
       activeOpacity={activeOpacity}
       onPress={onPress}
       testID={testID}
+      key={`${screenWidth}`}
     >
       {leadingAccessory}
       {icon && (

--- a/src/components/tabController2/TabBarItem.tsx
+++ b/src/components/tabController2/TabBarItem.tsx
@@ -124,19 +124,12 @@ export default function TabBarItem({
   style,
   ...props
 }: Props) {
-  const {currentPage} = useContext(TabBarContext);
+  const {currentPage, screenWidth} = useContext(TabBarContext);
   const itemRef = useRef();
   const itemWidth = useRef(props.width);
   // JSON.parse(JSON.stringify is due to an issue with reanimated
   const sharedLabelStyle = useSharedValue(JSON.parse(JSON.stringify(labelStyle)));
   const sharedSelectedLabelStyle = useSharedValue(JSON.parse(JSON.stringify(selectedLabelStyle)));
-
-  useEffect(() => {
-    if (itemWidth.current) {
-      props.onLayout?.({nativeEvent: {layout: {x: 0, y: 0, width: itemWidth.current, height: 0}}} as LayoutChangeEvent,
-        index);
-    }
-  }, []);
 
   const onPress = useCallback(() => {
     if (!ignore) {
@@ -146,10 +139,17 @@ export default function TabBarItem({
     props.onPress?.(index);
   }, [index, props.onPress, ignore]);
 
+  useEffect(() => {
+    itemWidth.current = props.width;
+  }, [screenWidth]);
+
   const onLayout = useCallback((event: LayoutChangeEvent) => {
     const {width} = event.nativeEvent.layout;
 
-    if (!itemWidth.current && itemRef?.current) {
+    if (itemWidth.current) {
+      props.onLayout?.({nativeEvent: {layout: {x: 0, y: 0, width: itemWidth.current, height: 0}}} as LayoutChangeEvent,
+        index);
+    } else if (itemRef?.current) {
       itemWidth.current = width;
       // @ts-ignore
       itemRef.current?.setNativeProps({style: {width, paddingHorizontal: null, flex: null}});
@@ -183,11 +183,19 @@ export default function TabBarItem({
     };
   });
 
+  const constantWidthStyle = useAnimatedStyle(() => {
+    if (itemWidth.current) {
+      return {flex: 0, width: itemWidth.current};
+    }
+
+    return {};
+  });
+
   return (
     <TouchableOpacity
       // @ts-expect-error
       ref={itemRef}
-      style={[styles.tabItem, style]}
+      style={[styles.tabItem, style, constantWidthStyle]}
       onLayout={onLayout}
       activeBackgroundColor={activeBackgroundColor}
       activeOpacity={activeOpacity}

--- a/src/components/tabController2/TabPage.tsx
+++ b/src/components/tabController2/TabPage.tsx
@@ -1,4 +1,4 @@
-import React, {PropsWithChildren, useCallback, useContext, useState} from 'react';
+import React, {PropsWithChildren, useCallback, useContext, useState, useMemo} from 'react';
 import {StyleSheet} from 'react-native';
 import Reanimated, {useAnimatedStyle, useAnimatedReaction, runOnJS} from 'react-native-reanimated';
 import TabBarContext from './TabBarContext';
@@ -37,7 +37,7 @@ export default function TabPage({
   renderLoading,
   ...props
 }: PropsWithChildren<TabControllerPageProps>) {
-  const {currentPage, targetPage, asCarousel, containerWidth, screenWidth} = useContext(TabBarContext);
+  const {currentPage, targetPage, asCarousel, screenWidth} = useContext(TabBarContext);
   const [shouldLoad, setLoaded] = useState(!lazy);
 
   const lazyLoad = useCallback(() => {
@@ -59,13 +59,17 @@ export default function TabPage({
     const isActive = Math.round(currentPage.value) === index;
     return {
       opacity: isActive || asCarousel ? 1 : 0,
-      zIndex: isActive || asCarousel ? 1 : 0,
-      width: asCarousel ? containerWidth.value || screenWidth : undefined
+      zIndex: isActive || asCarousel ? 1 : 0
     };
   });
 
+  const style = useMemo(() => {
+    const style = {width: asCarousel ? screenWidth : undefined};
+    return [!asCarousel && styles.page, animatedPageStyle, style];
+  }, [asCarousel, screenWidth, animatedPageStyle]);
+
   return (
-    <Reanimated.View style={[!asCarousel && styles.page, animatedPageStyle]} testID={testID}>
+    <Reanimated.View style={style} testID={testID}>
       {!shouldLoad && renderLoading?.()}
       {shouldLoad && props.children}
     </Reanimated.View>

--- a/src/components/tabController2/TabPage.tsx
+++ b/src/components/tabController2/TabPage.tsx
@@ -2,7 +2,6 @@ import React, {PropsWithChildren, useCallback, useContext, useState} from 'react
 import {StyleSheet} from 'react-native';
 import Reanimated, {useAnimatedStyle, useAnimatedReaction, runOnJS} from 'react-native-reanimated';
 import TabBarContext from './TabBarContext';
-import {Constants} from 'helpers';
 
 export interface TabControllerPageProps {
   /**
@@ -38,7 +37,7 @@ export default function TabPage({
   renderLoading,
   ...props
 }: PropsWithChildren<TabControllerPageProps>) {
-  const {currentPage, targetPage, asCarousel, containerWidth} = useContext(TabBarContext);
+  const {currentPage, targetPage, asCarousel, containerWidth, screenWidth} = useContext(TabBarContext);
   const [shouldLoad, setLoaded] = useState(!lazy);
 
   const lazyLoad = useCallback(() => {
@@ -61,7 +60,7 @@ export default function TabPage({
     return {
       opacity: isActive || asCarousel ? 1 : 0,
       zIndex: isActive || asCarousel ? 1 : 0,
-      width: asCarousel ? containerWidth.value || Constants.screenWidth : undefined
+      width: asCarousel ? containerWidth.value || screenWidth : undefined
     };
   });
 

--- a/src/components/tabController2/index.tsx
+++ b/src/components/tabController2/index.tsx
@@ -91,6 +91,12 @@ function TabController({
   const containerWidth = useSharedValue(pageWidth);
 
   useEffect(() => {
+    // TODO: this causes a crash on iOS
+    // 1. Refresh app in TabController screen
+    // 2. Switch to landscape
+    // 3. Press the Community tab
+    // 4. Switch to portrait
+    // Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Mouting block is expected to not be set'
     containerWidth.value = pageWidth;
   }, [pageWidth]);
 

--- a/src/components/tabController2/index.tsx
+++ b/src/components/tabController2/index.tsx
@@ -1,8 +1,9 @@
 // TODO: support commented props
-import React, {PropsWithChildren, useMemo, useEffect} from 'react';
+import React, {PropsWithChildren, useMemo, useEffect, useRef, useState} from 'react';
 import _ from 'lodash';
 import {useAnimatedReaction, useSharedValue, withTiming, runOnJS} from 'react-native-reanimated';
 import {Constants} from '../../helpers';
+import {orientations} from '../../helpers/Constants';
 import {asBaseComponent} from '../../commons/new';
 import {LogService} from '../../services';
 import TabBarContext from './TabBarContext';
@@ -56,9 +57,24 @@ function TabController({
   carouselPageWidth,
   children
 }: PropsWithChildren<TabControllerProps>) {
+  const [screenWidth, setScreenWidth] = useState<number>(Constants.windowWidth);
+  const orientation = useRef<orientations>(Constants.orientation);
+  useEffect(() => {
+    const onOrientationChange = () => {
+      if (orientation.current !== Constants.orientation) {
+        orientation.current = Constants.orientation;
+        setScreenWidth(Constants.windowWidth);
+      }
+    };
+    Constants.addDimensionsEventListener(onOrientationChange);
+    return () => {
+      Constants.removeDimensionsEventListener(onOrientationChange);
+    };
+  }, []);
+
   const pageWidth = useMemo(() => {
-    return carouselPageWidth || Constants.screenWidth;
-  }, [carouselPageWidth]);
+    return carouselPageWidth || screenWidth;
+  }, [carouselPageWidth, screenWidth]);
 
   const ignoredItems = useMemo(() => {
     return _.filter<TabControllerItemProps[]>(items, (item: TabControllerItemProps) => item.ignore);
@@ -100,6 +116,7 @@ function TabController({
       initialIndex,
       asCarousel,
       pageWidth,
+      screenWidth,
       /* Items */
       items,
       ignoredItems,
@@ -111,7 +128,7 @@ function TabController({
       /* Callbacks */
       onChangeIndex
     };
-  }, [/* initialIndex,*/initialIndex, asCarousel, items, onChangeIndex]);
+  }, [/* initialIndex,*/initialIndex, asCarousel, items, onChangeIndex, screenWidth]);
 
   return <TabBarContext.Provider value={context}>{children}</TabBarContext.Provider>;
 }

--- a/src/components/tabController2/index.tsx
+++ b/src/components/tabController2/index.tsx
@@ -91,6 +91,10 @@ function TabController({
   const containerWidth = useSharedValue(pageWidth);
 
   useEffect(() => {
+    containerWidth.value = pageWidth;
+  }, [pageWidth]);
+
+  useEffect(() => {
     if (!_.isUndefined(selectedIndex)) {
       LogService.deprecationWarn({component: 'TabController2', oldProp: 'selectedIndex', newProp: 'initialIndex'});
     }

--- a/src/components/tabController2/index.tsx
+++ b/src/components/tabController2/index.tsx
@@ -91,7 +91,7 @@ function TabController({
 
   useEffect(() => {
     if (!_.isUndefined(selectedIndex)) {
-      LogService.deprecationWarn({component: 'TabController2', oldProp: 'selectedIndex', newProp: 'initialIndex'});
+      // LogService.deprecationWarn({component: 'TabController2', oldProp: 'selectedIndex', newProp: 'initialIndex'});
     }
   }, [selectedIndex]);
 

--- a/src/components/tabController2/index.tsx
+++ b/src/components/tabController2/index.tsx
@@ -88,17 +88,6 @@ function TabController({
   /* targetPage - transitioned page index (can be a fraction when transitioning between pages) */
   const targetPage = useSharedValue(initialIndex);
   const carouselOffset = useSharedValue(initialIndex * Math.round(pageWidth));
-  const containerWidth = useSharedValue(pageWidth);
-
-  useEffect(() => {
-    // TODO: this causes a crash on iOS
-    // 1. Refresh app in TabController screen
-    // 2. Switch to landscape
-    // 3. Press the Community tab
-    // 4. Switch to portrait
-    // Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Mouting block is expected to not be set'
-    containerWidth.value = pageWidth;
-  }, [pageWidth]);
 
   useEffect(() => {
     if (!_.isUndefined(selectedIndex)) {
@@ -134,7 +123,6 @@ function TabController({
       targetPage,
       currentPage,
       carouselOffset,
-      containerWidth,
       /* Callbacks */
       onChangeIndex
     };

--- a/src/components/tabController2/useScrollToItem.ts
+++ b/src/components/tabController2/useScrollToItem.ts
@@ -110,6 +110,13 @@ const useScrollToItem = <T extends ScrollToSupportedViews>(props: ScrollToItemPr
   // const contentWidth = _.sum(itemsWidths);
   // TODO: const scrollEnabled = contentWidth.current > containerWidth;
 
+  useEffect(() => {
+    if (!_.includes(itemsWidths.current, null)) {
+      itemsWidths.current = _.times(itemsCount, () => null);
+      setOffsets({CENTER: [], LEFT: [], RIGHT: []});
+    }
+  }, [screenWidth]);
+
   const setSnapBreakpoints = useCallback((widths: number[]) => {
     if (_.isEmpty(widths)) {
       return;
@@ -159,11 +166,11 @@ const useScrollToItem = <T extends ScrollToSupportedViews>(props: ScrollToItemPr
   const onItemLayout = useCallback((event: LayoutChangeEvent, index: number) => {
     const {width} = event.nativeEvent.layout;
     itemsWidths.current[index] = width;
-    if (!_.includes(itemsWidths.current, null)) {
+    if (!_.includes(itemsWidths.current, null) && _.isEmpty(offsets.CENTER)) {
       setSnapBreakpoints(itemsWidths.current as number[]);
     }
   },
-  [setSnapBreakpoints]);
+  [setSnapBreakpoints, offsets]);
 
   const focusIndex = useCallback((index: number, animated = true) => {
     if (index >= 0 && offsets.CENTER.length > index) {

--- a/src/components/tabController2/useScrollToItem.ts
+++ b/src/components/tabController2/useScrollToItem.ts
@@ -24,7 +24,7 @@ export type ScrollToItemProps<T extends ScrollToSupportedViews> = {
   /**
    * The screen width, should update on orientation change
    */
-   screenWidth: number;
+  screenWidth: number;
   /**
    * Where would the item be located (default to CENTER)
    */
@@ -67,7 +67,7 @@ export type ScrollToItemResultProps<T extends ScrollToSupportedViews> = Pick<
   /**
    * The items' offsets as share animated value
    */
-   itemsOffsetsAnimated: any; //TODO: should be SharedValue<number[]>
+  itemsOffsetsAnimated: any; //TODO: should be SharedValue<number[]>
   /**
    * Use in order to focus the item with the specified index (use when the selectedIndex is not changed)
    */

--- a/src/components/tabController2/useScrollToItem.ts
+++ b/src/components/tabController2/useScrollToItem.ts
@@ -3,7 +3,6 @@ import {useState, useCallback, useEffect, useRef, RefObject} from 'react';
 import {LayoutChangeEvent} from 'react-native';
 import {useSharedValue} from 'react-native-reanimated';
 import {useScrollTo, ScrollToSupportedViews, ScrollToResultProps} from 'hooks';
-import {Constants} from 'helpers';
 
 export enum OffsetType {
   CENTER = 'CENTER',
@@ -22,6 +21,10 @@ export type ScrollToItemProps<T extends ScrollToSupportedViews> = {
    * The selected item's index
    */
   selectedIndex?: number;
+  /**
+   * The screen width, should update on orientation change
+   */
+   screenWidth: number;
   /**
    * Where would the item be located (default to CENTER)
    */
@@ -86,6 +89,7 @@ const useScrollToItem = <T extends ScrollToSupportedViews>(props: ScrollToItemPr
     scrollViewRef: propsScrollViewRef,
     itemsCount,
     selectedIndex,
+    screenWidth,
     offsetType = OffsetType.CENTER,
     addOffsetMargin = true,
     outerSpacing = 0,
@@ -111,14 +115,14 @@ const useScrollToItem = <T extends ScrollToSupportedViews>(props: ScrollToItemPr
       return;
     }
 
-    const screenCenter = Constants.screenWidth / 2; // TODO: change to something more dynamic?
+    const screenCenter = screenWidth / 2; // TODO: change to something more dynamic?
     let index = 0;
     const centeredOffsets = [];
     let currentCenterOffset = outerSpacing;
     const leftOffsets = [];
     leftOffsets.push(outerSpacing - innerSpacing);
     const rightOffsets = [];
-    rightOffsets.push(-Constants.screenWidth + widths[0] + outerSpacing + innerSpacing);
+    rightOffsets.push(-screenWidth + widths[0] + outerSpacing + innerSpacing);
     while (index < itemsCount) {
       /* map animated widths and offsets */
       itemsWidthsAnimated.value[index] = widths[index];
@@ -150,7 +154,7 @@ const useScrollToItem = <T extends ScrollToSupportedViews>(props: ScrollToItemPr
     itemsWidthsAnimated.value = [...itemsWidthsAnimated.value];
     itemsOffsetsAnimated.value = [...itemsOffsetsAnimated.value];
   },
-  [itemsCount, outerSpacing, innerSpacing, addOffsetMargin]);
+  [itemsCount, outerSpacing, innerSpacing, addOffsetMargin, screenWidth]);
 
   const onItemLayout = useCallback((event: LayoutChangeEvent, index: number) => {
     const {width} = event.nativeEvent.layout;

--- a/src/components/tabController2/useScrollToItem.ts
+++ b/src/components/tabController2/useScrollToItem.ts
@@ -184,6 +184,11 @@ const useScrollToItem = <T extends ScrollToSupportedViews>(props: ScrollToItemPr
     }
   }, [selectedIndex, focusIndex]);
 
+  useEffect(() => {
+    focusIndex(currentIndex.current, false);
+    // TODO: This is called the first time as well, can we prevent that? - Is is a real problem?
+  }, [screenWidth]);
+
   return {
     scrollViewRef,
     onItemLayout,

--- a/src/helpers/Constants.ts
+++ b/src/helpers/Constants.ts
@@ -78,10 +78,10 @@ const constants = {
   /* Layout */
   isRTL: I18nManager.isRTL,
   get orientation() {
-    return getOrientation(screenHeight, screenWidth);
+    return getOrientation(windowHeight, windowWidth);
   },
   get isLandscape() {
-    return getOrientation(screenHeight, screenWidth) === orientations.LANDSCAPE;
+    return getOrientation(windowHeight, windowWidth) === orientations.LANDSCAPE;
   },
   get screenWidth() {
     return screenWidth;


### PR DESCRIPTION
## Description
TabController2 - add orientation change support.
Incomplete - mainly need to fix label not moving to the selected item.
**But** I had to change the `key` in `TabBarItem` (`key={`${screenWidth}`}`) so I'm unsure about this.
You should look at each commit separately for easier time.
Last commit is for testing only.

## Changelog
TabController2 - add orientation change support