### PR TITLE
Add flexGrow to textField to keep it flexed even when in a row layout

### DIFF
--- a/src/incubator/TextField/Input.tsx
+++ b/src/incubator/TextField/Input.tsx
@@ -65,6 +65,7 @@ const Input = ({
 
 const styles = StyleSheet.create({
   input: {
+    flexGrow: 1,
     textAlign: Constants.isRTL ? 'right' : 'left',
     // Setting paddingTop/Bottom separately fix height issues on iOS with multiline
     paddingTop: 0,


### PR DESCRIPTION
## Description
Add flexGrow to textField to keep it flexed even when in a row layout. 
Because elements lose their flexness when their are in a row layout, we must add the flexGrow

## Changelog
Fix TextField press area by keeping the input width flexed 
