### PR TITLE
Temporarily support string for Badge size

### DIFF
--- a/generatedTypes/src/components/avatar/index.d.ts
+++ b/generatedTypes/src/components/avatar/index.d.ts
@@ -150,7 +150,7 @@ declare class Avatar extends PureComponent<AvatarProps> {
     getRibbonStyle(): StyleProp<ViewStyle>;
     getBadgeBorderWidth: () => any;
     getBadgeColor(): any;
-    getBadgeSize: () => number;
+    getBadgeSize: () => string | number;
     getBadgePosition: () => object;
     renderBadge(): JSX.Element | undefined;
     renderRibbon(): JSX.Element | undefined;

--- a/generatedTypes/src/components/badge/index.d.ts
+++ b/generatedTypes/src/components/badge/index.d.ts
@@ -15,7 +15,7 @@ export declare type BadgeProps = ViewProps & TouchableOpacityProps & {
     /**
      * the badge size
      */
-    size?: number;
+    size?: number | string;
     /**
      * Press handler
      */
@@ -83,7 +83,7 @@ declare class Badge extends PureComponent<BadgeProps> {
         accessibilityRole: string;
         accessibilityLabel: string;
     };
-    get size(): number;
+    get size(): string | number;
     isSmallBadge(): boolean;
     getBadgeSizeStyle(): any;
     getFormattedLabel(): any;
@@ -343,7 +343,7 @@ declare const _default: React.ComponentClass<ViewProps & TouchableOpacityProps &
     /**
      * the badge size
      */
-    size?: number | undefined;
+    size?: string | number | undefined;
     /**
      * Press handler
      */

--- a/src/components/avatar/index.tsx
+++ b/src/components/avatar/index.tsx
@@ -237,6 +237,7 @@ class Avatar extends PureComponent<AvatarProps> {
     const radius = size / 2;
     const x = Math.sqrt(radius ** 2 * 2);
     const y = x - radius;
+    // @ts-expect-error TODO: once badge size will stop supporting string type this should be resolved
     const shift = Math.sqrt(y ** 2 / 2) - (this.getBadgeSize() + this.getBadgeBorderWidth() * 2) / 2;
     const badgeLocation = _.split(_.toLower(badgePosition), '_', 2);
     const badgeAlignment = {position: 'absolute', [badgeLocation[0]]: shift, [badgeLocation[1]]: shift};

--- a/src/components/badge/index.tsx
+++ b/src/components/badge/index.tsx
@@ -37,7 +37,7 @@ export type BadgeProps = ViewProps &
     /**
      * the badge size
      */
-    size?: number;
+    size?: number | string;
     /**
      * Press handler
      */


### PR DESCRIPTION
## Description
Temporarily support string for Badge size
Once we'll migrate our one app users from passing strings, we'll remove this type 

## Changelog
Temporarily support string for Badge size for gradual migration after v6