### PR TITLE
fix/ GridView - incorrect rowCount implies wrong margin

### DIFF
--- a/src/components/gridView/index.tsx
+++ b/src/components/gridView/index.tsx
@@ -181,7 +181,7 @@ class GridView extends UIComponent<GridViewProps, GridViewState> {
 
     const {numColumns = DEFAULT_NUM_COLUMNS} = this.state;
     const itemsCount = _.size(items);
-    const rowCount = itemsCount / numColumns;
+    const rowCount = Math.ceil(itemsCount / numColumns);
     const isLastItemInRow = (index + 1) % numColumns === 0;
     const isLastRow = index + 1 > (rowCount - 1) * numColumns;
     const isLastItem = index === itemsCount - 1;


### PR DESCRIPTION
## Description
In `GridView` the `rowCount` calculations are taken without the ceiling op. This in turn affects the `isLastRow` constant which applies the bottom margin. Without the change, bottom margin is incorrectly applied in some cases, see screenshots below.

## Changelog
GridView - Applied ceiling op to `rowCount` calculation