### PR TITLE
Fix issue with Carousel's containerWidth being reset

### DIFF
--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -273,7 +273,7 @@ class Carousel extends Component<CarouselProps, CarouselState> {
       layout: {width: containerWidth, height: containerHeight}
     }
   }: LayoutChangeEvent) => {
-    const {pageWidth = containerWidth, pageHeight = containerHeight} = this.props;
+    const {pageWidth = containerWidth, pageHeight = containerHeight, horizontal} = this.props;
 
     const initialOffset = presenter.calcOffset(this.props, {
       currentPage: this.state.currentPage,
@@ -281,7 +281,11 @@ class Carousel extends Component<CarouselProps, CarouselState> {
       pageHeight
     });
 
-    this.setState({containerWidth, pageWidth, pageHeight, initialOffset});
+    // NOTE: This is to avoid resetting containerWidth to 0 - an issue that happens
+    // on Android in some case when onLayout is re-triggered
+    if ((horizontal && containerWidth) || (!horizontal && containerHeight)) {
+      this.setState({containerWidth, pageWidth, pageHeight, initialOffset});
+    }
   };
 
   onMomentumScrollEnd = () => {


### PR DESCRIPTION
## Description
We found a rare issue where the Carousel component re-trigger an onLayout event (when being rendered inside a TabController page). 
The second onLayout event has containerWidth of `0` which break the functionality of Carousel's `snapToOffsets` feature. 
**This issue only happen on Android! ** 

MMV-232

## Changelog
Fix rare issue with Carousel on Android that can cause an exception
