### PR TITLE
WheelPicker - omitting 'color' from textStyle

### DIFF
--- a/generatedTypes/src/incubator/WheelPicker/index.d.ts
+++ b/generatedTypes/src/incubator/WheelPicker/index.d.ts
@@ -41,7 +41,7 @@ export interface WheelPickerProps {
     /**
      * Row text style
      */
-    textStyle?: TextStyle;
+    textStyle?: Omit<TextStyle, 'color'>;
     /**
      * Additional label on the right of the item text
      */

--- a/src/incubator/WheelPicker/index.tsx
+++ b/src/incubator/WheelPicker/index.tsx
@@ -54,7 +54,7 @@ export interface WheelPickerProps {
   /**
    * Row text style
    */
-  textStyle?: TextStyle;
+  textStyle?: Omit<TextStyle, 'color'>;
   /**
    * Additional label on the right of the item text
    */


### PR DESCRIPTION
## Description
WheelPicker - omitting 'color' from 'textStyle' to alert user that passing the 'color' here will not work.

## Changelog
WheelPicker - omitting 'color' from textStyle