### PR TITLE
Fix/ tabController itemsCount

### DIFF
--- a/src/components/tabController/index.tsx
+++ b/src/components/tabController/index.tsx
@@ -129,7 +129,7 @@ function TabController({
       /* Items */
       items,
       ignoredItems,
-      itemsCount: items.length - ignoredItems.length,
+      itemsCount: items?.length - ignoredItems.length,
       /* Animated Values */
       targetPage,
       currentPage,


### PR DESCRIPTION
## Description
Fix bug when evaluating `items.length` and `items` is undefined.
The bug causes an app crash when trying to get the TextField (old) screen.

## Changelog
TabController - Fix bug when evaluating `items.length` and `items` is undefined