### PR TITLE
Add overlayBackground and able to change search Icon.

### DIFF
--- a/src/components/picker/PickerModal.js
+++ b/src/components/picker/PickerModal.js
@@ -21,12 +21,14 @@ class PickerModal extends BaseComponent {
     searchStyle: PropTypes.shape({
       color: PropTypes.string,
       placeholderTextColor: PropTypes.string,
-      selectionColor: PropTypes.string
+      selectionColor: PropTypes.string,
+      icon: PropTypes.object
     }),
     searchPlaceholder: PropTypes.string,
     onSearchChange: PropTypes.func,
     renderCustomSearch: PropTypes.elementType,
-    listProps: PropTypes.object
+    listProps: PropTypes.object,
+    overlayBackgroundColor: PropTypes.string
   };
 
   static defaultProps = {
@@ -55,7 +57,7 @@ class PickerModal extends BaseComponent {
 
       return (
         <View style={this.styles.searchInputContainer}>
-          <Image style={this.styles.searchIcon} source={Assets.icons.search}/>
+          <Image style={this.styles.searchIcon} source={searchStyle.icon || Assets.icons.search}/>
           <TextInput
             testID={testID}
             ref={r => (this.search = r)}
@@ -78,7 +80,7 @@ class PickerModal extends BaseComponent {
   };
 
   render() {
-    const {visible, enableModalBlur, topBarProps, listProps, children, onShow} = this.props;
+    const {visible, enableModalBlur, topBarProps, listProps, children, onShow, overlayBackgroundColor} = this.props;
     return (
       <Modal
         animationType={'slide'}
@@ -87,6 +89,7 @@ class PickerModal extends BaseComponent {
         visible={visible}
         onRequestClose={topBarProps.onCancel}
         onShow={onShow}
+        overlayBackgroundColor={overlayBackgroundColor}
       >
         <Modal.TopBar {...topBarProps}/>
         {this.renderSearchInput()}

--- a/src/components/picker/PickerModal.js
+++ b/src/components/picker/PickerModal.js
@@ -89,7 +89,7 @@ class PickerModal extends BaseComponent {
         visible={visible}
         onRequestClose={topBarProps.onCancel}
         onShow={onShow}
-        overlayBackgroundColor={pickerModalProps.backgroundColor}
+        {...pickerModalProps}
       >
         <Modal.TopBar {...topBarProps}/>
         {this.renderSearchInput()}

--- a/src/components/picker/PickerModal.js
+++ b/src/components/picker/PickerModal.js
@@ -28,7 +28,7 @@ class PickerModal extends BaseComponent {
     onSearchChange: PropTypes.func,
     renderCustomSearch: PropTypes.elementType,
     listProps: PropTypes.object,
-    overlayBackgroundColor: PropTypes.string
+    pickerModalProps: PropTypes.object
   };
 
   static defaultProps = {
@@ -80,7 +80,7 @@ class PickerModal extends BaseComponent {
   };
 
   render() {
-    const {visible, enableModalBlur, topBarProps, listProps, children, onShow, overlayBackgroundColor} = this.props;
+    const {visible, enableModalBlur, topBarProps, listProps, children, onShow, pickerModalProps} = this.props;
     return (
       <Modal
         animationType={'slide'}
@@ -89,7 +89,7 @@ class PickerModal extends BaseComponent {
         visible={visible}
         onRequestClose={topBarProps.onCancel}
         onShow={onShow}
-        overlayBackgroundColor={overlayBackgroundColor}
+        overlayBackgroundColor={pickerModalProps.backgroundColor}
       >
         <Modal.TopBar {...topBarProps}/>
         {this.renderSearchInput()}

--- a/src/components/picker/index.js
+++ b/src/components/picker/index.js
@@ -146,9 +146,9 @@ class Picker extends Component {
      */
     listProps: PropTypes.object,
     /**
-     * Pass a custom background color to the modal picker.
+     * Pass props to the picker modal
      */
-    overlayBackgroundColor: PropTypes.string
+    pickerModalProps: PropTypes.object
   };
 
   static defaultProps = {
@@ -370,7 +370,7 @@ class Picker extends Component {
       listProps,
       children,
       testID,
-      overlayBackgroundColor
+      pickerModalProps
     } = this.props;
     const {showExpandableModal, selectedItemPosition, value} = this.state;
 
@@ -412,7 +412,7 @@ class Picker extends Component {
           renderCustomSearch={renderCustomSearch}
           listProps={listProps}
           onShow={onShow}
-          overlayBackgroundColor={overlayBackgroundColor}
+          pickerModalProps={pickerModalProps}
         >
           {this.children}
         </PickerModal>

--- a/src/components/picker/index.js
+++ b/src/components/picker/index.js
@@ -144,7 +144,11 @@ class Picker extends Component {
     /**
      * Pass props to the list component that wraps the picker options (allows to control FlatList behavior)
      */
-    listProps: PropTypes.object
+    listProps: PropTypes.object,
+    /**
+     * Pass a custom background color to the modal picker.
+     */
+    overlayBackgroundColor: PropTypes.string
   };
 
   static defaultProps = {
@@ -365,7 +369,8 @@ class Picker extends Component {
       renderCustomModal,
       listProps,
       children,
-      testID
+      testID,
+      overlayBackgroundColor
     } = this.props;
     const {showExpandableModal, selectedItemPosition, value} = this.state;
 
@@ -407,6 +412,7 @@ class Picker extends Component {
           renderCustomSearch={renderCustomSearch}
           listProps={listProps}
           onShow={onShow}
+          overlayBackgroundColor={overlayBackgroundColor}
         >
           {this.children}
         </PickerModal>


### PR DESCRIPTION
## Description
*Able to change the background of the Picker's default modal. To fully support dark mode, I added also the ability to change the search icon.*

## Changelog
* 2 new props; *overlayBackground* and *searchStyle={{(...), icon: ""}}* 
* fixes #1371 