### PR TITLE
Feat/text add underline

### DIFF
--- a/demo/src/screens/componentScreens/TextScreen.js
+++ b/demo/src/screens/componentScreens/TextScreen.js
@@ -83,6 +83,15 @@ class TextScreen extends Component {
             <Text text60R highlightString={['dancing', 'da']} highlightStyle={{color: Colors.green30}}>
               Dancing in The Dark
             </Text>
+            <Text text60M marginV-10>
+              + Underline String
+            </Text>
+            <Text text60R highlightString={'danc'} underlineString={'da'}>
+              Dancing in The Dark
+            </Text>
+            <Text text60R highlightString={'danc'} underlineString={'cing'}>
+              Dancing in The Dark
+            </Text>
           </View>
           {this.renderDivider()}
           <View padding-20 centerH>

--- a/generatedTypes/src/components/text/index.d.ts
+++ b/generatedTypes/src/components/text/index.d.ts
@@ -23,6 +23,10 @@ export declare type TextProps = RNTextProps & TypographyModifiers & ColorsModifi
      */
     highlightStyle?: TextStyle;
     /**
+     * Substring to underline
+     */
+    underlineString?: string | string[];
+    /**
      * Use Animated.Text as a container
      */
     animated?: boolean;

--- a/generatedTypes/src/components/text/index.d.ts
+++ b/generatedTypes/src/components/text/index.d.ts
@@ -42,18 +42,6 @@ declare type PropsTypes = BaseComponentInjectedProps & ForwardRefInjectedProps &
 declare class Text extends PureComponent<PropsTypes> {
     static displayName: string;
     private TextContainer;
-    getPartsByHighlight(targetString: string | undefined, highlightString: string | string[]): {
-        string: string;
-        shouldHighlight: boolean;
-    }[];
-    getTextPartsByHighlight(targetString?: string, highlightString?: string): {
-        string: string;
-        shouldHighlight: boolean;
-    }[];
-    getArrayPartsByHighlight(targetString?: string, highlightString?: string[]): {
-        string: string;
-        shouldHighlight: boolean;
-    }[];
     renderText(children: any): any;
     render(): JSX.Element;
 }

--- a/generatedTypes/src/utils/TextUtils.d.ts
+++ b/generatedTypes/src/utils/TextUtils.d.ts
@@ -1,0 +1,13 @@
+declare function getPartsByHighlight(targetString: string | undefined, highlightString: string | string[]): {
+    string: string;
+    shouldHighlight: boolean;
+}[];
+declare function getTextPartsByHighlight(targetString?: string, highlightString?: string): {
+    string: string;
+    shouldHighlight: boolean;
+}[];
+declare function getArrayPartsByHighlight(targetString?: string, highlightString?: string[]): {
+    string: string;
+    shouldHighlight: boolean;
+}[];
+export { getPartsByHighlight, getTextPartsByHighlight, getArrayPartsByHighlight };

--- a/generatedTypes/src/utils/TextUtils.d.ts
+++ b/generatedTypes/src/utils/TextUtils.d.ts
@@ -1,13 +1,8 @@
-declare function getPartsByHighlight(targetString: string | undefined, highlightString: string | string[]): {
+interface TextPart {
     string: string;
-    shouldHighlight: boolean;
-}[];
-declare function getTextPartsByHighlight(targetString?: string, highlightString?: string): {
-    string: string;
-    shouldHighlight: boolean;
-}[];
-declare function getArrayPartsByHighlight(targetString?: string, highlightString?: string[]): {
-    string: string;
-    shouldHighlight: boolean;
-}[];
-export { getPartsByHighlight, getTextPartsByHighlight, getArrayPartsByHighlight };
+    shouldStyle: boolean;
+}
+declare function getPartsToStyle(targetString: string | undefined, stringToStyle: string | string[]): TextPart[];
+declare function getTextPartsToStyle(targetString?: string, stringToStyle?: string): TextPart[];
+declare function getArrayPartsToStyle(targetString?: string, stringToStyle?: string[]): TextPart[];
+export { getPartsToStyle, TextPart, getTextPartsToStyle, getArrayPartsToStyle };

--- a/generatedTypes/src/utils/TextUtils.d.ts
+++ b/generatedTypes/src/utils/TextUtils.d.ts
@@ -10,5 +10,5 @@ interface StyledTextPart {
 declare function getPartsToStyle(targetString: string | undefined, stringToStyle: undefined | string | string[]): TextPart[];
 declare function getTextPartsToStyle(targetString?: string, stringToStyle?: string): TextPart[];
 declare function getArrayPartsToStyle(targetString?: string, stringToStyle?: string[]): TextPart[];
-declare function unifyTextPartsStyles(targetString: string | undefined, withStyle1: StyleProp<TextStyle>, noStyle1: StyleProp<TextStyle>, withStyle2: StyleProp<TextStyle>, noStyle2: StyleProp<TextStyle>, textParts1?: TextPart[], textParts2?: TextPart[]): StyledTextPart[] | undefined;
+declare function unifyTextPartsStyles(targetString: string | undefined, textParts1: TextPart[] | undefined, withStyle1: StyleProp<TextStyle>, noStyle1: StyleProp<TextStyle>, textParts2: TextPart[] | undefined, withStyle2: StyleProp<TextStyle>, noStyle2: StyleProp<TextStyle>): StyledTextPart[] | undefined;
 export { getPartsToStyle, unifyTextPartsStyles, TextPart, StyledTextPart, getTextPartsToStyle, getArrayPartsToStyle };

--- a/generatedTypes/src/utils/TextUtils.d.ts
+++ b/generatedTypes/src/utils/TextUtils.d.ts
@@ -1,8 +1,14 @@
+import { StyleProp, TextStyle } from 'react-native';
 interface TextPart {
     string: string;
     shouldStyle: boolean;
 }
-declare function getPartsToStyle(targetString: string | undefined, stringToStyle: string | string[]): TextPart[];
+interface StyledTextPart {
+    string: string;
+    style?: StyleProp<TextStyle>;
+}
+declare function getPartsToStyle(targetString: string | undefined, stringToStyle: undefined | string | string[]): TextPart[];
 declare function getTextPartsToStyle(targetString?: string, stringToStyle?: string): TextPart[];
 declare function getArrayPartsToStyle(targetString?: string, stringToStyle?: string[]): TextPart[];
-export { getPartsToStyle, TextPart, getTextPartsToStyle, getArrayPartsToStyle };
+declare function unifyTextPartsStyles(targetString: string | undefined, withStyle1: StyleProp<TextStyle>, noStyle1: StyleProp<TextStyle>, withStyle2: StyleProp<TextStyle>, noStyle2: StyleProp<TextStyle>, textParts1?: TextPart[], textParts2?: TextPart[]): StyledTextPart[] | undefined;
+export { getPartsToStyle, unifyTextPartsStyles, TextPart, StyledTextPart, getTextPartsToStyle, getArrayPartsToStyle };

--- a/generatedTypes/src/utils/index.d.ts
+++ b/generatedTypes/src/utils/index.d.ts
@@ -1,0 +1,2 @@
+import * as TextUtils from './TextUtils';
+export { TextUtils };

--- a/src/.babelrc.json
+++ b/src/.babelrc.json
@@ -9,6 +9,7 @@
         "alias": {
           "commons": "./src/commons",
           "helpers": "./src/helpers",
+          "utils": "./src/utils",
           "hooks": "./src/hooks",
           "optionalDeps": "./src/optionalDependencies",
           "services": "./src/services",

--- a/src/components/text/__tests__/index.spec.js
+++ b/src/components/text/__tests__/index.spec.js
@@ -3,6 +3,11 @@ import {Text} from '../index';
 describe('Text', () => {
   describe('getTextPartsByHighlight', () => {
 
+    it('should return the whole string as a single part when highlight string is undefined', () => {
+      const uut = new Text({});
+      const result = uut.getTextPartsByHighlight('Playground Screen', undefined);
+      expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
+    });
     it('should return the whole string as a single part when highlight string is empty', () => {
       const uut = new Text({});
       const result = uut.getTextPartsByHighlight('Playground Screen', '');
@@ -53,6 +58,60 @@ describe('Text', () => {
       const uut = new Text({});
       const result = uut.getTextPartsByHighlight('@ancing in the @ark', '');
       expect(result).toEqual([{string: '@ancing in the @ark', shouldHighlight: false}]);
+    });
+  });
+
+  describe('getArrayPartsByHighlight', () => {
+
+    it('should return the whole string as a single part when highlight array is empty', () => {
+      const uut = new Text({});
+      const result = uut.getArrayPartsByHighlight('Playground Screen', []);
+      expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
+    });
+    it('should return the whole string as a single part when highlight string is empty', () => {
+      const uut = new Text({});
+      const result = uut.getArrayPartsByHighlight('Playground Screen', ['']);
+      expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
+    });
+    it('should return the whole string as a single part when highlight string dont match', () => {
+      const uut = new Text({});
+      const result = uut.getArrayPartsByHighlight('Playground Screen', ['aaa']);
+      expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
+    });
+    it('should break text to parts according to highlight string', () => {
+      const uut = new Text({});
+      const result = uut.getArrayPartsByHighlight('Playground Screen', ['Scr']);
+      expect(result).toEqual([{string: 'Playground ', shouldHighlight: false}, {string: 'Scr', shouldHighlight: true}, {string: 'een', shouldHighlight: false}]);
+    });
+    
+    it('highlight repeats more than once should color the first match', () => {
+      const uut = new Text({});
+      const result = uut.getArrayPartsByHighlight('Dancing in the Dark', ['Da']);
+      expect(result).toEqual([{string: 'Da', shouldHighlight: true}, {string: 'ncing in the Dark', shouldHighlight: false}]);
+    });
+    
+    it('should handle ignore case-sensetive', () => {
+      const uut = new Text({});
+      const result = uut.getArrayPartsByHighlight('Dancing in the Dark', ['da']);
+      expect(result).toEqual([{string: 'Da', shouldHighlight: true}, {string: 'ncing in the Dark', shouldHighlight: false}]);
+    });
+
+    it('Should handle special characters @', () => {
+      const uut = new Text({});
+      const result = uut.getArrayPartsByHighlight('@ancing in the @ark', ['@a']);
+      expect(result).toEqual([{string: '@a', shouldHighlight: true}, {string: 'ncing in the @ark', shouldHighlight: false}]);
+    });
+
+    it('Should handle special characters !', () => {
+      const uut = new Text({});
+      const result = uut.getArrayPartsByHighlight('!ancing in the !ark', ['!a']);
+      expect(result).toEqual([{string: '!a', shouldHighlight: true}, {string: 'ncing in the !ark', shouldHighlight: false}]);
+    });
+
+    it('Should handle special characters starts with @', () => {
+      const uut = new Text({});
+      const result = uut.getArrayPartsByHighlight('uilib@wix.com', ['@wix']);
+      expect(result).toEqual([{string: 'uilib', shouldHighlight: false}, {string: '@wix', shouldHighlight: true}, {string: '.com', shouldHighlight: false}]);
     });
   });
 });

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -38,6 +38,10 @@ export type TextProps = RNTextProps &
      */
     highlightStyle?: TextStyle;
     /**
+     * Substring to underline
+     */
+    underlineString?: string | string[];
+    /**
      * Use Animated.Text as a container
      */
     animated?: boolean;
@@ -67,9 +71,9 @@ class Text extends PureComponent<PropsTypes> {
   // }
 
   renderText(children: any): any {
-    const {highlightString, highlightStyle} = this.props;
+    const {highlightString, highlightStyle, underlineString} = this.props;
 
-    if (!_.isEmpty(highlightString)) {
+    if (!_.isEmpty(highlightString) || !_.isEmpty(underlineString)) {
       if (_.isArray(children)) {
         return _.map(children, child => {
           return this.renderText(child);
@@ -77,15 +81,20 @@ class Text extends PureComponent<PropsTypes> {
       }
 
       if (_.isString(children)) {
-        const textParts = highlightString && TextUtils.getPartsToStyle(children, highlightString);
+        const highlightTextParts = TextUtils.getPartsToStyle(children, highlightString);
+        const underlineTextParts = TextUtils.getPartsToStyle(children, underlineString);
+        const textParts = TextUtils.unifyTextPartsStyles(children,
+          [styles.highlight, highlightStyle],
+          styles.notHighlight,
+          styles.underline,
+          styles.notUnderline,
+          highlightTextParts,
+          underlineTextParts);
         return (
           textParts &&
           _.map(textParts, (text, index) => {
             return (
-              <RNText
-                key={index}
-                style={text.shouldStyle ? [styles.highlight, highlightStyle] : styles.notHighlight}
-              >
+              <RNText key={index} style={text.style}>
                 {text.string}
               </RNText>
             );
@@ -138,6 +147,12 @@ const styles = StyleSheet.create({
   },
   notHighlight: {
     color: undefined
+  },
+  underline: {
+    textDecorationLine: 'underline'
+  },
+  notUnderline: {
+    textDecorationLine: undefined
   }
 });
 

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -11,6 +11,7 @@ import {
   ColorsModifiers
 } from '../../commons/new';
 import {Colors} from 'style';
+import {TextUtils} from 'utils';
 
 export type TextProps = RNTextProps &
   TypographyModifiers &
@@ -65,80 +66,6 @@ class Text extends PureComponent<PropsTypes> {
   //   this._root.setNativeProps(nativeProps); // eslint-disable-line
   // }
 
-  getPartsByHighlight(targetString = '', highlightString: string | string[]) {
-    if (typeof highlightString === 'string') {
-      if (_.isEmpty(highlightString.trim())) {
-        return [{string: targetString, shouldHighlight: false}];
-      }
-      return this.getTextPartsByHighlight(targetString, highlightString);
-    } else {
-      return this.getArrayPartsByHighlight(targetString, highlightString);
-    }
-  }
-
-  getTextPartsByHighlight(targetString = '', highlightString = '') {
-    if (highlightString === '') {
-      return [{string: targetString, shouldHighlight: false}];
-    }
-    const textParts = [];
-    let highlightIndex;
-    do {
-      highlightIndex = targetString.toLowerCase().indexOf(highlightString.toLowerCase());
-      if (highlightIndex !== -1) {
-        if (highlightIndex > 0) {
-          textParts.push({string: targetString.substring(0, highlightIndex), shouldHighlight: false});
-        }
-        textParts.push({string: targetString.substr(highlightIndex, highlightString.length), shouldHighlight: true});
-        targetString = targetString.substr(highlightIndex + highlightString.length);
-      } else {
-        textParts.push({string: targetString, shouldHighlight: false});
-      }
-    } while (highlightIndex !== -1);
-
-    return textParts;
-  }
-
-  getArrayPartsByHighlight(targetString = '', highlightString = ['']) {
-    const target = _.toLower(targetString);
-    const indices = [];
-    let index = 0;
-    let lastWordLength = 0;
-    for (let j = 0; j < highlightString.length; j++) {
-      const word = _.toLower(highlightString[j]);
-      if (word.length === 0) {
-        break;
-      }
-
-      const targetSuffix = target.substring(index + lastWordLength);
-      const i = targetSuffix.indexOf(word);
-      if (i >= 0) {
-        const newIndex = index + lastWordLength + i;
-        indices.push({start: index + lastWordLength + i, end: index + lastWordLength + i + word.length});
-        index = newIndex;
-        lastWordLength = word.length;
-      } else {
-        break;
-      }
-    }
-    const parts = [];
-    for (let k = 0; k < indices.length; k++) {
-      if (k === 0 && indices[k].start !== 0) {
-        parts.push({string: targetString.substring(0, indices[k].start), shouldHighlight: false});
-      }
-      parts.push({string: targetString.substring(indices[k].start, indices[k].end), shouldHighlight: true});
-      if (k === indices.length - 1) {
-        parts.push({string: targetString.substring(indices[k].end), shouldHighlight: false});
-      } else {
-        parts.push({string: targetString.substring(indices[k].end, indices[k + 1].start), shouldHighlight: false});
-      }
-    }
-    if (parts.length === 0) {
-      parts.push({string: targetString, shouldHighlight: false});
-    }
-
-    return parts;
-  }
-
   renderText(children: any): any {
     const {highlightString, highlightStyle} = this.props;
 
@@ -150,7 +77,7 @@ class Text extends PureComponent<PropsTypes> {
       }
 
       if (_.isString(children)) {
-        const textParts = highlightString && this.getPartsByHighlight(children, highlightString);
+        const textParts = highlightString && TextUtils.getPartsByHighlight(children, highlightString);
         return (
           textParts &&
           _.map(textParts, (text, index) => {

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -77,14 +77,14 @@ class Text extends PureComponent<PropsTypes> {
       }
 
       if (_.isString(children)) {
-        const textParts = highlightString && TextUtils.getPartsByHighlight(children, highlightString);
+        const textParts = highlightString && TextUtils.getPartsToStyle(children, highlightString);
         return (
           textParts &&
           _.map(textParts, (text, index) => {
             return (
               <RNText
                 key={index}
-                style={text.shouldHighlight ? [styles.highlight, highlightStyle] : styles.notHighlight}
+                style={text.shouldStyle ? [styles.highlight, highlightStyle] : styles.notHighlight}
               >
                 {text.string}
               </RNText>

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -84,12 +84,12 @@ class Text extends PureComponent<PropsTypes> {
         const highlightTextParts = TextUtils.getPartsToStyle(children, highlightString);
         const underlineTextParts = TextUtils.getPartsToStyle(children, underlineString);
         const textParts = TextUtils.unifyTextPartsStyles(children,
+          highlightTextParts,
           [styles.highlight, highlightStyle],
           styles.notHighlight,
+          underlineTextParts,
           styles.underline,
-          styles.notUnderline,
-          highlightTextParts,
-          underlineTextParts);
+          styles.notUnderline);
         return (
           textParts &&
           _.map(textParts, (text, index) => {

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -105,6 +105,10 @@ class Text extends PureComponent<PropsTypes> {
     let lastWordLength = 0;
     for (let j = 0; j < highlightString.length; j++) {
       const word = _.toLower(highlightString[j]);
+      if (word.length === 0) {
+        break;
+      }
+
       const targetSuffix = target.substring(index + lastWordLength);
       const i = targetSuffix.indexOf(word);
       if (i >= 0) {
@@ -128,6 +132,10 @@ class Text extends PureComponent<PropsTypes> {
         parts.push({string: targetString.substring(indices[k].end, indices[k + 1].start), shouldHighlight: false});
       }
     }
+    if (parts.length === 0) {
+      parts.push({string: targetString, shouldHighlight: false});
+    }
+
     return parts;
   }
 

--- a/src/components/text/text.api.json
+++ b/src/components/text/text.api.json
@@ -15,6 +15,7 @@
     {"name": "uppercase", "type": "boolean", "description": "Whether to change the text to uppercase"},
     {"name": "highlightString", "type": "string | string[]", "description": "Substring to highlight"},
     {"name": "highlightStyle", "type": "TextStyle", "description": "Custom highlight style for highlight string"},
+    {"name": "underlineString", "type": "string | string[]", "description": "Substring to underline"},
     {"name": "animated", "type": "boolean", "description": "Use Animated.Text as a container"}
   ]
 }

--- a/src/utils/TextUtils.ts
+++ b/src/utils/TextUtils.ts
@@ -1,8 +1,8 @@
-import _ from 'lodash';
+import {isEmpty, toLower} from 'lodash';
 
 function getPartsByHighlight(targetString = '', highlightString: string | string[]) {
   if (typeof highlightString === 'string') {
-    if (_.isEmpty(highlightString.trim())) {
+    if (isEmpty(highlightString.trim())) {
       return [{string: targetString, shouldHighlight: false}];
     }
     return getTextPartsByHighlight(targetString, highlightString);
@@ -34,12 +34,12 @@ function getTextPartsByHighlight(targetString = '', highlightString = '') {
 }
 
 function getArrayPartsByHighlight(targetString = '', highlightString = ['']) {
-  const target = _.toLower(targetString);
+  const target = toLower(targetString);
   const indices = [];
   let index = 0;
   let lastWordLength = 0;
   for (let j = 0; j < highlightString.length; j++) {
-    const word = _.toLower(highlightString[j]);
+    const word = toLower(highlightString[j]);
     if (word.length === 0) {
       break;
     }
@@ -55,23 +55,23 @@ function getArrayPartsByHighlight(targetString = '', highlightString = ['']) {
       break;
     }
   }
-  const parts = [];
+  const textParts = [];
   for (let k = 0; k < indices.length; k++) {
     if (k === 0 && indices[k].start !== 0) {
-      parts.push({string: targetString.substring(0, indices[k].start), shouldHighlight: false});
+      textParts.push({string: targetString.substring(0, indices[k].start), shouldHighlight: false});
     }
-    parts.push({string: targetString.substring(indices[k].start, indices[k].end), shouldHighlight: true});
+    textParts.push({string: targetString.substring(indices[k].start, indices[k].end), shouldHighlight: true});
     if (k === indices.length - 1) {
-      parts.push({string: targetString.substring(indices[k].end), shouldHighlight: false});
+      textParts.push({string: targetString.substring(indices[k].end), shouldHighlight: false});
     } else {
-      parts.push({string: targetString.substring(indices[k].end, indices[k + 1].start), shouldHighlight: false});
+      textParts.push({string: targetString.substring(indices[k].end, indices[k + 1].start), shouldHighlight: false});
     }
   }
-  if (parts.length === 0) {
-    parts.push({string: targetString, shouldHighlight: false});
+  if (textParts.length === 0) {
+    textParts.push({string: targetString, shouldHighlight: false});
   }
 
-  return parts;
+  return textParts;
 }
 
 export {getPartsByHighlight, getTextPartsByHighlight, getArrayPartsByHighlight};

--- a/src/utils/TextUtils.ts
+++ b/src/utils/TextUtils.ts
@@ -101,12 +101,12 @@ function getUnifiedStyle(string: string,
 
 // eslint-disable-next-line max-params
 function unifyTextPartsStyles(targetString = '',
+  textParts1: TextPart[] | undefined,
   withStyle1: StyleProp<TextStyle>,
   noStyle1: StyleProp<TextStyle>,
+  textParts2: TextPart[] | undefined,
   withStyle2: StyleProp<TextStyle>,
-  noStyle2: StyleProp<TextStyle>,
-  textParts1?: TextPart[],
-  textParts2?: TextPart[]): StyledTextPart[] | undefined {
+  noStyle2: StyleProp<TextStyle>): StyledTextPart[] | undefined {
   const result: StyledTextPart[] = [];
   if (!textParts1 && !textParts2) {
     return undefined;

--- a/src/utils/TextUtils.ts
+++ b/src/utils/TextUtils.ts
@@ -1,45 +1,50 @@
 import {isEmpty, toLower} from 'lodash';
 
-function getPartsByHighlight(targetString = '', highlightString: string | string[]) {
-  if (typeof highlightString === 'string') {
-    if (isEmpty(highlightString.trim())) {
-      return [{string: targetString, shouldHighlight: false}];
+interface TextPart {
+  string: string;
+  shouldStyle: boolean;
+}
+
+function getPartsToStyle(targetString = '', stringToStyle: string | string[]): TextPart[] {
+  if (typeof stringToStyle === 'string') {
+    if (isEmpty(stringToStyle.trim())) {
+      return [{string: targetString, shouldStyle: false}];
     }
-    return getTextPartsByHighlight(targetString, highlightString);
+    return getTextPartsToStyle(targetString, stringToStyle);
   } else {
-    return getArrayPartsByHighlight(targetString, highlightString);
+    return getArrayPartsToStyle(targetString, stringToStyle);
   }
 }
 
-function getTextPartsByHighlight(targetString = '', highlightString = '') {
-  if (highlightString === '') {
-    return [{string: targetString, shouldHighlight: false}];
+function getTextPartsToStyle(targetString = '', stringToStyle = ''): TextPart[] {
+  if (stringToStyle === '') {
+    return [{string: targetString, shouldStyle: false}];
   }
   const textParts = [];
   let highlightIndex;
   do {
-    highlightIndex = targetString.toLowerCase().indexOf(highlightString.toLowerCase());
+    highlightIndex = targetString.toLowerCase().indexOf(stringToStyle.toLowerCase());
     if (highlightIndex !== -1) {
       if (highlightIndex > 0) {
-        textParts.push({string: targetString.substring(0, highlightIndex), shouldHighlight: false});
+        textParts.push({string: targetString.substring(0, highlightIndex), shouldStyle: false});
       }
-      textParts.push({string: targetString.substr(highlightIndex, highlightString.length), shouldHighlight: true});
-      targetString = targetString.substr(highlightIndex + highlightString.length);
+      textParts.push({string: targetString.substr(highlightIndex, stringToStyle.length), shouldStyle: true});
+      targetString = targetString.substr(highlightIndex + stringToStyle.length);
     } else {
-      textParts.push({string: targetString, shouldHighlight: false});
+      textParts.push({string: targetString, shouldStyle: false});
     }
   } while (highlightIndex !== -1);
 
   return textParts;
 }
 
-function getArrayPartsByHighlight(targetString = '', highlightString = ['']) {
+function getArrayPartsToStyle(targetString = '', stringToStyle = ['']): TextPart[] {
   const target = toLower(targetString);
   const indices = [];
   let index = 0;
   let lastWordLength = 0;
-  for (let j = 0; j < highlightString.length; j++) {
-    const word = toLower(highlightString[j]);
+  for (let j = 0; j < stringToStyle.length; j++) {
+    const word = toLower(stringToStyle[j]);
     if (word.length === 0) {
       break;
     }
@@ -58,20 +63,20 @@ function getArrayPartsByHighlight(targetString = '', highlightString = ['']) {
   const textParts = [];
   for (let k = 0; k < indices.length; k++) {
     if (k === 0 && indices[k].start !== 0) {
-      textParts.push({string: targetString.substring(0, indices[k].start), shouldHighlight: false});
+      textParts.push({string: targetString.substring(0, indices[k].start), shouldStyle: false});
     }
-    textParts.push({string: targetString.substring(indices[k].start, indices[k].end), shouldHighlight: true});
+    textParts.push({string: targetString.substring(indices[k].start, indices[k].end), shouldStyle: true});
     if (k === indices.length - 1) {
-      textParts.push({string: targetString.substring(indices[k].end), shouldHighlight: false});
+      textParts.push({string: targetString.substring(indices[k].end), shouldStyle: false});
     } else {
-      textParts.push({string: targetString.substring(indices[k].end, indices[k + 1].start), shouldHighlight: false});
+      textParts.push({string: targetString.substring(indices[k].end, indices[k + 1].start), shouldStyle: false});
     }
   }
   if (textParts.length === 0) {
-    textParts.push({string: targetString, shouldHighlight: false});
+    textParts.push({string: targetString, shouldStyle: false});
   }
 
   return textParts;
 }
 
-export {getPartsByHighlight, getTextPartsByHighlight, getArrayPartsByHighlight};
+export {getPartsToStyle, TextPart, getTextPartsToStyle, getArrayPartsToStyle};

--- a/src/utils/TextUtils.ts
+++ b/src/utils/TextUtils.ts
@@ -1,0 +1,77 @@
+import _ from 'lodash';
+
+function getPartsByHighlight(targetString = '', highlightString: string | string[]) {
+  if (typeof highlightString === 'string') {
+    if (_.isEmpty(highlightString.trim())) {
+      return [{string: targetString, shouldHighlight: false}];
+    }
+    return getTextPartsByHighlight(targetString, highlightString);
+  } else {
+    return getArrayPartsByHighlight(targetString, highlightString);
+  }
+}
+
+function getTextPartsByHighlight(targetString = '', highlightString = '') {
+  if (highlightString === '') {
+    return [{string: targetString, shouldHighlight: false}];
+  }
+  const textParts = [];
+  let highlightIndex;
+  do {
+    highlightIndex = targetString.toLowerCase().indexOf(highlightString.toLowerCase());
+    if (highlightIndex !== -1) {
+      if (highlightIndex > 0) {
+        textParts.push({string: targetString.substring(0, highlightIndex), shouldHighlight: false});
+      }
+      textParts.push({string: targetString.substr(highlightIndex, highlightString.length), shouldHighlight: true});
+      targetString = targetString.substr(highlightIndex + highlightString.length);
+    } else {
+      textParts.push({string: targetString, shouldHighlight: false});
+    }
+  } while (highlightIndex !== -1);
+
+  return textParts;
+}
+
+function getArrayPartsByHighlight(targetString = '', highlightString = ['']) {
+  const target = _.toLower(targetString);
+  const indices = [];
+  let index = 0;
+  let lastWordLength = 0;
+  for (let j = 0; j < highlightString.length; j++) {
+    const word = _.toLower(highlightString[j]);
+    if (word.length === 0) {
+      break;
+    }
+
+    const targetSuffix = target.substring(index + lastWordLength);
+    const i = targetSuffix.indexOf(word);
+    if (i >= 0) {
+      const newIndex = index + lastWordLength + i;
+      indices.push({start: index + lastWordLength + i, end: index + lastWordLength + i + word.length});
+      index = newIndex;
+      lastWordLength = word.length;
+    } else {
+      break;
+    }
+  }
+  const parts = [];
+  for (let k = 0; k < indices.length; k++) {
+    if (k === 0 && indices[k].start !== 0) {
+      parts.push({string: targetString.substring(0, indices[k].start), shouldHighlight: false});
+    }
+    parts.push({string: targetString.substring(indices[k].start, indices[k].end), shouldHighlight: true});
+    if (k === indices.length - 1) {
+      parts.push({string: targetString.substring(indices[k].end), shouldHighlight: false});
+    } else {
+      parts.push({string: targetString.substring(indices[k].end, indices[k + 1].start), shouldHighlight: false});
+    }
+  }
+  if (parts.length === 0) {
+    parts.push({string: targetString, shouldHighlight: false});
+  }
+
+  return parts;
+}
+
+export {getPartsByHighlight, getTextPartsByHighlight, getArrayPartsByHighlight};

--- a/src/utils/TextUtils.ts
+++ b/src/utils/TextUtils.ts
@@ -39,7 +39,7 @@ function getTextPartsToStyle(targetString = '', stringToStyle = ''): TextPart[] 
     } else {
       textParts.push({string: targetString, shouldStyle: false});
     }
-  } while (highlightIndex !== -1);
+  } while (highlightIndex !== -1 && targetString.length > 0);
 
   return textParts;
 }

--- a/src/utils/TextUtils.ts
+++ b/src/utils/TextUtils.ts
@@ -1,11 +1,17 @@
 import {isEmpty, toLower} from 'lodash';
+import {StyleProp, TextStyle} from 'react-native';
 
 interface TextPart {
   string: string;
   shouldStyle: boolean;
 }
 
-function getPartsToStyle(targetString = '', stringToStyle: string | string[]): TextPart[] {
+interface StyledTextPart {
+  string: string;
+  style?: StyleProp<TextStyle>;
+}
+
+function getPartsToStyle(targetString = '', stringToStyle: undefined | string | string[]): TextPart[] {
   if (typeof stringToStyle === 'string') {
     if (isEmpty(stringToStyle.trim())) {
       return [{string: targetString, shouldStyle: false}];
@@ -79,4 +85,75 @@ function getArrayPartsToStyle(targetString = '', stringToStyle = ['']): TextPart
   return textParts;
 }
 
-export {getPartsToStyle, TextPart, getTextPartsToStyle, getArrayPartsToStyle};
+// eslint-disable-next-line max-params
+function getUnifiedStyle(string: string,
+  shouldStyle1: boolean,
+  withStyle1: StyleProp<TextStyle>,
+  noStyle1: StyleProp<TextStyle>,
+  shouldStyle2: boolean,
+  withStyle2: StyleProp<TextStyle>,
+  noStyle2: StyleProp<TextStyle>): StyledTextPart {
+  return {
+    string,
+    style: [shouldStyle1 ? withStyle1 : noStyle1, shouldStyle2 ? withStyle2 : noStyle2]
+  };
+}
+
+// eslint-disable-next-line max-params
+function unifyTextPartsStyles(targetString = '',
+  withStyle1: StyleProp<TextStyle>,
+  noStyle1: StyleProp<TextStyle>,
+  withStyle2: StyleProp<TextStyle>,
+  noStyle2: StyleProp<TextStyle>,
+  textParts1?: TextPart[],
+  textParts2?: TextPart[]): StyledTextPart[] | undefined {
+  const result: StyledTextPart[] = [];
+  if (!textParts1 && !textParts2) {
+    return undefined;
+  } else if (!textParts1 || !textParts2) {
+    const is1 = !textParts1;
+    const textParts = is1 ? textParts1 : textParts2;
+    const withStyle = is1 ? withStyle1 : withStyle2;
+    const noStyle = is1 ? noStyle1 : noStyle2;
+    for (let i = 0; i < textParts!.length; ++i) {
+      result.push({string: textParts![i].string, style: textParts![i].shouldStyle ? withStyle : noStyle});
+    }
+
+    return result;
+  }
+
+  let arrayIndex1 = -1,
+    arrayIndex2 = -1;
+  let totalLength1 = 0,
+    totalLength2 = 0;
+  let startIndex = 0,
+    endIndex;
+  while (arrayIndex1 < textParts1.length - 1 || arrayIndex2 < textParts2.length - 1) {
+    if (totalLength1 === totalLength2) {
+      ++arrayIndex1;
+      ++arrayIndex2;
+      totalLength1 += textParts1[arrayIndex1].string.length;
+      totalLength2 += textParts2[arrayIndex2].string.length;
+    } else if (totalLength1 > totalLength2) {
+      ++arrayIndex2;
+      totalLength2 += textParts2[arrayIndex2].string.length;
+    } else {
+      ++arrayIndex1;
+      totalLength1 += textParts1[arrayIndex1].string.length;
+    }
+
+    endIndex = Math.min(totalLength1, totalLength2);
+    result.push(getUnifiedStyle(targetString.substring(startIndex, endIndex),
+      textParts1[arrayIndex1].shouldStyle,
+      withStyle1,
+      noStyle1,
+      textParts2[arrayIndex2].shouldStyle,
+      withStyle2,
+      noStyle2));
+    startIndex = endIndex;
+  }
+
+  return result;
+}
+
+export {getPartsToStyle, unifyTextPartsStyles, TextPart, StyledTextPart, getTextPartsToStyle, getArrayPartsToStyle};

--- a/src/utils/__tests__/TextUtils.spec.js
+++ b/src/utils/__tests__/TextUtils.spec.js
@@ -73,9 +73,14 @@ describe('Text', () => {
       ]);
     });
 
-    it('Should handle empty string .', () => {
+    it('Should handle empty string.', () => {
       const result = getTextPartsToStyle('@ancing in the @ark', '');
       expect(result).toEqual([{string: '@ancing in the @ark', shouldStyle: false}]);
+    });
+
+    it('Should handle full string.', () => {
+      const result = getTextPartsToStyle('Dancing in the Dark', 'Dancing in the Dark');
+      expect(result).toEqual([{string: 'Dancing in the Dark', shouldStyle: true}]);
     });
   });
 

--- a/src/utils/__tests__/TextUtils.spec.js
+++ b/src/utils/__tests__/TextUtils.spec.js
@@ -1,62 +1,52 @@
-import {Text} from '../index';
+import {getTextPartsByHighlight, getArrayPartsByHighlight} from '../TextUtils';
 
 describe('Text', () => {
   describe('getTextPartsByHighlight', () => {
 
     it('should return the whole string as a single part when highlight string is undefined', () => {
-      const uut = new Text({});
-      const result = uut.getTextPartsByHighlight('Playground Screen', undefined);
+      const result = getTextPartsByHighlight('Playground Screen', undefined);
       expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
     });
     it('should return the whole string as a single part when highlight string is empty', () => {
-      const uut = new Text({});
-      const result = uut.getTextPartsByHighlight('Playground Screen', '');
+      const result = getTextPartsByHighlight('Playground Screen', '');
       expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
     });
     it('should return the whole string as a single part when highlight string dont match', () => {
-      const uut = new Text({});
-      const result = uut.getTextPartsByHighlight('Playground Screen', 'aaa');
+      const result = getTextPartsByHighlight('Playground Screen', 'aaa');
       expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
     });
     it('should break text to parts according to highlight string', () => {
-      const uut = new Text({});
-      const result = uut.getTextPartsByHighlight('Playground Screen', 'Scr');
+      const result = getTextPartsByHighlight('Playground Screen', 'Scr');
       expect(result).toEqual([{string: 'Playground ', shouldHighlight: false}, {string: 'Scr', shouldHighlight: true}, {string: 'een', shouldHighlight: false}]);
     });
     
     it('should handle case when highlight repeats more than once', () => {
-      const uut = new Text({});
-      const result = uut.getTextPartsByHighlight('Dancing in the Dark', 'Da');
+      const result = getTextPartsByHighlight('Dancing in the Dark', 'Da');
       expect(result).toEqual([{string: 'Da', shouldHighlight: true}, {string: 'ncing in the ', shouldHighlight: false}, {string: 'Da', shouldHighlight: true}, {string: 'rk', shouldHighlight: false}]);
     });
     
     it('should handle ignore case-sensetive', () => {
-      const uut = new Text({});
-      const result = uut.getTextPartsByHighlight('Dancing in the Dark', 'da');
+      const result = getTextPartsByHighlight('Dancing in the Dark', 'da');
       expect(result).toEqual([{string: 'Da', shouldHighlight: true}, {string: 'ncing in the ', shouldHighlight: false}, {string: 'Da', shouldHighlight: true}, {string: 'rk', shouldHighlight: false}]);
     });
 
     it('Should handle special characters @', () => {
-      const uut = new Text({});
-      const result = uut.getTextPartsByHighlight('@ancing in the @ark', '@a');
+      const result = getTextPartsByHighlight('@ancing in the @ark', '@a');
       expect(result).toEqual([{string: '@a', shouldHighlight: true}, {string: 'ncing in the ', shouldHighlight: false}, {string: '@a', shouldHighlight: true}, {string: 'rk', shouldHighlight: false}]);
     });
 
     it('Should handle special characters !', () => {
-      const uut = new Text({});
-      const result = uut.getTextPartsByHighlight('!ancing in the !ark', '!a');
+      const result = getTextPartsByHighlight('!ancing in the !ark', '!a');
       expect(result).toEqual([{string: '!a', shouldHighlight: true}, {string: 'ncing in the ', shouldHighlight: false}, {string: '!a', shouldHighlight: true}, {string: 'rk', shouldHighlight: false}]);
     });
 
     it('Should handle special characters starts with @', () => {
-      const uut = new Text({});
-      const result = uut.getTextPartsByHighlight('uilib@wix.com', '@wix');
+      const result = getTextPartsByHighlight('uilib@wix.com', '@wix');
       expect(result).toEqual([{string: 'uilib', shouldHighlight: false}, {string: '@wix', shouldHighlight: true}, {string: '.com', shouldHighlight: false}]);
     });
 
     it('Should handle empty string .', () => {
-      const uut = new Text({});
-      const result = uut.getTextPartsByHighlight('@ancing in the @ark', '');
+      const result = getTextPartsByHighlight('@ancing in the @ark', '');
       expect(result).toEqual([{string: '@ancing in the @ark', shouldHighlight: false}]);
     });
   });
@@ -64,53 +54,44 @@ describe('Text', () => {
   describe('getArrayPartsByHighlight', () => {
 
     it('should return the whole string as a single part when highlight array is empty', () => {
-      const uut = new Text({});
-      const result = uut.getArrayPartsByHighlight('Playground Screen', []);
+      const result = getArrayPartsByHighlight('Playground Screen', []);
       expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
     });
     it('should return the whole string as a single part when highlight string is empty', () => {
-      const uut = new Text({});
-      const result = uut.getArrayPartsByHighlight('Playground Screen', ['']);
+      const result = getArrayPartsByHighlight('Playground Screen', ['']);
       expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
     });
     it('should return the whole string as a single part when highlight string dont match', () => {
-      const uut = new Text({});
-      const result = uut.getArrayPartsByHighlight('Playground Screen', ['aaa']);
+      const result = getArrayPartsByHighlight('Playground Screen', ['aaa']);
       expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
     });
     it('should break text to parts according to highlight string', () => {
-      const uut = new Text({});
-      const result = uut.getArrayPartsByHighlight('Playground Screen', ['Scr']);
+      const result = getArrayPartsByHighlight('Playground Screen', ['Scr']);
       expect(result).toEqual([{string: 'Playground ', shouldHighlight: false}, {string: 'Scr', shouldHighlight: true}, {string: 'een', shouldHighlight: false}]);
     });
     
     it('highlight repeats more than once should color the first match', () => {
-      const uut = new Text({});
-      const result = uut.getArrayPartsByHighlight('Dancing in the Dark', ['Da']);
+      const result = getArrayPartsByHighlight('Dancing in the Dark', ['Da']);
       expect(result).toEqual([{string: 'Da', shouldHighlight: true}, {string: 'ncing in the Dark', shouldHighlight: false}]);
     });
     
     it('should handle ignore case-sensetive', () => {
-      const uut = new Text({});
-      const result = uut.getArrayPartsByHighlight('Dancing in the Dark', ['da']);
+      const result = getArrayPartsByHighlight('Dancing in the Dark', ['da']);
       expect(result).toEqual([{string: 'Da', shouldHighlight: true}, {string: 'ncing in the Dark', shouldHighlight: false}]);
     });
 
     it('Should handle special characters @', () => {
-      const uut = new Text({});
-      const result = uut.getArrayPartsByHighlight('@ancing in the @ark', ['@a']);
+      const result = getArrayPartsByHighlight('@ancing in the @ark', ['@a']);
       expect(result).toEqual([{string: '@a', shouldHighlight: true}, {string: 'ncing in the @ark', shouldHighlight: false}]);
     });
 
     it('Should handle special characters !', () => {
-      const uut = new Text({});
-      const result = uut.getArrayPartsByHighlight('!ancing in the !ark', ['!a']);
+      const result = getArrayPartsByHighlight('!ancing in the !ark', ['!a']);
       expect(result).toEqual([{string: '!a', shouldHighlight: true}, {string: 'ncing in the !ark', shouldHighlight: false}]);
     });
 
     it('Should handle special characters starts with @', () => {
-      const uut = new Text({});
-      const result = uut.getArrayPartsByHighlight('uilib@wix.com', ['@wix']);
+      const result = getArrayPartsByHighlight('uilib@wix.com', ['@wix']);
       expect(result).toEqual([{string: 'uilib', shouldHighlight: false}, {string: '@wix', shouldHighlight: true}, {string: '.com', shouldHighlight: false}]);
     });
   });

--- a/src/utils/__tests__/TextUtils.spec.js
+++ b/src/utils/__tests__/TextUtils.spec.js
@@ -149,12 +149,12 @@ describe('Text', () => {
       const highlightTextParts = getPartsToStyle(string, []);
       const underlineTextParts = getPartsToStyle(string, []);
       const result = unifyTextPartsStyles(string,
+        highlightTextParts,
         styles.highlight,
         styles.notHighlight,
+        underlineTextParts,
         styles.underline,
-        styles.notUnderline,
-        highlightTextParts,
-        underlineTextParts);
+        styles.notUnderline);
       expect(result).toEqual([{string: 'Playground Screen', style: [{color: undefined}, {textDecorationLine: undefined}]}]);
     });
     it('should return the whole string as a single part when style string is empty', () => {
@@ -162,12 +162,12 @@ describe('Text', () => {
       const highlightTextParts = getPartsToStyle(string, ['']);
       const underlineTextParts = getPartsToStyle(string, ['']);
       const result = unifyTextPartsStyles(string,
+        highlightTextParts,
         styles.highlight,
         styles.notHighlight,
+        underlineTextParts,
         styles.underline,
-        styles.notUnderline,
-        highlightTextParts,
-        underlineTextParts);
+        styles.notUnderline);
       expect(result).toEqual([{string: 'Playground Screen', style: [{color: undefined}, {textDecorationLine: undefined}]}]);
     });
     it('should return the whole string as a single part when style string dont match', () => {
@@ -175,12 +175,12 @@ describe('Text', () => {
       const highlightTextParts = getPartsToStyle(string, ['aaa']);
       const underlineTextParts = getPartsToStyle(string, ['bbb']);
       const result = unifyTextPartsStyles(string,
+        highlightTextParts,
         styles.highlight,
         styles.notHighlight,
+        underlineTextParts,
         styles.underline,
-        styles.notUnderline,
-        highlightTextParts,
-        underlineTextParts);
+        styles.notUnderline);
       expect(result).toEqual([{string: 'Playground Screen', style: [{color: undefined}, {textDecorationLine: undefined}]}]);
     });
     it('should break text to parts according to style string (highlight)', () => {
@@ -188,12 +188,12 @@ describe('Text', () => {
       const highlightTextParts = getPartsToStyle(string, ['Scr']);
       const underlineTextParts = getPartsToStyle(string, ['']);
       const result = unifyTextPartsStyles(string,
+        highlightTextParts,
         styles.highlight,
         styles.notHighlight,
+        underlineTextParts,
         styles.underline,
-        styles.notUnderline,
-        highlightTextParts,
-        underlineTextParts);
+        styles.notUnderline);
       expect(result).toEqual([
         {string: 'Playground ', style: [{color: undefined}, {textDecorationLine: undefined}]},
         {string: 'Scr', style: [{color: 'red'}, {textDecorationLine: undefined}]},
@@ -205,12 +205,12 @@ describe('Text', () => {
       const highlightTextParts = getPartsToStyle(string, ['']);
       const underlineTextParts = getPartsToStyle(string, ['Scr']);
       const result = unifyTextPartsStyles(string,
+        highlightTextParts,
         styles.highlight,
         styles.notHighlight,
+        underlineTextParts,
         styles.underline,
-        styles.notUnderline,
-        highlightTextParts,
-        underlineTextParts);
+        styles.notUnderline);
       expect(result).toEqual([
         {string: 'Playground ', style: [{color: undefined}, {textDecorationLine: undefined}]},
         {string: 'Scr', style: [{color: undefined}, {textDecorationLine: 'underline'}]},
@@ -222,12 +222,12 @@ describe('Text', () => {
       const highlightTextParts = getPartsToStyle(string, ['Scr']);
       const underlineTextParts = getPartsToStyle(string, ['Scr']);
       const result = unifyTextPartsStyles(string,
+        highlightTextParts,
         styles.highlight,
         styles.notHighlight,
+        underlineTextParts,
         styles.underline,
-        styles.notUnderline,
-        highlightTextParts,
-        underlineTextParts);
+        styles.notUnderline);
       expect(result).toEqual([
         {string: 'Playground ', style: [{color: undefined}, {textDecorationLine: undefined}]},
         {string: 'Scr', style: [{color: 'red'}, {textDecorationLine: 'underline'}]},
@@ -239,12 +239,12 @@ describe('Text', () => {
       const highlightTextParts = getPartsToStyle(string, ['Play']);
       const underlineTextParts = getPartsToStyle(string, ['Scr']);
       const result = unifyTextPartsStyles(string,
+        highlightTextParts,
         styles.highlight,
         styles.notHighlight,
+        underlineTextParts,
         styles.underline,
-        styles.notUnderline,
-        highlightTextParts,
-        underlineTextParts);
+        styles.notUnderline);
       expect(result).toEqual([
         {string: 'Play', style: [{color: 'red'}, {textDecorationLine: undefined}]},
         {string: 'ground ', style: [{color: undefined}, {textDecorationLine: undefined}]},
@@ -257,12 +257,12 @@ describe('Text', () => {
       const highlightTextParts = getPartsToStyle(string, ['Playground']);
       const underlineTextParts = getPartsToStyle(string, ['laygroun']);
       const result = unifyTextPartsStyles(string,
+        highlightTextParts,
         styles.highlight,
         styles.notHighlight,
+        underlineTextParts,
         styles.underline,
-        styles.notUnderline,
-        highlightTextParts,
-        underlineTextParts);
+        styles.notUnderline);
       expect(result).toEqual([
         {string: 'P', style: [{color: 'red'}, {textDecorationLine: undefined}]},
         {string: 'laygroun', style: [{color: 'red'}, {textDecorationLine: 'underline'}]},
@@ -275,12 +275,12 @@ describe('Text', () => {
       const highlightTextParts = getPartsToStyle(string, ['laygroun']);
       const underlineTextParts = getPartsToStyle(string, ['Playground']);
       const result = unifyTextPartsStyles(string,
+        highlightTextParts,
         styles.highlight,
         styles.notHighlight,
+        underlineTextParts,
         styles.underline,
-        styles.notUnderline,
-        highlightTextParts,
-        underlineTextParts);
+        styles.notUnderline);
       expect(result).toEqual([
         {string: 'P', style: [{color: undefined}, {textDecorationLine: 'underline'}]},
         {string: 'laygroun', style: [{color: 'red'}, {textDecorationLine: 'underline'}]},
@@ -293,12 +293,12 @@ describe('Text', () => {
       const highlightTextParts = getPartsToStyle(string, ['Playg']);
       const underlineTextParts = getPartsToStyle(string, ['ground']);
       const result = unifyTextPartsStyles(string,
+        highlightTextParts,
         styles.highlight,
         styles.notHighlight,
+        underlineTextParts,
         styles.underline,
-        styles.notUnderline,
-        highlightTextParts,
-        underlineTextParts);
+        styles.notUnderline);
       expect(result).toEqual([
         {string: 'Play', style: [{color: 'red'}, {textDecorationLine: undefined}]},
         {string: 'g', style: [{color: 'red'}, {textDecorationLine: 'underline'}]},

--- a/src/utils/__tests__/TextUtils.spec.js
+++ b/src/utils/__tests__/TextUtils.spec.js
@@ -1,8 +1,8 @@
-import {getTextPartsToStyle, getArrayPartsToStyle} from '../TextUtils';
+import {StyleSheet} from 'react-native';
+import {getTextPartsToStyle, getArrayPartsToStyle, getPartsToStyle, unifyTextPartsStyles} from '../TextUtils';
 
 describe('Text', () => {
   describe('getTextPartsToStyle', () => {
-
     it('should return the whole string as a single part when style string is undefined', () => {
       const result = getTextPartsToStyle('Playground Screen', undefined);
       expect(result).toEqual([{string: 'Playground Screen', shouldStyle: false}]);
@@ -17,32 +17,60 @@ describe('Text', () => {
     });
     it('should break text to parts according to style string', () => {
       const result = getTextPartsToStyle('Playground Screen', 'Scr');
-      expect(result).toEqual([{string: 'Playground ', shouldStyle: false}, {string: 'Scr', shouldStyle: true}, {string: 'een', shouldStyle: false}]);
+      expect(result).toEqual([
+        {string: 'Playground ', shouldStyle: false},
+        {string: 'Scr', shouldStyle: true},
+        {string: 'een', shouldStyle: false}
+      ]);
     });
-    
+
     it('should handle case when style repeats more than once', () => {
       const result = getTextPartsToStyle('Dancing in the Dark', 'Da');
-      expect(result).toEqual([{string: 'Da', shouldStyle: true}, {string: 'ncing in the ', shouldStyle: false}, {string: 'Da', shouldStyle: true}, {string: 'rk', shouldStyle: false}]);
+      expect(result).toEqual([
+        {string: 'Da', shouldStyle: true},
+        {string: 'ncing in the ', shouldStyle: false},
+        {string: 'Da', shouldStyle: true},
+        {string: 'rk', shouldStyle: false}
+      ]);
     });
-    
+
     it('should handle ignore case-sensetive', () => {
       const result = getTextPartsToStyle('Dancing in the Dark', 'da');
-      expect(result).toEqual([{string: 'Da', shouldStyle: true}, {string: 'ncing in the ', shouldStyle: false}, {string: 'Da', shouldStyle: true}, {string: 'rk', shouldStyle: false}]);
+      expect(result).toEqual([
+        {string: 'Da', shouldStyle: true},
+        {string: 'ncing in the ', shouldStyle: false},
+        {string: 'Da', shouldStyle: true},
+        {string: 'rk', shouldStyle: false}
+      ]);
     });
 
     it('Should handle special characters @', () => {
       const result = getTextPartsToStyle('@ancing in the @ark', '@a');
-      expect(result).toEqual([{string: '@a', shouldStyle: true}, {string: 'ncing in the ', shouldStyle: false}, {string: '@a', shouldStyle: true}, {string: 'rk', shouldStyle: false}]);
+      expect(result).toEqual([
+        {string: '@a', shouldStyle: true},
+        {string: 'ncing in the ', shouldStyle: false},
+        {string: '@a', shouldStyle: true},
+        {string: 'rk', shouldStyle: false}
+      ]);
     });
 
     it('Should handle special characters !', () => {
       const result = getTextPartsToStyle('!ancing in the !ark', '!a');
-      expect(result).toEqual([{string: '!a', shouldStyle: true}, {string: 'ncing in the ', shouldStyle: false}, {string: '!a', shouldStyle: true}, {string: 'rk', shouldStyle: false}]);
+      expect(result).toEqual([
+        {string: '!a', shouldStyle: true},
+        {string: 'ncing in the ', shouldStyle: false},
+        {string: '!a', shouldStyle: true},
+        {string: 'rk', shouldStyle: false}
+      ]);
     });
 
     it('Should handle special characters starts with @', () => {
       const result = getTextPartsToStyle('uilib@wix.com', '@wix');
-      expect(result).toEqual([{string: 'uilib', shouldStyle: false}, {string: '@wix', shouldStyle: true}, {string: '.com', shouldStyle: false}]);
+      expect(result).toEqual([
+        {string: 'uilib', shouldStyle: false},
+        {string: '@wix', shouldStyle: true},
+        {string: '.com', shouldStyle: false}
+      ]);
     });
 
     it('Should handle empty string .', () => {
@@ -52,7 +80,6 @@ describe('Text', () => {
   });
 
   describe('getArrayPartsToStyle', () => {
-
     it('should return the whole string as a single part when style array is empty', () => {
       const result = getArrayPartsToStyle('Playground Screen', []);
       expect(result).toEqual([{string: 'Playground Screen', shouldStyle: false}]);
@@ -67,32 +94,233 @@ describe('Text', () => {
     });
     it('should break text to parts according to style string', () => {
       const result = getArrayPartsToStyle('Playground Screen', ['Scr']);
-      expect(result).toEqual([{string: 'Playground ', shouldStyle: false}, {string: 'Scr', shouldStyle: true}, {string: 'een', shouldStyle: false}]);
+      expect(result).toEqual([
+        {string: 'Playground ', shouldStyle: false},
+        {string: 'Scr', shouldStyle: true},
+        {string: 'een', shouldStyle: false}
+      ]);
     });
-    
+
     it('style repeats more than once should color the first match', () => {
       const result = getArrayPartsToStyle('Dancing in the Dark', ['Da']);
-      expect(result).toEqual([{string: 'Da', shouldStyle: true}, {string: 'ncing in the Dark', shouldStyle: false}]);
+      expect(result).toEqual([
+        {string: 'Da', shouldStyle: true},
+        {string: 'ncing in the Dark', shouldStyle: false}
+      ]);
     });
-    
+
     it('should handle ignore case-sensetive', () => {
       const result = getArrayPartsToStyle('Dancing in the Dark', ['da']);
-      expect(result).toEqual([{string: 'Da', shouldStyle: true}, {string: 'ncing in the Dark', shouldStyle: false}]);
+      expect(result).toEqual([
+        {string: 'Da', shouldStyle: true},
+        {string: 'ncing in the Dark', shouldStyle: false}
+      ]);
     });
 
     it('Should handle special characters @', () => {
       const result = getArrayPartsToStyle('@ancing in the @ark', ['@a']);
-      expect(result).toEqual([{string: '@a', shouldStyle: true}, {string: 'ncing in the @ark', shouldStyle: false}]);
+      expect(result).toEqual([
+        {string: '@a', shouldStyle: true},
+        {string: 'ncing in the @ark', shouldStyle: false}
+      ]);
     });
 
     it('Should handle special characters !', () => {
       const result = getArrayPartsToStyle('!ancing in the !ark', ['!a']);
-      expect(result).toEqual([{string: '!a', shouldStyle: true}, {string: 'ncing in the !ark', shouldStyle: false}]);
+      expect(result).toEqual([
+        {string: '!a', shouldStyle: true},
+        {string: 'ncing in the !ark', shouldStyle: false}
+      ]);
     });
 
     it('Should handle special characters starts with @', () => {
       const result = getArrayPartsToStyle('uilib@wix.com', ['@wix']);
-      expect(result).toEqual([{string: 'uilib', shouldStyle: false}, {string: '@wix', shouldStyle: true}, {string: '.com', shouldStyle: false}]);
+      expect(result).toEqual([
+        {string: 'uilib', shouldStyle: false},
+        {string: '@wix', shouldStyle: true},
+        {string: '.com', shouldStyle: false}
+      ]);
+    });
+  });
+
+  describe('unifyTextPartsStyles', () => {
+    it('should return the whole string as a single part when style array is empty', () => {
+      const string = 'Playground Screen';
+      const highlightTextParts = getPartsToStyle(string, []);
+      const underlineTextParts = getPartsToStyle(string, []);
+      const result = unifyTextPartsStyles(string,
+        styles.highlight,
+        styles.notHighlight,
+        styles.underline,
+        styles.notUnderline,
+        highlightTextParts,
+        underlineTextParts);
+      expect(result).toEqual([{string: 'Playground Screen', style: [{color: undefined}, {textDecorationLine: undefined}]}]);
+    });
+    it('should return the whole string as a single part when style string is empty', () => {
+      const string = 'Playground Screen';
+      const highlightTextParts = getPartsToStyle(string, ['']);
+      const underlineTextParts = getPartsToStyle(string, ['']);
+      const result = unifyTextPartsStyles(string,
+        styles.highlight,
+        styles.notHighlight,
+        styles.underline,
+        styles.notUnderline,
+        highlightTextParts,
+        underlineTextParts);
+      expect(result).toEqual([{string: 'Playground Screen', style: [{color: undefined}, {textDecorationLine: undefined}]}]);
+    });
+    it('should return the whole string as a single part when style string dont match', () => {
+      const string = 'Playground Screen';
+      const highlightTextParts = getPartsToStyle(string, ['aaa']);
+      const underlineTextParts = getPartsToStyle(string, ['bbb']);
+      const result = unifyTextPartsStyles(string,
+        styles.highlight,
+        styles.notHighlight,
+        styles.underline,
+        styles.notUnderline,
+        highlightTextParts,
+        underlineTextParts);
+      expect(result).toEqual([{string: 'Playground Screen', style: [{color: undefined}, {textDecorationLine: undefined}]}]);
+    });
+    it('should break text to parts according to style string (highlight)', () => {
+      const string = 'Playground Screen';
+      const highlightTextParts = getPartsToStyle(string, ['Scr']);
+      const underlineTextParts = getPartsToStyle(string, ['']);
+      const result = unifyTextPartsStyles(string,
+        styles.highlight,
+        styles.notHighlight,
+        styles.underline,
+        styles.notUnderline,
+        highlightTextParts,
+        underlineTextParts);
+      expect(result).toEqual([
+        {string: 'Playground ', style: [{color: undefined}, {textDecorationLine: undefined}]},
+        {string: 'Scr', style: [{color: 'red'}, {textDecorationLine: undefined}]},
+        {string: 'een', style: [{color: undefined}, {textDecorationLine: undefined}]}
+      ]);
+    });
+    it('should break text to parts according to style string (underline)', () => {
+      const string = 'Playground Screen';
+      const highlightTextParts = getPartsToStyle(string, ['']);
+      const underlineTextParts = getPartsToStyle(string, ['Scr']);
+      const result = unifyTextPartsStyles(string,
+        styles.highlight,
+        styles.notHighlight,
+        styles.underline,
+        styles.notUnderline,
+        highlightTextParts,
+        underlineTextParts);
+      expect(result).toEqual([
+        {string: 'Playground ', style: [{color: undefined}, {textDecorationLine: undefined}]},
+        {string: 'Scr', style: [{color: undefined}, {textDecorationLine: 'underline'}]},
+        {string: 'een', style: [{color: undefined}, {textDecorationLine: undefined}]}
+      ]);
+    });
+    it('should break text to parts according to style string (both)', () => {
+      const string = 'Playground Screen';
+      const highlightTextParts = getPartsToStyle(string, ['Scr']);
+      const underlineTextParts = getPartsToStyle(string, ['Scr']);
+      const result = unifyTextPartsStyles(string,
+        styles.highlight,
+        styles.notHighlight,
+        styles.underline,
+        styles.notUnderline,
+        highlightTextParts,
+        underlineTextParts);
+      expect(result).toEqual([
+        {string: 'Playground ', style: [{color: undefined}, {textDecorationLine: undefined}]},
+        {string: 'Scr', style: [{color: 'red'}, {textDecorationLine: 'underline'}]},
+        {string: 'een', style: [{color: undefined}, {textDecorationLine: undefined}]}
+      ]);
+    });
+    it('should break text to parts according to style string (different strings)', () => {
+      const string = 'Playground Screen';
+      const highlightTextParts = getPartsToStyle(string, ['Play']);
+      const underlineTextParts = getPartsToStyle(string, ['Scr']);
+      const result = unifyTextPartsStyles(string,
+        styles.highlight,
+        styles.notHighlight,
+        styles.underline,
+        styles.notUnderline,
+        highlightTextParts,
+        underlineTextParts);
+      expect(result).toEqual([
+        {string: 'Play', style: [{color: 'red'}, {textDecorationLine: undefined}]},
+        {string: 'ground ', style: [{color: undefined}, {textDecorationLine: undefined}]},
+        {string: 'Scr', style: [{color: undefined}, {textDecorationLine: 'underline'}]},
+        {string: 'een', style: [{color: undefined}, {textDecorationLine: undefined}]}
+      ]);
+    });
+    it('should break text to parts according to style string (overlapping 1)', () => {
+      const string = 'Playground Screen';
+      const highlightTextParts = getPartsToStyle(string, ['Playground']);
+      const underlineTextParts = getPartsToStyle(string, ['laygroun']);
+      const result = unifyTextPartsStyles(string,
+        styles.highlight,
+        styles.notHighlight,
+        styles.underline,
+        styles.notUnderline,
+        highlightTextParts,
+        underlineTextParts);
+      expect(result).toEqual([
+        {string: 'P', style: [{color: 'red'}, {textDecorationLine: undefined}]},
+        {string: 'laygroun', style: [{color: 'red'}, {textDecorationLine: 'underline'}]},
+        {string: 'd', style: [{color: 'red'}, {textDecorationLine: undefined}]},
+        {string: ' Screen', style: [{color: undefined}, {textDecorationLine: undefined}]}
+      ]);
+    });
+    it('should break text to parts according to style string (overlapping 2)', () => {
+      const string = 'Playground Screen';
+      const highlightTextParts = getPartsToStyle(string, ['laygroun']);
+      const underlineTextParts = getPartsToStyle(string, ['Playground']);
+      const result = unifyTextPartsStyles(string,
+        styles.highlight,
+        styles.notHighlight,
+        styles.underline,
+        styles.notUnderline,
+        highlightTextParts,
+        underlineTextParts);
+      expect(result).toEqual([
+        {string: 'P', style: [{color: undefined}, {textDecorationLine: 'underline'}]},
+        {string: 'laygroun', style: [{color: 'red'}, {textDecorationLine: 'underline'}]},
+        {string: 'd', style: [{color: undefined}, {textDecorationLine: 'underline'}]},
+        {string: ' Screen', style: [{color: undefined}, {textDecorationLine: undefined}]}
+      ]);
+    });
+    it('should break text to parts according to style string (overlapping 3)', () => {
+      const string = 'Playground Screen';
+      const highlightTextParts = getPartsToStyle(string, ['Playg']);
+      const underlineTextParts = getPartsToStyle(string, ['ground']);
+      const result = unifyTextPartsStyles(string,
+        styles.highlight,
+        styles.notHighlight,
+        styles.underline,
+        styles.notUnderline,
+        highlightTextParts,
+        underlineTextParts);
+      expect(result).toEqual([
+        {string: 'Play', style: [{color: 'red'}, {textDecorationLine: undefined}]},
+        {string: 'g', style: [{color: 'red'}, {textDecorationLine: 'underline'}]},
+        {string: 'round', style: [{color: undefined}, {textDecorationLine: 'underline'}]},
+        {string: ' Screen', style: [{color: undefined}, {textDecorationLine: undefined}]}
+      ]);
     });
   });
 });
+
+const styles = StyleSheet.create({
+  highlight: {
+    color: 'red'
+  },
+  notHighlight: {
+    color: undefined
+  },
+  underline: {
+    textDecorationLine: 'underline'
+  },
+  notUnderline: {
+    textDecorationLine: undefined
+  }
+});
+

--- a/src/utils/__tests__/TextUtils.spec.js
+++ b/src/utils/__tests__/TextUtils.spec.js
@@ -1,98 +1,98 @@
-import {getTextPartsByHighlight, getArrayPartsByHighlight} from '../TextUtils';
+import {getTextPartsToStyle, getArrayPartsToStyle} from '../TextUtils';
 
 describe('Text', () => {
-  describe('getTextPartsByHighlight', () => {
+  describe('getTextPartsToStyle', () => {
 
-    it('should return the whole string as a single part when highlight string is undefined', () => {
-      const result = getTextPartsByHighlight('Playground Screen', undefined);
-      expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
+    it('should return the whole string as a single part when style string is undefined', () => {
+      const result = getTextPartsToStyle('Playground Screen', undefined);
+      expect(result).toEqual([{string: 'Playground Screen', shouldStyle: false}]);
     });
-    it('should return the whole string as a single part when highlight string is empty', () => {
-      const result = getTextPartsByHighlight('Playground Screen', '');
-      expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
+    it('should return the whole string as a single part when style string is empty', () => {
+      const result = getTextPartsToStyle('Playground Screen', '');
+      expect(result).toEqual([{string: 'Playground Screen', shouldStyle: false}]);
     });
-    it('should return the whole string as a single part when highlight string dont match', () => {
-      const result = getTextPartsByHighlight('Playground Screen', 'aaa');
-      expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
+    it('should return the whole string as a single part when style string dont match', () => {
+      const result = getTextPartsToStyle('Playground Screen', 'aaa');
+      expect(result).toEqual([{string: 'Playground Screen', shouldStyle: false}]);
     });
-    it('should break text to parts according to highlight string', () => {
-      const result = getTextPartsByHighlight('Playground Screen', 'Scr');
-      expect(result).toEqual([{string: 'Playground ', shouldHighlight: false}, {string: 'Scr', shouldHighlight: true}, {string: 'een', shouldHighlight: false}]);
+    it('should break text to parts according to style string', () => {
+      const result = getTextPartsToStyle('Playground Screen', 'Scr');
+      expect(result).toEqual([{string: 'Playground ', shouldStyle: false}, {string: 'Scr', shouldStyle: true}, {string: 'een', shouldStyle: false}]);
     });
     
-    it('should handle case when highlight repeats more than once', () => {
-      const result = getTextPartsByHighlight('Dancing in the Dark', 'Da');
-      expect(result).toEqual([{string: 'Da', shouldHighlight: true}, {string: 'ncing in the ', shouldHighlight: false}, {string: 'Da', shouldHighlight: true}, {string: 'rk', shouldHighlight: false}]);
+    it('should handle case when style repeats more than once', () => {
+      const result = getTextPartsToStyle('Dancing in the Dark', 'Da');
+      expect(result).toEqual([{string: 'Da', shouldStyle: true}, {string: 'ncing in the ', shouldStyle: false}, {string: 'Da', shouldStyle: true}, {string: 'rk', shouldStyle: false}]);
     });
     
     it('should handle ignore case-sensetive', () => {
-      const result = getTextPartsByHighlight('Dancing in the Dark', 'da');
-      expect(result).toEqual([{string: 'Da', shouldHighlight: true}, {string: 'ncing in the ', shouldHighlight: false}, {string: 'Da', shouldHighlight: true}, {string: 'rk', shouldHighlight: false}]);
+      const result = getTextPartsToStyle('Dancing in the Dark', 'da');
+      expect(result).toEqual([{string: 'Da', shouldStyle: true}, {string: 'ncing in the ', shouldStyle: false}, {string: 'Da', shouldStyle: true}, {string: 'rk', shouldStyle: false}]);
     });
 
     it('Should handle special characters @', () => {
-      const result = getTextPartsByHighlight('@ancing in the @ark', '@a');
-      expect(result).toEqual([{string: '@a', shouldHighlight: true}, {string: 'ncing in the ', shouldHighlight: false}, {string: '@a', shouldHighlight: true}, {string: 'rk', shouldHighlight: false}]);
+      const result = getTextPartsToStyle('@ancing in the @ark', '@a');
+      expect(result).toEqual([{string: '@a', shouldStyle: true}, {string: 'ncing in the ', shouldStyle: false}, {string: '@a', shouldStyle: true}, {string: 'rk', shouldStyle: false}]);
     });
 
     it('Should handle special characters !', () => {
-      const result = getTextPartsByHighlight('!ancing in the !ark', '!a');
-      expect(result).toEqual([{string: '!a', shouldHighlight: true}, {string: 'ncing in the ', shouldHighlight: false}, {string: '!a', shouldHighlight: true}, {string: 'rk', shouldHighlight: false}]);
+      const result = getTextPartsToStyle('!ancing in the !ark', '!a');
+      expect(result).toEqual([{string: '!a', shouldStyle: true}, {string: 'ncing in the ', shouldStyle: false}, {string: '!a', shouldStyle: true}, {string: 'rk', shouldStyle: false}]);
     });
 
     it('Should handle special characters starts with @', () => {
-      const result = getTextPartsByHighlight('uilib@wix.com', '@wix');
-      expect(result).toEqual([{string: 'uilib', shouldHighlight: false}, {string: '@wix', shouldHighlight: true}, {string: '.com', shouldHighlight: false}]);
+      const result = getTextPartsToStyle('uilib@wix.com', '@wix');
+      expect(result).toEqual([{string: 'uilib', shouldStyle: false}, {string: '@wix', shouldStyle: true}, {string: '.com', shouldStyle: false}]);
     });
 
     it('Should handle empty string .', () => {
-      const result = getTextPartsByHighlight('@ancing in the @ark', '');
-      expect(result).toEqual([{string: '@ancing in the @ark', shouldHighlight: false}]);
+      const result = getTextPartsToStyle('@ancing in the @ark', '');
+      expect(result).toEqual([{string: '@ancing in the @ark', shouldStyle: false}]);
     });
   });
 
-  describe('getArrayPartsByHighlight', () => {
+  describe('getArrayPartsToStyle', () => {
 
-    it('should return the whole string as a single part when highlight array is empty', () => {
-      const result = getArrayPartsByHighlight('Playground Screen', []);
-      expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
+    it('should return the whole string as a single part when style array is empty', () => {
+      const result = getArrayPartsToStyle('Playground Screen', []);
+      expect(result).toEqual([{string: 'Playground Screen', shouldStyle: false}]);
     });
-    it('should return the whole string as a single part when highlight string is empty', () => {
-      const result = getArrayPartsByHighlight('Playground Screen', ['']);
-      expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
+    it('should return the whole string as a single part when style string is empty', () => {
+      const result = getArrayPartsToStyle('Playground Screen', ['']);
+      expect(result).toEqual([{string: 'Playground Screen', shouldStyle: false}]);
     });
-    it('should return the whole string as a single part when highlight string dont match', () => {
-      const result = getArrayPartsByHighlight('Playground Screen', ['aaa']);
-      expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
+    it('should return the whole string as a single part when style string dont match', () => {
+      const result = getArrayPartsToStyle('Playground Screen', ['aaa']);
+      expect(result).toEqual([{string: 'Playground Screen', shouldStyle: false}]);
     });
-    it('should break text to parts according to highlight string', () => {
-      const result = getArrayPartsByHighlight('Playground Screen', ['Scr']);
-      expect(result).toEqual([{string: 'Playground ', shouldHighlight: false}, {string: 'Scr', shouldHighlight: true}, {string: 'een', shouldHighlight: false}]);
+    it('should break text to parts according to style string', () => {
+      const result = getArrayPartsToStyle('Playground Screen', ['Scr']);
+      expect(result).toEqual([{string: 'Playground ', shouldStyle: false}, {string: 'Scr', shouldStyle: true}, {string: 'een', shouldStyle: false}]);
     });
     
-    it('highlight repeats more than once should color the first match', () => {
-      const result = getArrayPartsByHighlight('Dancing in the Dark', ['Da']);
-      expect(result).toEqual([{string: 'Da', shouldHighlight: true}, {string: 'ncing in the Dark', shouldHighlight: false}]);
+    it('style repeats more than once should color the first match', () => {
+      const result = getArrayPartsToStyle('Dancing in the Dark', ['Da']);
+      expect(result).toEqual([{string: 'Da', shouldStyle: true}, {string: 'ncing in the Dark', shouldStyle: false}]);
     });
     
     it('should handle ignore case-sensetive', () => {
-      const result = getArrayPartsByHighlight('Dancing in the Dark', ['da']);
-      expect(result).toEqual([{string: 'Da', shouldHighlight: true}, {string: 'ncing in the Dark', shouldHighlight: false}]);
+      const result = getArrayPartsToStyle('Dancing in the Dark', ['da']);
+      expect(result).toEqual([{string: 'Da', shouldStyle: true}, {string: 'ncing in the Dark', shouldStyle: false}]);
     });
 
     it('Should handle special characters @', () => {
-      const result = getArrayPartsByHighlight('@ancing in the @ark', ['@a']);
-      expect(result).toEqual([{string: '@a', shouldHighlight: true}, {string: 'ncing in the @ark', shouldHighlight: false}]);
+      const result = getArrayPartsToStyle('@ancing in the @ark', ['@a']);
+      expect(result).toEqual([{string: '@a', shouldStyle: true}, {string: 'ncing in the @ark', shouldStyle: false}]);
     });
 
     it('Should handle special characters !', () => {
-      const result = getArrayPartsByHighlight('!ancing in the !ark', ['!a']);
-      expect(result).toEqual([{string: '!a', shouldHighlight: true}, {string: 'ncing in the !ark', shouldHighlight: false}]);
+      const result = getArrayPartsToStyle('!ancing in the !ark', ['!a']);
+      expect(result).toEqual([{string: '!a', shouldStyle: true}, {string: 'ncing in the !ark', shouldStyle: false}]);
     });
 
     it('Should handle special characters starts with @', () => {
-      const result = getArrayPartsByHighlight('uilib@wix.com', ['@wix']);
-      expect(result).toEqual([{string: 'uilib', shouldHighlight: false}, {string: '@wix', shouldHighlight: true}, {string: '.com', shouldHighlight: false}]);
+      const result = getArrayPartsToStyle('uilib@wix.com', ['@wix']);
+      expect(result).toEqual([{string: 'uilib', shouldStyle: false}, {string: '@wix', shouldStyle: true}, {string: '.com', shouldStyle: false}]);
     });
   });
 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,3 @@
+import * as TextUtils from './TextUtils';
+
+export {TextUtils};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
       "react-native-ui-lib": ["index.d.ts"],
       "commons": ["./src/commons"],
       "helpers": ["./src/helpers"],
+      "utils": ["./src/utils"],
       "hooks": ["./src/hooks"],
       "optionalDeps": ["./src/optionalDependencies"],
       "services": ["./src/services"],


### PR DESCRIPTION
## Description
Text - add underline support (`underlineString` prop).
Moved logic to `textUtils` (added support for `utils`).
I'm not entirely happy with the new methods (`getUnifiedStyle` and `unifyTextPartsStyles`), they receive a lot of params and the latter is a bit long; however I did not see a simple way to improve the readability, maybe you will 🙏 
Reading each commit will probably make this easier.

## Changelog
Text - add underline support (`underlineString` prop)
