### PR TITLE
Fix Android double press bug after dismissing DateTimePicker dialog

### DIFF
--- a/src/components/dateTimePicker/index.js
+++ b/src/components/dateTimePicker/index.js
@@ -151,6 +151,8 @@ class DateTimePicker extends Component {
       if (Constants.isAndroid) {
         this.onDonePressed();
       }
+    } else if (event.type === 'dismissed' && Constants.isAndroid) {
+      this.toggleExpandableOverlay();
     }
   };
 


### PR DESCRIPTION
## Description
On Android, dismissing the DateTimePicker dialog by clicking Cancel or by clicking on the background overlay will cause a bug whereby you have to press the DateTimePicker input twice into to launch the DateTimePicker dialog again. This is because the expandable overlay is still in the expanded state after dismissing the dialog. This commit fixes this bug by toggling the expandable overlay when the DateTimePicker dialog is dismissed.

## Tests
### Before
https://user-images.githubusercontent.com/1888212/139923766-601be1fe-5447-44fe-a204-e08f5592bf7a.mp4
### After
https://user-images.githubusercontent.com/1888212/139923851-aa70e361-e191-4244-9392-f835971b66e3.mp4

## Changelog
Fix Android double press bug after dismissing DateTimePicker dialog
