### PR TITLE
Dialog remove deprecated prop

### DIFF
--- a/demo/src/screens/componentScreens/ChipScreen.tsx
+++ b/demo/src/screens/componentScreens/ChipScreen.tsx
@@ -72,7 +72,7 @@ export default class ChipScreen extends Component {
     const {showDialog} = this.state;
 
     return (
-      <Dialog migrate visible={showDialog} useSafeArea bottom onDismiss={this.closeDialog}>
+      <Dialog visible={showDialog} useSafeArea bottom onDismiss={this.closeDialog}>
         {this.renderContent()}
       </Dialog>
     );

--- a/demo/src/screens/componentScreens/DialogScreen.js
+++ b/demo/src/screens/componentScreens/DialogScreen.js
@@ -235,7 +235,6 @@ Scroll: ${scroll}`;
 
     return (
       <Dialog
-        migrate
         useSafeArea
         key={this.getDialogKey(height)}
         top={position === 'top'}

--- a/demo/src/screens/componentScreens/PickerScreen.js
+++ b/demo/src/screens/componentScreens/PickerScreen.js
@@ -57,7 +57,6 @@ export default class PickerScreen extends Component {
 
     return (
       <Dialog
-        migrate
         visible={visible}
         onDismiss={() => {
           onDone();

--- a/generatedTypes/src/components/actionSheet/index.d.ts
+++ b/generatedTypes/src/components/actionSheet/index.d.ts
@@ -66,7 +66,7 @@ declare type ActionSheetProps = {
     /**
      * Called once the modal has been dismissed (iOS only, modal only)
      */
-    onModalDismissed?: DialogProps['onModalDismissed'];
+    onModalDismissed?: DialogProps['onDialogDismissed'];
     /**
      * Whether or not to handle SafeArea
      */

--- a/generatedTypes/src/components/dialog/index.d.ts
+++ b/generatedTypes/src/components/dialog/index.d.ts
@@ -40,10 +40,6 @@ export interface DialogProps extends AlignmentModifiers, RNPartialProps {
      */
     useSafeArea?: boolean;
     /**
-     * Called once the modal has been dismissed (iOS only) - Deprecated, use onDialogDismissed instead
-     */
-    onModalDismissed?: (props: any) => void;
-    /**
      * Called once the dialog has been dismissed completely
      */
     onDialogDismissed?: (props: any) => void;

--- a/src/components/actionSheet/index.tsx
+++ b/src/components/actionSheet/index.tsx
@@ -13,8 +13,8 @@ import Image from '../image';
 import ListItem from '../listItem';
 import PanningProvider from '../panningViews/panningProvider';
 
-const VERTICAL_PADDING = 8;
 
+const VERTICAL_PADDING = 8;
 type ActionSheetOnOptionPress = (index: number) => void;
 
 type ActionSheetProps = {
@@ -84,7 +84,7 @@ type ActionSheetProps = {
   /**
    * Called once the modal has been dismissed (iOS only, modal only)
    */
-  onModalDismissed?: DialogProps['onModalDismissed'];
+  onModalDismissed?: DialogProps['onDialogDismissed'];
   /**
    * Whether or not to handle SafeArea
    */
@@ -233,7 +233,7 @@ class ActionSheet extends Component<ActionSheetProps> {
         containerStyle={[styles.dialog, dialogStyle]}
         visible={visible}
         onDismiss={onDismiss}
-        onModalDismissed={onModalDismissed}
+        onDialogDismissed={onModalDismissed}
         panDirection={PanningProvider.Directions.DOWN}
       >
         {this.renderSheet()}

--- a/src/components/dateTimePicker/index.js
+++ b/src/components/dateTimePicker/index.js
@@ -205,7 +205,6 @@ class DateTimePicker extends Component {
 
     return (
       <Dialog
-        migrate
         visible={showExpandableOverlay}
         width="100%"
         height={null}

--- a/src/components/dialog/index.tsx
+++ b/src/components/dialog/index.tsx
@@ -5,7 +5,6 @@ import {Colors} from '../../style';
 import Constants, {orientations} from '../../helpers/Constants';
 import {AlignmentModifiers, extractAlignmentsValues} from '../../commons/modifiers';
 import {asBaseComponent} from '../../commons/new';
-import {LogService} from '../../services';
 import Modal from '../modal';
 import View from '../view';
 import PanListenerView from '../panningViews/panListenerView';
@@ -58,10 +57,6 @@ export interface DialogProps extends AlignmentModifiers, RNPartialProps {
      * Whether or not to handle SafeArea
      */
     useSafeArea?: boolean;
-    /**
-     * Called once the modal has been dismissed (iOS only) - Deprecated, use onDialogDismissed instead
-     */
-    onModalDismissed?: (props: any) => void;
     /**
      * Called once the dialog has been dismissed completely
      */
@@ -125,10 +120,6 @@ class Dialog extends Component<DialogProps, DialogState> {
 
     this.styles = createStyles(this.props);
     this.setAlignment();
-
-    if (!_.isUndefined(props.onModalDismissed)) {
-      LogService.deprecationWarn({component: 'Dialog', oldProp: 'onModalDismissed', newProp: 'onDialogDismissed'});
-    }
   }
 
   componentDidMount() {
@@ -171,7 +162,6 @@ class Dialog extends Component<DialogProps, DialogState> {
     if (!this.state.modalVisibility) {
       setTimeout(() => { // unfortunately this is needed if a modal needs to open on iOS
         this.props.onDialogDismissed?.(this.props);
-        this.props.onModalDismissed?.(this.props);
       }, 100);
     }
   }
@@ -198,11 +188,6 @@ class Dialog extends Component<DialogProps, DialogState> {
       this._onDismiss();
     }
   };
-
-  onModalDismissed = () => {
-    this.props.onDialogDismissed?.(this.props);
-    this.props.onModalDismissed?.(this.props);
-  }
 
   hideDialogView = () => {
     this.setState({dialogVisibility: false});
@@ -290,7 +275,6 @@ class Dialog extends Component<DialogProps, DialogState> {
         animationType={'none'}
         onBackgroundPress={onBackgroundPress}
         onRequestClose={onBackgroundPress}
-        // onDismiss={this.onModalDismissed}
         supportedOrientations={supportedOrientations}
         accessibilityLabel={accessibilityLabel}
       >

--- a/src/components/picker/PickerDialog.android.js
+++ b/src/components/picker/PickerDialog.android.js
@@ -67,7 +67,7 @@ class PickerDialog extends BaseComponent {
     // TODO: should be taken from dialogProps but there's an issue with "babel-plugin-typescript-to-proptypes" plugin
     const {panDirection} = this.props;
     return (
-      <Dialog {...dialogProps} migrate height="50%" width="77%" panDirection={panDirection}>
+      <Dialog {...dialogProps} height="50%" width="77%" panDirection={panDirection}>
         <View style={styles.dialog}>
           {this.renderHeader()}
           <View flex center paddingH-24>

--- a/src/components/picker/PickerDialog.ios.js
+++ b/src/components/picker/PickerDialog.ios.js
@@ -42,7 +42,7 @@ class PickerDialog extends BaseComponent {
     // TODO: should be taken from dialogProps but there's an issue with "babel-plugin-typescript-to-proptypes" plugin
     const {panDirection} = this.props;
     return (
-      <Dialog {...dialogProps} width="100%" migrate bottom animationConfig={{duration: 300}} panDirection={panDirection}>
+      <Dialog {...dialogProps} width="100%" bottom animationConfig={{duration: 300}} panDirection={panDirection}>
         <View flex bg-white>
           {this.renderHeader()}
           <View centerV flex>


### PR DESCRIPTION
## Description
Dialog - remove 'onModalDismissed' (use 'onDialogDismissed' instead).

## Changelog
Dialog - remove 'onModalDismissed' (use 'onDialogDismissed' instead).
