### PR TITLE
Add `color` prop to GradientSlider

### DIFF
--- a/src/components/slider/GradientSlider.tsx
+++ b/src/components/slider/GradientSlider.tsx
@@ -231,6 +231,7 @@ class GradientSlider extends Component<GradientSliderComponentProps, GradientSli
         containerStyle={containerStyle}
         disabled={disabled}
         accessible={accessible}
+        color={this.props.initialColor}
       />
     );
   }


### PR DESCRIPTION
## Description
Addresses Issue #1533.
Added `color={this.props.initialColor}` to `GradientSlider` component.

## Changelog
Component: `GradientSlider`
Prop: color
