### PR TITLE
Fix issue with RN TextInput clear doesn't trigger onChangeText

### DIFF
--- a/generatedTypes/src/incubator/TextField/useImperativeInputHandle.d.ts
+++ b/generatedTypes/src/incubator/TextField/useImperativeInputHandle.d.ts
@@ -1,4 +1,4 @@
 import React from 'react';
-import { TextInput } from 'react-native';
-declare const useImperativeInputHandle: (ref: React.Ref<any>) => React.MutableRefObject<TextInput | undefined>;
+import { TextInput, TextInputProps } from 'react-native';
+declare const useImperativeInputHandle: (ref: React.Ref<any>, props: Pick<TextInputProps, 'onChangeText'>) => React.MutableRefObject<TextInput | undefined>;
 export default useImperativeInputHandle;

--- a/src/incubator/TextField/Input.tsx
+++ b/src/incubator/TextField/Input.tsx
@@ -41,7 +41,7 @@ const Input = ({
   formatter,
   ...props
 }: InputProps & ForwardRefInjectedProps) => {
-  const inputRef = useImperativeInputHandle(forwardedRef);
+  const inputRef = useImperativeInputHandle(forwardedRef, {onChangeText: props.onChangeText});
   const context = useContext(FieldContext);
   const placeholder = !context.isFocused ? props.placeholder : hint || props.placeholder;
   const inputColor = getColorByState(color, context);

--- a/src/incubator/TextField/useImperativeInputHandle.ts
+++ b/src/incubator/TextField/useImperativeInputHandle.ts
@@ -1,15 +1,19 @@
 import React, {useContext, useImperativeHandle, useRef} from 'react';
-import {TextInput} from 'react-native';
+import {TextInput, TextInputProps} from 'react-native';
 import FieldContext from './FieldContext';
 
-const useImperativeInputHandle = (ref: React.Ref<any>) => {
+const useImperativeInputHandle = (ref: React.Ref<any>, props: Pick<TextInputProps, 'onChangeText'>) => {
   const inputRef = useRef<TextInput>();
   const context = useContext(FieldContext);
   useImperativeHandle(ref, () => {
     return {
       focus: () => inputRef.current?.focus(),
       blur: () => inputRef.current?.blur(),
-      clear: () => inputRef.current?.clear(),
+      clear: () => {
+        inputRef.current?.clear();
+        // NOTE: This fixes an RN issue - when triggering imperative clear method, it doesn't call onChangeText
+        props.onChangeText?.('');
+      },
       validate: () => {
         context.validateField();
       }


### PR DESCRIPTION
## Description
This is a hotfix for current release cycle 
Fix issue with RN TextInput's clear method doesn't trigger onChangeText



## Changelog
Fix issue with RN TextInput's clear method doesn't trigger onChangeText
