### PR TITLE
Fix/add Scheme to style package

### DIFF
--- a/scripts/buildPackages.js
+++ b/scripts/buildPackages.js
@@ -15,7 +15,8 @@ const packages = [
       'Spacings',
       'BorderRadiuses',
       'Shadows',
-      'ThemeManager'
+      'ThemeManager',
+      'Scheme'
     ]
   },
   {
@@ -26,7 +27,8 @@ const packages = [
       'BorderRadiuses',
       'Shadows',
       'Spacings',
-      'ThemeManager'
+      'ThemeManager',
+      'Scheme'
     ]
   }
 ];


### PR DESCRIPTION
## Description
I got errors when trying to use Scheme, e.g. `import { Scheme } from 'react-native-ui-lib/style'`

```
TypeError: undefined is not an object (evaluating '_style.Scheme.schemes')
```

If I am using this incorrectly let me know but I believe this will fix the issue.

## Changelog
Add `Scheme` to be accessible from the style package