### PR TITLE
Fix ChipsInput typings

### DIFF
--- a/generatedTypes/src/components/chipsInput/index.d.ts
+++ b/generatedTypes/src/components/chipsInput/index.d.ts
@@ -3,12 +3,11 @@ import React, { Component } from 'react';
 import { ViewStyle, TextInput, NativeSyntheticEvent, TextInputKeyPressEventData, ScrollView, ScrollViewProps, TextInputProps as RNTextInputProps } from 'react-native';
 import { BaseComponentInjectedProps, TypographyModifiers } from '../../commons/new';
 import { ChipProps } from '../chip';
-import { TextFieldProps } from '../../../typings/components/Inputs';
 declare type ChipType = string | boolean | any;
 export declare type ChipsInputChipProps = ChipProps & {
     invalid?: boolean;
 };
-export declare type ChipsInputProps = TypographyModifiers & TextFieldProps & {
+export declare type ChipsInputProps = TypographyModifiers & RNTextInputProps & {
     /**
     * DEPRECATED: use chips instead. list of tags. can be string boolean or custom object when implementing getLabel
     */
@@ -132,7 +131,7 @@ declare class ChipsInput extends Component<OwnProps, State> {
     renderTag: (tag: ChipType, index: number) => JSX.Element;
     renderTagWrapper: (tag: ChipType, index: number) => JSX.Element;
     renderNewChip: () => JSX.Element[];
-    renderTitleText: () => "" | JSX.Element | undefined;
+    renderTitleText: () => any;
     renderChips: () => JSX.Element[];
     renderCharCounter(): JSX.Element | undefined;
     renderUnderline: () => JSX.Element;

--- a/src/components/chipsInput/index.tsx
+++ b/src/components/chipsInput/index.tsx
@@ -13,7 +13,9 @@ import TouchableOpacity from '../touchableOpacity';
 import Text from '../text';
 import Chip, {ChipProps} from '../chip';
 import {getValidationBasedColor, getCounterTextColor, getCounterText, getChipDismissColor, isDisabled} from './Presenter';
-import {TextFieldProps} from '../../../typings/components/Inputs';
+// TODO: We can't use these typing because they break ChipsInput typings
+// Instead we'll use TextInputProps for now till we migrate to new Incubator.TextField
+// import {TextFieldProps} from '../../../typings/components/Inputs';
 
 // TODO: support updating tags externally
 // TODO: support char array as tag creators (like comma)
@@ -22,7 +24,7 @@ import {TextFieldProps} from '../../../typings/components/Inputs';
 type ChipType = string | boolean | any;
 export type ChipsInputChipProps = ChipProps & {invalid?: boolean}
 
-export type ChipsInputProps = TypographyModifiers & TextFieldProps & {
+export type ChipsInputProps = TypographyModifiers & RNTextInputProps /* & TextFieldProps */ & {
   /**
   * DEPRECATED: use chips instead. list of tags. can be string boolean or custom object when implementing getLabel
   */
@@ -394,6 +396,7 @@ class ChipsInput extends Component<OwnProps, State> {
   }
 
   renderTitleText = () => {
+    // @ts-expect-error
     const {title, defaultChipProps} = this.props;
     const color = this.state.isFocused ? getValidationBasedColor(this.state.chips, defaultChipProps) : Colors.grey30;
     return title && (
@@ -449,6 +452,7 @@ class ChipsInput extends Component<OwnProps, State> {
   }
 
   renderTextInput() {
+    // @ts-expect-error
     const {inputStyle, selectionColor, title, ...others} = this.props;
     const {value} = this.state;
     const isLastTagMarked = this.isLastTagMarked();


### PR DESCRIPTION
## Description
There was an issue with ChipsInput typings, they weren't recognized. 
Apparently it was caused because we used the old TextField types from the manual typings folder. 
The fix here is not ideal but a temp one till we complete the migration to the new TextField

## Changelog
Fix missing ChipsInput typings