### PR TITLE
Infra/ migrate SegmentedControl to reanimated v2

### DIFF
--- a/generatedTypes/src/components/segmentedControl/index.d.ts
+++ b/generatedTypes/src/components/segmentedControl/index.d.ts
@@ -48,6 +48,10 @@ export declare type SegmentedControlProps = {
      */
     iconOnRight?: boolean;
     /**
+     * Disable the trailing delay when changing index
+     */
+    disableThrottle?: boolean;
+    /**
      * Additional spacing styles for the container
      */
     containerStyle?: StyleProp<ViewStyle>;

--- a/generatedTypes/src/components/segmentedControl/segment.d.ts
+++ b/generatedTypes/src/components/segmentedControl/segment.d.ts
@@ -34,7 +34,7 @@ export declare type SegmentProps = SegmentedControlItemProps & {
     /**
      * Callback for when segment has pressed.
      */
-    onPress: (index: number) => void;
+    onPress?: (index: number) => void;
     /**
      * The index of the segment.
      */
@@ -61,7 +61,7 @@ declare const _default: React.ComponentClass<SegmentedControlItemProps & {
     /**
      * Callback for when segment has pressed.
      */
-    onPress: (index: number) => void;
+    onPress?: ((index: number) => void) | undefined;
     /**
      * The index of the segment.
      */

--- a/src/components/segmentedControl/segment.tsx
+++ b/src/components/segmentedControl/segment.tsx
@@ -41,7 +41,7 @@ export type SegmentProps = SegmentedControlItemProps & {
   /**
    * Callback for when segment has pressed.
    */
-  onPress: (index: number) => void;
+  onPress?: (index: number) => void;
   /**
    * The index of the segment.
    */
@@ -81,7 +81,7 @@ const Segment = React.memo((props: SegmentProps) => {
   }, [iconSource, segmentedColor, iconStyle]);
 
   const onSegmentPress = useCallback(() => {
-    onPress(index);
+    onPress?.(index);
   }, [index, onPress]);
 
   const segmentOnLayout = useCallback((event: LayoutChangeEvent) => {


### PR DESCRIPTION
## Description
- Migrate SegmentedControl to reanimated v2
- Add a `disableThrottle` prop to allow disabling the trailing delay when changing the index. (resolves https://github.com/wix/react-native-ui-lib/issues/1526)

## Changelog
Migrate SegmentedControl to reanimated v2 and add a `disableThrottle` prop