### PR TITLE
Dont Merge - Render Hint target clone while hint is visible so user can press

### DIFF
--- a/demo/src/screens/componentScreens/HintsScreen.tsx
+++ b/demo/src/screens/componentScreens/HintsScreen.tsx
@@ -126,7 +126,7 @@ export default class HintsScreen extends Component<HintScreenProps, HintScreenSt
             targetFrame={useTargetFrame ? targetFrame : undefined}
             // borderRadius={BorderRadiuses.br40}
             // edgeMargins={30}
-            // onBackgroundPress={() => this.setState({showHint: !showHint})}
+            onBackgroundPress={useTargetFrame ? undefined : () => this.setState({showHint: !showHint})}
             customContent={
               showCustomContent
                 ? this.renderCustomContent()
@@ -142,7 +142,10 @@ export default class HintsScreen extends Component<HintScreenProps, HintScreenSt
             {!useTargetFrame && (
               <Button
                 label={showHint ? 'Hide' : 'Show'}
-                onPress={() => this.setState({showHint: !showHint})}
+                onPress={() => {
+                  console.warn('pressed button');
+                  this.setState({showHint: !showHint});
+                }}
                 style={{alignSelf: targetPosition}}
                 testID={'Hint.button'}
                 // style={{alignSelf: targetPosition, marginLeft: 30}}

--- a/src/components/hint/index.tsx
+++ b/src/components/hint/index.tsx
@@ -497,7 +497,7 @@ class Hint extends Component<HintProps, HintState> {
   }
 
   renderHintContainer() {
-    const {style, targetFrame, ...others} = this.props;
+    const {style, targetFrame, onBackgroundPress, ...others} = this.props;
     return (
       <>
         <View
@@ -509,7 +509,9 @@ class Hint extends Component<HintProps, HintState> {
         >
           {this.renderHint()}
         </View>
-        {!targetFrame && <View style={[styles.container, this.getContainerPosition()]}>{this.renderChildren()}</View>}
+        {!targetFrame && onBackgroundPress && (
+          <View style={[styles.container, this.getContainerPosition()]}>{this.renderChildren()}</View>
+        )}
       </>
     );
   }

--- a/src/components/hint/index.tsx
+++ b/src/components/hint/index.tsx
@@ -497,17 +497,20 @@ class Hint extends Component<HintProps, HintState> {
   }
 
   renderHintContainer() {
-    const {style, ...others} = this.props;
+    const {style, targetFrame, ...others} = this.props;
     return (
-      <View
-        {...others}
-        // this view must be collapsable, don't pass testID or backgroundColor etc'.
-        collapsable
-        testID={undefined}
-        style={[styles.container, style, this.getContainerPosition()]}
-      >
-        {this.renderHint()}
-      </View>
+      <>
+        <View
+          {...others}
+          // this view must be collapsable, don't pass testID or backgroundColor etc'.
+          collapsable
+          testID={undefined}
+          style={[styles.container, style, this.getContainerPosition()]}
+        >
+          {this.renderHint()}
+        </View>
+        {!targetFrame && <View style={[styles.container, this.getContainerPosition()]}>{this.renderChildren()}</View>}
+      </>
     );
   }
 


### PR DESCRIPTION
## Description
DONT MERGE - ONLY REVIEW 
Render Hint target clone while hint is visible so user can press
WOAUILIB-2177

## Changelog
Fix issue with Hint's target not pressable while Hint is shown (relevant when pressing `onBackgroundPress` prop)