### PR TITLE
TypeScript: Add labelStyle type for Picker.Item

### DIFF
--- a/typings/components/Picker.d.ts
+++ b/typings/components/Picker.d.ts
@@ -1,5 +1,5 @@
 import {ReactElement} from 'react';
-import {FlatListProps, GestureResponderEvent, LayoutChangeEvent} from 'react-native';
+import {FlatListProps, GestureResponderEvent, LayoutChangeEvent, StyleProp, TextStyle} from 'react-native';
 import {BaseComponent} from '../commons';
 import {TextFieldProps} from './Inputs';
 import {TopBarProps} from './Modal';
@@ -21,6 +21,7 @@ export type PickerItemRenderItemFunc = (
 
 export interface PickerItemProps {
   label?: string;
+  labelStyle?: StyleProp<TextStyle>;
   value?: PickerItemValue;
   getItemLabel?: (value?: PickerItemValue) => string;
   isSelected?: boolean;


### PR DESCRIPTION
## Description
TypeScript currently warns that labelStyle is not a prop when used in Picker.Item, so this fixes that with the proper type.

## Changelog
**TypeScript:** Add proper `labelStyle` prop type for Picker.Item