### PR TITLE
KeyboardTrackingView - change 'useSafeArea' default to 'false'

### DIFF
--- a/lib/components/Keyboard/KeyboardTracking/KeyboardTrackingView/KeyboardTrackingView.ios.tsx
+++ b/lib/components/Keyboard/KeyboardTracking/KeyboardTrackingView/KeyboardTrackingView.ios.tsx
@@ -20,9 +20,8 @@ const KeyboardTrackingViewTempManager = NativeModules.KeyboardTrackingViewTempMa
 class KeyboardTrackingView extends PureComponent<KeyboardTrackingViewProps> {
   static displayName = 'KeyboardTrackingView';
 
-  /** V6 should be change to default false */
   static defaultProps = {
-    useSafeArea: true
+    useSafeArea: false
   };
 
   ref?: any;


### PR DESCRIPTION
## Description
KeyboardTrackingView - change 'useSafeArea' default to 'false'.

## Changelog
KeyboardTrackingView - change 'useSafeArea' default to 'false'.
