### PR TITLE
fix typo react-native-gesutre-handler -> react-native-gesture-handler

### DIFF
--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -33,7 +33,7 @@ If you plan on using specific components, see **UILib Packages** above.
 ### Peer Dependencies
 UILIb has mandatory peer dependencies on the following packages:
 - react-native-reanimated (Make sure to follow [Reanimated setup guide](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation))
-- react-native-gesutre-handler
+- react-native-gesture-handler
 
 ### Optional Dependencies
 Some dependencies are optional and required by specific components or features (e.g. Card's blur features requires installing `@react-native-community/blur` package)


### PR DESCRIPTION
## Description
Fix typo on `react-native-ui-lib/getting-started/setup` docs.
