### PR TITLE
Fix support for setting color scheme manually 

### DIFF
--- a/demo/src/configurations.js
+++ b/demo/src/configurations.js
@@ -36,7 +36,7 @@ Spacings.loadSpacings({
 /* Dark Mode Schemes */
 Colors.loadSchemes({
   light: {
-    screenBG: 'transparent',
+    screenBG: Colors.white,
     textColor: Colors.grey10,
     moonOrSun: Colors.yellow30,
     mountainForeground: Colors.green30,

--- a/demo/src/screens/foundationScreens/DarkModeScreen.tsx
+++ b/demo/src/screens/foundationScreens/DarkModeScreen.tsx
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import {StyleSheet} from 'react-native';
-import {View, Text, Colors, Constants, SegmentedControl, SegmentedControlItemProps} from 'react-native-ui-lib';
+import {View, Text, Colors, Constants, SegmentedControl, SchemeType} from 'react-native-ui-lib';
 
 const SCHEME_TYPES = [
   {label: 'device (default)', value: 'default'},
@@ -20,7 +20,7 @@ class DarkModeScreen extends Component {
 
   changeSchemeType = (index: number) => {
     this.setState({selectedSchemeType: SCHEME_TYPES[index].value});
-    Colors.setScheme(SCHEME_TYPES[index].value);
+    Colors.setScheme(SCHEME_TYPES[index].value as SchemeType);
   };
 
   render() {

--- a/demo/src/screens/foundationScreens/DarkModeScreen.tsx
+++ b/demo/src/screens/foundationScreens/DarkModeScreen.tsx
@@ -2,7 +2,7 @@ import React, {Component} from 'react';
 import {StyleSheet} from 'react-native';
 import {View, Text, Colors, Constants, SegmentedControl, SchemeType} from 'react-native-ui-lib';
 
-const SCHEME_TYPES = [
+const SCHEME_TYPES: {label: string; value: SchemeType}[] = [
   {label: 'device (default)', value: 'default'},
   {label: 'dark', value: 'dark'},
   {label: 'light', value: 'light'}
@@ -20,7 +20,7 @@ class DarkModeScreen extends Component {
 
   changeSchemeType = (index: number) => {
     this.setState({selectedSchemeType: SCHEME_TYPES[index].value});
-    Colors.setScheme(SCHEME_TYPES[index].value as SchemeType);
+    Colors.setScheme(SCHEME_TYPES[index].value);
   };
 
   render() {

--- a/demo/src/screens/foundationScreens/DarkModeScreen.tsx
+++ b/demo/src/screens/foundationScreens/DarkModeScreen.tsx
@@ -1,22 +1,46 @@
 import React, {Component} from 'react';
 import {StyleSheet} from 'react-native';
-import {View, Text, Constants} from 'react-native-ui-lib';
+import {View, Text, Colors, Constants, SegmentedControl, SegmentedControlItemProps} from 'react-native-ui-lib';
+
+const SCHEME_TYPES = [
+  {label: 'device (default)', value: 'default'},
+  {label: 'dark', value: 'dark'},
+  {label: 'light', value: 'light'}
+];
+
+const DEVICE_DARK_MODE_MESSAGE = Constants.isIOS
+  ? 'Change to dark mode in simulator by pressing Cmd+Shift+A'
+  : 'Change to dark mode';
+const MANUAL_DARK_MODE_MESSAGE = 'Setting the scheme manually will ignore device settings';
 
 class DarkModeScreen extends Component {
-  state = {};
+  state = {
+    selectedSchemeType: 'default'
+  };
+
+  changeSchemeType = (index: number) => {
+    this.setState({selectedSchemeType: SCHEME_TYPES[index].value});
+    Colors.setScheme(SCHEME_TYPES[index].value);
+  };
+
   render() {
+    const {selectedSchemeType} = this.state;
+    const message = selectedSchemeType === 'default' ? DEVICE_DARK_MODE_MESSAGE : MANUAL_DARK_MODE_MESSAGE;
+
     return (
       <View flex padding-page bg-screenBG>
         <Text h1 textColor>
           Dark Mode
         </Text>
-        {Constants.isIOS ? (
-          <Text marginT-s2 body textColor>
-            Change to dark mode in simulator by pressing Cmd+Shift+A
-          </Text>
-        ) : (
-          <Text marginT-s2 body textColor>Change to dark mode</Text>
-        )}
+        <SegmentedControl
+          containerStyle={{alignSelf: 'flex-start', marginTop: 20}}
+          segments={SCHEME_TYPES}
+          onChangeIndex={this.changeSchemeType}
+        />
+
+        <Text marginT-s2 body textColor>
+          {message}
+        </Text>
 
         <View style={styles.moonOrSun} bg-moonOrSun/>
         <View style={[styles.mountain, styles.mountainBackground]} bg-mountainBackground/>

--- a/generatedTypes/src/components/connectionStatusBar/index.d.ts
+++ b/generatedTypes/src/components/connectionStatusBar/index.d.ts
@@ -30,12 +30,6 @@ declare class ConnectionStatusBar extends PureComponent<ConnectionStatusBarProps
 }
 export { ConnectionStatusBar };
 declare const _default: React.ComponentClass<ConnectionStatusBarProps & {
-    /**
-     * @description: Top bar to show a "no internet" connection status. Note: Run on real device for best results
-     * @image: https://user-images.githubusercontent.com/33805983/34683190-f3b1904c-f4a9-11e7-9d46-9a340bd35448.png, https://user-images.githubusercontent.com/33805983/34484206-edc6c6e4-efcb-11e7-88b2-cd394c19dd5e.png
-     * @example: https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/ConnectionStatusBarScreen.tsx
-     * @notes: The component requires installing the '@react-native-community/netinfo' native library
-     */
     useCustomTheme?: boolean | undefined;
 }, any> & typeof ConnectionStatusBar;
 export default _default;

--- a/generatedTypes/src/style/colors.d.ts
+++ b/generatedTypes/src/style/colors.d.ts
@@ -1,18 +1,8 @@
 import _ from 'lodash';
 import tinycolor from 'tinycolor2';
-declare type Schemes = {
-    light: {
-        [key: string]: string;
-    };
-    dark: {
-        [key: string]: string;
-    };
-};
-declare type SchemeType = 'default' | 'light' | 'dark';
+import { Schemes, SchemeType } from './scheme';
 export declare class Colors {
     [key: string]: any;
-    schemes: Schemes;
-    currentScheme: SchemeType;
     constructor();
     /**
      * Load custom set of colors
@@ -107,6 +97,9 @@ declare const colorObject: Colors & {
     orange30: string;
     orange40: string;
     orange50: string;
+    /**
+     * Get app's current color scheme
+     */
     orange60: string;
     orange70: string;
     orange80: string;
@@ -120,6 +113,14 @@ declare const colorObject: Colors & {
     red80: string;
     purple10: string;
     purple20: string;
+    /**
+     * Add alpha to hex or rgb color
+     * arguments:
+     * p1 - hex color / R part of RGB
+     * p2 - opacity / G part of RGB
+     * p3 - B part of RGB
+     * p4 - opacity
+     */
     purple30: string;
     purple40: string;
     purple50: string;
@@ -138,11 +139,6 @@ declare const colorObject: Colors & {
     black: string;
     transparent: string;
 } & {
-    /**
-     * Set color scheme for app
-     * arguments:
-     * scheme - color scheme e.g light/dark/default
-     */
     primary: string;
 };
 export default colorObject;

--- a/generatedTypes/src/style/index.d.ts
+++ b/generatedTypes/src/style/index.d.ts
@@ -1,4 +1,5 @@
 export { default as Colors } from './colors';
+export { default as Scheme, SchemeType, Schemes, SchemeChangeListener } from './scheme';
 export { default as Typography } from './typography';
 export { default as BorderRadiuses } from './borderRadiuses';
 export { default as Shadows } from './shadows';

--- a/generatedTypes/src/style/scheme.d.ts
+++ b/generatedTypes/src/style/scheme.d.ts
@@ -1,0 +1,53 @@
+export declare type Schemes = {
+    light: {
+        [key: string]: string;
+    };
+    dark: {
+        [key: string]: string;
+    };
+};
+export declare type SchemeType = 'default' | 'light' | 'dark';
+export declare type SchemeChangeListener = (schemeType?: 'light' | 'dark') => void;
+declare class Scheme {
+    currentScheme: SchemeType;
+    schemes: Schemes;
+    changeListeners: SchemeChangeListener[];
+    constructor();
+    private broadcastSchemeChange;
+    /**
+     * Get app's current color scheme
+     */
+    getSchemeType(): 'light' | 'dark';
+    /**
+     * Set color scheme for app
+     * arguments:
+     * scheme - color scheme e.g light/dark/default
+     */
+    setScheme(scheme: SchemeType): void;
+    /**
+     * Load set of schemes for light/dark mode
+     * arguments:
+     * schemes - two sets of map of colors e.g {light: {screen: 'white'}, dark: {screen: 'black'}}
+     */
+    loadSchemes(schemes: Schemes): void;
+    /**
+     * Retrieve scheme by current scheme type
+     */
+    getScheme(): {
+        [key: string]: string;
+    } | {
+        [key: string]: string;
+    };
+    /**
+     * Add a change scheme event listener
+     */
+    addChangeListener(listener: SchemeChangeListener): void;
+    /**
+     * Remove a change scheme event listener
+     * arguments:
+     * listener - listener reference to remove
+     */
+    removeChangeListener(listener: SchemeChangeListener): void;
+}
+declare const _default: Scheme;
+export default _default;

--- a/src/commons/asBaseComponent.tsx
+++ b/src/commons/asBaseComponent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import {Appearance, EventSubscription} from 'react-native';
 import hoistStatics from 'hoist-non-react-statics';
 import * as Modifiers from './modifiers';
+import {Scheme} from '../style';
 import forwardRef from './forwardRef';
 import UIComponent from './UIComponent';
 
@@ -27,32 +27,19 @@ function asBaseComponent<PROPS, STATICS = {}>(WrappedComponent: React.ComponentT
       error: false
     };
 
-    appearanceListenerSubscription?: EventSubscription = undefined;
-
     componentDidMount() {
-      // <  RN64 - void
-      // >= RN65 - EventSubscription
-      const subscription = Appearance.addChangeListener(this.appearanceListener);
-      if (subscription !== undefined) {
-        // @ts-ignore
-        this.appearanceListenerSubscription = subscription;
-      }
+      Scheme.addChangeListener(this.appearanceListener);
     }
 
     componentWillUnmount() {
-      if (this.appearanceListenerSubscription) {
-        // >=RN65
-        this.appearanceListenerSubscription?.remove();
-      } else {
-        // <RN65
-        Appearance.removeChangeListener(this.appearanceListener);
-      }
+      Scheme.removeChangeListener(this.appearanceListener);
     }
 
-    appearanceListener: Appearance.AppearanceListener = () => {
+    appearanceListener = () => {
       // iOS 13 and above will trigger this call with the wrong colorScheme value. So just ignore returned colorScheme for now
       // https://github.com/facebook/react-native/issues/28525
-      this.setState({colorScheme: Appearance.getColorScheme()});
+      // this.setState({colorScheme: Appearance.getColorScheme()});
+      this.setState({colorScheme: Scheme.getSchemeType()});
     };
 
     static getThemeProps = (props: any, context: any) => {

--- a/src/commons/modifiers.ts
+++ b/src/commons/modifiers.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import {StyleSheet} from 'react-native';
-import {Typography, Colors, BorderRadiuses, Spacings, ThemeManager} from '../style';
+import {Typography, Colors, Scheme, BorderRadiuses, Spacings, ThemeManager} from '../style';
 import {BorderRadiusesLiterals} from '../style/borderRadiuses';
 import TypographyPresets from '../style/typographyPresets';
 import {SpacingLiterals} from '../style/spacings';
@@ -58,7 +58,6 @@ const STYLE_KEY_CONVERTERS = {
   flexS: 'flexShrink'
 } as const;
 
-
 export type PaddingLiterals = keyof typeof PADDING_VARIATIONS;
 export type NativePaddingKeyType = typeof PADDING_VARIATIONS[PaddingLiterals];
 export type MarginLiterals = keyof typeof MARGIN_VARIATIONS;
@@ -69,12 +68,18 @@ export type ColorLiterals = keyof typeof colorsPalette;
 export type TypographyLiterals = keyof typeof TypographyPresets;
 export type BorderRadiusLiterals = keyof typeof BorderRadiusesLiterals;
 export type AlignmentLiterals =
-| 'row' | 'spread'
-| 'center' | 'centerH' | 'centerV'
-| 'left' | 'right' | 'top' | 'bottom';
+  | 'row'
+  | 'spread'
+  | 'center'
+  | 'centerH'
+  | 'centerV'
+  | 'left'
+  | 'right'
+  | 'top'
+  | 'bottom';
 export type PositionLiterals = 'absF' | 'absL' | 'absR' | 'absT' | 'absB' | 'absV' | 'absH';
 
-export type Modifier<T extends string> = Partial<Record<T, boolean>>
+export type Modifier<T extends string> = Partial<Record<T, boolean>>;
 export type CustomModifier = {[key: string]: boolean};
 
 export type TypographyModifiers = Modifier<TypographyLiterals> | CustomModifier;
@@ -87,8 +92,7 @@ export type MarginModifiers = Modifier<MarginLiterals>;
 export type FlexModifiers = Modifier<FlexLiterals>;
 export type BorderRadiusModifiers = Modifier<BorderRadiusLiterals>;
 
-export type ContainerModifiers =
-  AlignmentModifiers &
+export type ContainerModifiers = AlignmentModifiers &
   PositionModifiers &
   PaddingModifiers &
   MarginModifiers &
@@ -97,8 +101,7 @@ export type ContainerModifiers =
   BackgroundColorModifier;
 
 export function extractColorValue(props: Dictionary<any>) {
-  const scheme = Colors.getScheme();
-  const schemeColors = Colors.schemes[scheme];
+  const schemeColors = Scheme.getScheme();
   const allColorsKeys: Array<keyof typeof Colors> = [..._.keys(Colors), ..._.keys(schemeColors)];
   const colorPropsKeys = _.chain(props)
     .keys()
@@ -110,8 +113,8 @@ export function extractColorValue(props: Dictionary<any>) {
 
 export function extractBackgroundColorValue(props: Dictionary<any>) {
   let backgroundColor;
-  const scheme = Colors.getScheme();
-  const schemeColors = Colors.schemes[scheme];
+
+  const schemeColors = Scheme.getScheme();
 
   const keys = Object.keys(props);
   const bgProp = _.findLast(keys, prop => Colors.getBackgroundKeysPattern().test(prop) && !!props[prop])!;
@@ -243,7 +246,7 @@ export function extractPositionStyle(props: Dictionary<any>) {
     }
     style = {...style, ...styles.absolute};
   });
-    
+
   return _.isEmpty(style) ? undefined : style;
 }
 
@@ -366,8 +369,8 @@ export function generateModifiersStyle(options = {
   alignments: true,
   flex: true,
   position: true
-}, props: Dictionary<any>) {
-
+},
+props: Dictionary<any>) {
   //@ts-ignore
   const boundProps = props || this.props;
   const style: ExtractedStyle = {};

--- a/src/style/__tests__/scheme.spec.js
+++ b/src/style/__tests__/scheme.spec.js
@@ -1,0 +1,94 @@
+let Scheme;
+describe('Scheme', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    Scheme = require('../scheme').default;
+  });
+
+  describe('initial values', () => {
+    it('should initial schemes be empty objects', () => {
+      expect(Scheme.schemes).toEqual({dark: {}, light: {}});
+    });
+
+    it('should initial current scheme type be "default"', () => {
+      expect(Scheme.currentScheme).toBe('default');
+    });
+
+    it('should retrieve actual scheme type (defaulting to "light")', () => {
+      expect(Scheme.getSchemeType()).toBe('light');
+    });
+  });
+
+  describe('setScheme', () => {
+    it('should initially be light', () => {
+      expect(Scheme.getSchemeType()).toBe('light');
+    });
+    it('should override default scheme', () => {
+      Scheme.setScheme('dark');
+      expect(Scheme.getSchemeType()).toBe('dark');
+    });
+
+    it('should throw on invalid scheme color', () => {
+      expect(() => Scheme.setScheme('yellow')).toThrow(`yellow is invalid colorScheme, please use 'light' | 'dark' | 'default'`);
+    });
+  });
+
+  describe('getScheme/loadScheme', () => {
+    beforeEach(() => {
+      Scheme.loadSchemes({
+        dark: {
+          a: 'black',
+          b: 'black'
+        },
+        light: {
+          a: 'white',
+          b: 'white'
+        }
+      });
+    });
+
+    it('should return scheme by current scheme type (initially by light)', () => {
+      expect(Scheme.getScheme()).toEqual({
+        a: 'white',
+        b: 'white'
+      });
+    });
+
+    it('should return correct scheme after setScheme has changed scheme type', () => {
+      Scheme.setScheme('dark');
+      expect(Scheme.getScheme()).toEqual({
+        a: 'black',
+        b: 'black'
+      });
+    });
+  });
+
+  describe('scheme change listeners', () => {
+    it('should register scheme change listener', () => {
+      const listener = jest.fn();
+      Scheme.addSchemeChangeListener(listener);
+      expect(listener).not.toHaveBeenCalled();
+      Scheme.setScheme('dark');
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('should unregister scheme change listener', () => {
+      const listener = jest.fn();
+      Scheme.addSchemeChangeListener(listener);
+      Scheme.setScheme('dark');
+      expect(listener).toHaveBeenCalledTimes(1);
+      Scheme.removeSchemeChangeListener(listener);
+      Scheme.setScheme('light');
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not be triggered if scheme set to the same type', () => {
+      const listener = jest.fn();
+      Scheme.addSchemeChangeListener(listener);
+      Scheme.setScheme('dark');
+      expect(listener).toHaveBeenCalledTimes(1);
+      Scheme.setScheme('dark');
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/style/__tests__/scheme.spec.js
+++ b/src/style/__tests__/scheme.spec.js
@@ -61,6 +61,20 @@ describe('Scheme', () => {
         b: 'black'
       });
     });
+
+    it('should throw on missing color keys', () => {
+      expect(() => Scheme.loadSchemes({
+        dark: {
+          a: 'black',
+          b: 'black'
+        },
+        light: {
+          a: 'white',
+          b: 'white',
+          c: 'white'
+        }
+      })).toThrow(`There is a mismatch in scheme keys: c`);
+    });
   });
 
   describe('scheme change listeners', () => {

--- a/src/style/__tests__/scheme.spec.js
+++ b/src/style/__tests__/scheme.spec.js
@@ -66,7 +66,7 @@ describe('Scheme', () => {
   describe('scheme change listeners', () => {
     it('should register scheme change listener', () => {
       const listener = jest.fn();
-      Scheme.addSchemeChangeListener(listener);
+      Scheme.addChangeListener(listener);
       expect(listener).not.toHaveBeenCalled();
       Scheme.setScheme('dark');
       expect(listener).toHaveBeenCalledTimes(1);
@@ -74,17 +74,17 @@ describe('Scheme', () => {
 
     it('should unregister scheme change listener', () => {
       const listener = jest.fn();
-      Scheme.addSchemeChangeListener(listener);
+      Scheme.addChangeListener(listener);
       Scheme.setScheme('dark');
       expect(listener).toHaveBeenCalledTimes(1);
-      Scheme.removeSchemeChangeListener(listener);
+      Scheme.removeChangeListener(listener);
       Scheme.setScheme('light');
       expect(listener).toHaveBeenCalledTimes(1);
     });
 
     it('should not be triggered if scheme set to the same type', () => {
       const listener = jest.fn();
-      Scheme.addSchemeChangeListener(listener);
+      Scheme.addChangeListener(listener);
       Scheme.setScheme('dark');
       expect(listener).toHaveBeenCalledTimes(1);
       Scheme.setScheme('dark');

--- a/src/style/colors.ts
+++ b/src/style/colors.ts
@@ -1,4 +1,3 @@
-import {Appearance} from 'react-native';
 import _ from 'lodash';
 //@ts-ignore
 import Color from 'color';
@@ -6,23 +5,17 @@ import tinycolor from 'tinycolor2';
 import {colorsPalette, themeColors} from './colorsPalette';
 //@ts-ignore
 import ColorName from './colorName';
-
-type Schemes = {light: {[key: string]: string}; dark: {[key: string]: string}};
-type SchemeType = 'default' | 'light' | 'dark'
+import Scheme, {Schemes, SchemeType} from './scheme';
 
 export class Colors {
   [key: string]: any;
-  schemes: Schemes = {light: {}, dark: {}};
-  currentScheme: SchemeType = 'default';
 
   constructor() {
     const colors = Object.assign(colorsPalette, themeColors);
     Object.assign(this, colors);
 
-    Appearance.addChangeListener(() => {
-      if (this.currentScheme === 'default') {
-        Object.assign(this, this.schemes[Appearance.getColorScheme() ?? 'light']);
-      }
+    Scheme.addChangeListener(() => {
+      Object.assign(this, this.getScheme());
     });
   }
   /**
@@ -41,25 +34,15 @@ export class Colors {
    * schemes - two sets of map of colors e.g {light: {screen: 'white'}, dark: {screen: 'black'}}
    */
   loadSchemes(schemes: Schemes) {
-    const lightSchemeKeys = Object.keys(schemes.light);
-    const darkSchemeKeys = Object.keys(schemes.dark);
-
-    const missingKeys = _.xor(lightSchemeKeys, darkSchemeKeys);
-    if (!_.isEmpty(missingKeys)) {
-      console.error(`There is a mismatch in scheme keys: ${missingKeys.join(', ')}`);
-    }
-
-    this.schemes = schemes;
-    const colorScheme = this.getScheme();
-    Object.assign(this, this.schemes[colorScheme]);
+    Scheme.loadSchemes(schemes);
+    Object.assign(this, this.getScheme());
   }
 
   /**
    * Get app's current color scheme
    */
   getScheme(): 'light' | 'dark' {
-    const scheme = this.currentScheme === 'default' ? Appearance.getColorScheme() : this.currentScheme;
-    return scheme ?? 'light';
+    return Scheme.getSchemeType();
   }
 
   /**
@@ -68,12 +51,7 @@ export class Colors {
    * scheme - color scheme e.g light/dark/default
    */
   setScheme(scheme: SchemeType) {
-    if (!['light', 'dark', 'default'].includes(scheme)) {
-      throw new Error(`${scheme} is invalid colorScheme, please use 'light' | 'dark' | 'default'`);
-    }
-    this.currentScheme = scheme;
-    const colorScheme = this.getScheme();
-    Object.assign(this, this.schemes[colorScheme]);
+    Scheme.setScheme(scheme);
   }
 
   /**

--- a/src/style/index.ts
+++ b/src/style/index.ts
@@ -1,5 +1,5 @@
-
 export {default as Colors} from './colors';
+export {default as Scheme, SchemeType, Schemes, SchemeChangeListener} from './scheme';
 export {default as Typography} from './typography';
 export {default as BorderRadiuses} from './borderRadiuses';
 export {default as Shadows} from './shadows';

--- a/src/style/scheme.ts
+++ b/src/style/scheme.ts
@@ -13,9 +13,13 @@ class Scheme {
   constructor() {
     Appearance.addChangeListener(() => {
       if (this.currentScheme === 'default') {
-        Object.assign(this, this.schemes[Appearance.getColorScheme() ?? 'light']);
+        this.broadcastSchemeChange();
       }
     });
+  }
+
+  private broadcastSchemeChange() {
+    this.changeListeners.forEach(listener => listener(this.getSchemeType()));
   }
 
   /**
@@ -39,7 +43,7 @@ class Scheme {
     this.currentScheme = scheme;
 
     if (prevSchemeType !== this.getSchemeType()) {
-      this.changeListeners.forEach(listener => listener(this.getSchemeType()));
+      this.broadcastSchemeChange();
     }
   }
 

--- a/src/style/scheme.ts
+++ b/src/style/scheme.ts
@@ -1,9 +1,9 @@
 import {Appearance} from 'react-native';
 import {remove, xor, isEmpty} from 'lodash';
 
-type Schemes = {light: {[key: string]: string}; dark: {[key: string]: string}};
-type SchemeType = 'default' | 'light' | 'dark';
-type SchemeChangeListener = (schemeType?: 'light' | 'dark') => void;
+export type Schemes = {light: {[key: string]: string}; dark: {[key: string]: string}};
+export type SchemeType = 'default' | 'light' | 'dark';
+export type SchemeChangeListener = (schemeType?: 'light' | 'dark') => void;
 
 class Scheme {
   currentScheme: SchemeType = 'default';
@@ -70,7 +70,7 @@ class Scheme {
   /**
    * Add a change scheme event listener
    */
-  addSchemeChangeListener(listener: SchemeChangeListener) {
+  addChangeListener(listener: SchemeChangeListener) {
     this.changeListeners.push(listener);
   }
 
@@ -79,7 +79,7 @@ class Scheme {
    * arguments:
    * listener - listener reference to remove
    */
-  removeSchemeChangeListener(listener: SchemeChangeListener) {
+  removeChangeListener(listener: SchemeChangeListener) {
     remove(this.changeListeners, changeListener => changeListener === listener);
   }
 }

--- a/src/style/scheme.ts
+++ b/src/style/scheme.ts
@@ -1,0 +1,87 @@
+import {Appearance} from 'react-native';
+import {remove, xor, isEmpty} from 'lodash';
+
+type Schemes = {light: {[key: string]: string}; dark: {[key: string]: string}};
+type SchemeType = 'default' | 'light' | 'dark';
+type SchemeChangeListener = (schemeType?: 'light' | 'dark') => void;
+
+class Scheme {
+  currentScheme: SchemeType = 'default';
+  schemes: Schemes = {light: {}, dark: {}};
+  changeListeners: SchemeChangeListener[] = [];
+
+  constructor() {
+    Appearance.addChangeListener(() => {
+      if (this.currentScheme === 'default') {
+        Object.assign(this, this.schemes[Appearance.getColorScheme() ?? 'light']);
+      }
+    });
+  }
+
+  /**
+   * Get app's current color scheme
+   */
+  getSchemeType(): 'light' | 'dark' {
+    const scheme = this.currentScheme === 'default' ? Appearance.getColorScheme() : this.currentScheme;
+    return scheme ?? 'light';
+  }
+
+  /**
+   * Set color scheme for app
+   * arguments:
+   * scheme - color scheme e.g light/dark/default
+   */
+  setScheme(scheme: SchemeType) {
+    const prevSchemeType = this.getSchemeType();
+    if (!['light', 'dark', 'default'].includes(scheme)) {
+      throw new Error(`${scheme} is invalid colorScheme, please use 'light' | 'dark' | 'default'`);
+    }
+    this.currentScheme = scheme;
+
+    if (prevSchemeType !== this.getSchemeType()) {
+      this.changeListeners.forEach(listener => listener(this.getSchemeType()));
+    }
+  }
+
+  /**
+   * Load set of schemes for light/dark mode
+   * arguments:
+   * schemes - two sets of map of colors e.g {light: {screen: 'white'}, dark: {screen: 'black'}}
+   */
+  loadSchemes(schemes: Schemes) {
+    const lightSchemeKeys = Object.keys(schemes.light);
+    const darkSchemeKeys = Object.keys(schemes.dark);
+
+    const missingKeys = xor(lightSchemeKeys, darkSchemeKeys);
+    if (!isEmpty(missingKeys)) {
+      console.error(`There is a mismatch in scheme keys: ${missingKeys.join(', ')}`);
+    }
+
+    this.schemes = schemes;
+  }
+
+  /**
+   * Retrieve scheme by current scheme type
+   */
+  getScheme() {
+    return this.schemes[this.getSchemeType()];
+  }
+
+  /**
+   * Add a change scheme event listener
+   */
+  addSchemeChangeListener(listener: SchemeChangeListener) {
+    this.changeListeners.push(listener);
+  }
+
+  /**
+   * Remove a change scheme event listener
+   * arguments:
+   * listener - listener reference to remove
+   */
+  removeSchemeChangeListener(listener: SchemeChangeListener) {
+    remove(this.changeListeners, changeListener => changeListener === listener);
+  }
+}
+
+export default new Scheme();

--- a/src/style/scheme.ts
+++ b/src/style/scheme.ts
@@ -58,7 +58,7 @@ class Scheme {
 
     const missingKeys = xor(lightSchemeKeys, darkSchemeKeys);
     if (!isEmpty(missingKeys)) {
-      console.error(`There is a mismatch in scheme keys: ${missingKeys.join(', ')}`);
+      throw new Error(`There is a mismatch in scheme keys: ${missingKeys.join(', ')}`);
     }
 
     this.schemes = schemes;


### PR DESCRIPTION
## Description
Fix support for setting color scheme manually (Fix #1548)
- Created Scheme class to handle all schemes logic 
- Move relevant logic from Colors class to Scheme class
- Change appearance change registration in asBaseComponent with scheme change registration
- Update DarkModeScreen example to showcase a scenario of manual scheme change

## Changelog
Fix support for setting color scheme manually 