### PR TITLE
Infra/ Incubator.WheelPicker selectedValue

### DIFF
--- a/demo/src/screens/incubatorScreens/WheelPickerScreen.tsx
+++ b/demo/src/screens/incubatorScreens/WheelPickerScreen.tsx
@@ -2,8 +2,6 @@ import React, {useCallback, useState} from 'react';
 import {View, Text, Incubator, Colors, Typography, Button, Dialog} from 'react-native-ui-lib';
 import _ from 'lodash';
 
-type WheelPickerValue = Incubator.WheelPickerProps['initialValue'];
-
 const monthItems = _.map([
   'January',
   'February',
@@ -25,10 +23,7 @@ const yearItems = _.times(2030, i => i)
   .map(item => ({label: `${item}`, value: item}));
 const dayItems = _.times(31, i => i + 1).map(day => ({label: `${day}`, value: day}));
 
-const useData = (initialMonth?: string, initialYear?: string, initialDays?: number) => {
-  const [selectedMonth, setMonth] = useState<WheelPickerValue>(initialMonth);
-  const [, setYear] = useState<WheelPickerValue>(initialYear);
-  const [selectedDays, setDays] = useState<WheelPickerValue>(initialDays);
+export default () => {
   const [showDialog, setShowDialog] = useState(false);
 
   const onPickDaysPress = useCallback(() => {
@@ -39,42 +34,6 @@ const useData = (initialMonth?: string, initialYear?: string, initialDays?: numb
     setShowDialog(false);
   }, []);
 
-  const onMonthChange = useCallback((item: WheelPickerValue, _: number) => {
-    setMonth(item);
-  }, []);
-
-  const onYearChange = useCallback((item: WheelPickerValue, _: number) => {
-    setYear(item);
-  }, []);
-
-  const onDaysChange = useCallback((item: WheelPickerValue, _: number) => {
-    setDays(item);
-  }, []);
-
-  return {
-    onMonthChange,
-    onYearChange,
-    onDaysChange,
-    selectedMonth,
-    selectedDays,
-    onPickDaysPress,
-    onDialogDismissed,
-    showDialog
-  };
-};
-
-export default () => {
-  const {
-    selectedMonth,
-    onMonthChange,
-    onYearChange,
-    selectedDays,
-    onDaysChange,
-    onPickDaysPress,
-    onDialogDismissed,
-    showDialog
-  } = useData('February', undefined, 5);
-
   return (
     <View flex padding-page>
       <Text h1>Wheel Picker</Text>
@@ -82,12 +41,11 @@ export default () => {
       <View marginT-s5 centerH>
         <Text h3>Months</Text>
         <Incubator.WheelPicker
-          onChange={onMonthChange}
+          initialValue={'February'}
           activeTextColor={Colors.primary}
           inactiveTextColor={Colors.grey20}
           items={monthItems}
           textStyle={Typography.text60R}
-          selectedValue={selectedMonth}
         />
 
         <Text h3>Years</Text>
@@ -95,19 +53,14 @@ export default () => {
           (Uncontrolled, initialValue passed)
         </Text>
         <View width={'100%'} marginT-s3>
-          <Incubator.WheelPicker
-            onChange={onYearChange}
-            numberOfVisibleRows={3}
-            initialValue={2021}
-            items={yearItems}
-          />
+          <Incubator.WheelPicker numberOfVisibleRows={3} initialValue={2022} items={yearItems}/>
         </View>
       </View>
 
       <View marginB-s10>
         <Button marginT-40 label={'Pick Days'} marginH-100 onPress={onPickDaysPress}/>
         <Dialog width={'90%'} height={260} bottom visible={showDialog} onDismiss={onDialogDismissed}>
-          <Incubator.WheelPicker onChange={onDaysChange} selectedValue={selectedDays} label={'Days'} items={dayItems}/>
+          <Incubator.WheelPicker initialValue={5} label={'Days'} items={dayItems}/>
         </Dialog>
       </View>
     </View>

--- a/demo/src/screens/incubatorScreens/WheelPickerScreen.tsx
+++ b/demo/src/screens/incubatorScreens/WheelPickerScreen.tsx
@@ -18,13 +18,19 @@ const monthItems = _.map([
 ],
 item => ({label: item, value: item}));
 
-const yearItems = _.times(2030, i => i)
+const yearItems = _.times(2050, i => i)
   .reverse()
   .map(item => ({label: `${item}`, value: item}));
 const dayItems = _.times(31, i => i + 1).map(day => ({label: `${day}`, value: day}));
 
 export default () => {
   const [showDialog, setShowDialog] = useState(false);
+  const [yearsValue, setYearsValue] = useState(2022);
+
+  const updateYearsInitialValue = useCallback((increaseYears: boolean) => {
+    increaseYears ? setYearsValue(Math.min(yearsValue + 5, 2049)) : setYearsValue(Math.max(yearsValue - 5, 0));
+  },
+  [yearsValue]);
 
   const onPickDaysPress = useCallback(() => {
     setShowDialog(true);
@@ -49,11 +55,16 @@ export default () => {
         />
 
         <Text h3>Years</Text>
-        <Text bodySmall grey30>
-          (Uncontrolled, initialValue passed)
-        </Text>
         <View width={'100%'} marginT-s3>
-          <Incubator.WheelPicker numberOfVisibleRows={3} initialValue={2022} items={yearItems}/>
+          <Incubator.WheelPicker numberOfVisibleRows={3} initialValue={yearsValue} items={yearItems}/>
+        </View>
+
+        <Text marginT-10 bodySmall grey30>
+          (update value by passing a new initialValue)
+        </Text>
+        <View marginT-10 row>
+          <Button label={'-5 years'} marginR-20 onPress={() => updateYearsInitialValue(false)}/>
+          <Button label={'+5 years'} onPress={() => updateYearsInitialValue(true)}/>
         </View>
       </View>
 

--- a/generatedTypes/src/incubator/WheelPicker/index.d.ts
+++ b/generatedTypes/src/incubator/WheelPicker/index.d.ts
@@ -9,13 +9,9 @@ export declare enum WheelPickerAlign {
 }
 export interface WheelPickerProps {
     /**
-     * Initial value (doesn't work with selectedValue)
+     * Initial value
      */
     initialValue?: ItemProps | number | string;
-    /**
-     * The current selected value
-     */
-    selectedValue?: ItemProps | number | string;
     /**
      * Data source for WheelPicker
      */
@@ -75,7 +71,7 @@ export interface WheelPickerProps {
 declare const _default: React.ComponentClass<WheelPickerProps & {
     useCustomTheme?: boolean | undefined;
 }, any> & {
-    ({ items: propItems, itemHeight, numberOfVisibleRows, activeTextColor, inactiveTextColor, textStyle, label, labelStyle, labelProps, onChange, align, style, children, initialValue, selectedValue, testID }: WheelPickerProps): JSX.Element;
+    ({ items: propItems, itemHeight, numberOfVisibleRows, activeTextColor, inactiveTextColor, textStyle, label, labelStyle, labelProps, onChange, align, style, children, initialValue, testID }: WheelPickerProps): JSX.Element;
     alignments: typeof WheelPickerAlign;
     displayName: string;
 };

--- a/generatedTypes/src/incubator/WheelPicker/usePresenter.d.ts
+++ b/generatedTypes/src/incubator/WheelPicker/usePresenter.d.ts
@@ -3,7 +3,6 @@ import { ItemProps } from './Item';
 export declare type ItemValueTypes = ItemProps | number | string;
 declare type PropTypes = {
     initialValue?: ItemValueTypes;
-    selectedValue?: ItemValueTypes;
     children?: JSX.Element | JSX.Element[];
     items?: ItemProps[];
     itemHeight: number;
@@ -15,10 +14,9 @@ declare type RowItem = {
 };
 interface Presenter {
     items: ItemProps[];
-    shouldControlComponent: (offset: number) => boolean;
     index: number;
     height: number;
     getRowItemAtOffset: (offset: number) => RowItem;
 }
-declare const usePresenter: ({ initialValue, selectedValue, children, items: propItems, itemHeight, preferredNumVisibleRows }: PropTypes) => Presenter;
+declare const usePresenter: ({ initialValue, children, items: propItems, itemHeight, preferredNumVisibleRows }: PropTypes) => Presenter;
 export default usePresenter;

--- a/src/incubator/WheelPicker/__tests__/usePresenter.spec.js
+++ b/src/incubator/WheelPicker/__tests__/usePresenter.spec.js
@@ -2,7 +2,6 @@ import usePresenter from '../usePresenter';
 import {renderHook} from '@testing-library/react-hooks';
 
 describe('WheelPicker presenter tests', () => {
-  
   const makeSUT = ({items = makeItems(9), children, initialValue, itemHeight = 10, preferredNumVisibleRows = 20}) => {
     return renderHook(() =>
       usePresenter({
@@ -17,7 +16,7 @@ describe('WheelPicker presenter tests', () => {
   const makeItems = (count, stringValue) => {
     const items = [];
     while (count >= items.length) {
-      const someData = stringValue ? (stringValue + items.length) : items.length;
+      const someData = stringValue ? stringValue + items.length : items.length;
       const item = {value: someData, label: someData};
       items.push(item);
     }
@@ -27,10 +26,10 @@ describe('WheelPicker presenter tests', () => {
   it('expect height of the content-view to be itemHeight * preferredNumVisibleRows', () => {
     let sut = makeSUT({items: makeItems(44), itemHeight: 10, preferredNumVisibleRows: 5});
     expect(sut.result.current.height).toEqual(50);
-    
+
     sut = makeSUT({items: makeItems(10), itemHeight: 20, preferredNumVisibleRows: 3});
     expect(sut.result.current.height).toEqual(60);
-    
+
     sut = makeSUT({items: makeItems(10), itemHeight: 0, preferredNumVisibleRows: 0});
     expect(sut.result.current.height).toEqual(0);
   });
@@ -56,13 +55,13 @@ describe('WheelPicker presenter tests', () => {
 
     sut = makeSUT({items: makeItems(18), initialValue: 18});
     expect(sut.result.current.index).toEqual(18);
-    
+
     sut = makeSUT({items: makeItems(18), initialValue: 99});
     expect(sut.result.current.index).toEqual(-1);
 
     sut = makeSUT({items: makeItems(0), initialValue: 99});
     expect(sut.result.current.index).toEqual(-1);
-    
+
     sut = makeSUT({items: makeItems(0), initialValue: 0});
     expect(sut.result.current.index).toEqual(0);
   });
@@ -74,7 +73,7 @@ describe('WheelPicker presenter tests', () => {
 
   it('Expect getRowItemAtOffset to return the right row for offset', () => {
     let sut = makeSUT({initialValue: 2, itemHeight: 100});
-    
+
     let offset = 300;
     expect(sut.result.current.getRowItemAtOffset(offset).value).toEqual(3);
 

--- a/src/incubator/WheelPicker/__tests__/usePresenter.spec.js
+++ b/src/incubator/WheelPicker/__tests__/usePresenter.spec.js
@@ -3,12 +3,12 @@ import {renderHook} from '@testing-library/react-hooks';
 
 describe('WheelPicker presenter tests', () => {
   
-  const makeSUT = ({selectedValue, items = makeItems(9), children, itemHeight = 10, preferredNumVisibleRows = 20}) => {
+  const makeSUT = ({items = makeItems(9), children, initialValue, itemHeight = 10, preferredNumVisibleRows = 20}) => {
     return renderHook(() =>
       usePresenter({
-        selectedValue,
         items,
         children,
+        initialValue,
         itemHeight,
         preferredNumVisibleRows
       }));
@@ -36,59 +36,49 @@ describe('WheelPicker presenter tests', () => {
   });
 
   it('Expect to find items by their string types', () => {
-    let sut = makeSUT({items: makeItems(15, 'a'), selectedValue: 'a2'});
+    let sut = makeSUT({items: makeItems(15, 'a'), initialValue: 'a2'});
     expect(sut.result.current.index).toEqual(2);
 
-    sut = makeSUT({items: makeItems(100, 'bbb'), selectedValue: 'bbb71'});
+    sut = makeSUT({items: makeItems(100, 'bbb'), initialValue: 'bbb71'});
     expect(sut.result.current.index).toEqual(71);
 
     // no data found
-    sut = makeSUT({items: makeItems(10, 'b'), selectedValue: '$$$'});
+    sut = makeSUT({items: makeItems(10, 'b'), initialValue: '$$$'});
     expect(sut.result.current.index).toEqual(-1);
   });
 
   it('Expect to find items by their number types', () => {
-    let sut = makeSUT({items: makeItems(11), selectedValue: 0});
+    let sut = makeSUT({items: makeItems(11), initialValue: 0});
     expect(sut.result.current.index).toEqual(0);
 
-    sut = makeSUT({items: makeItems(8), selectedValue: 4});
+    sut = makeSUT({items: makeItems(8), initialValue: 4});
     expect(sut.result.current.index).toEqual(4);
 
-    sut = makeSUT({items: makeItems(18), selectedValue: 18});
+    sut = makeSUT({items: makeItems(18), initialValue: 18});
     expect(sut.result.current.index).toEqual(18);
     
-    sut = makeSUT({items: makeItems(18), selectedValue: 99});
+    sut = makeSUT({items: makeItems(18), initialValue: 99});
     expect(sut.result.current.index).toEqual(-1);
 
-    sut = makeSUT({items: makeItems(0), selectedValue: 99});
+    sut = makeSUT({items: makeItems(0), initialValue: 99});
     expect(sut.result.current.index).toEqual(-1);
     
-    sut = makeSUT({items: makeItems(0), selectedValue: 0});
+    sut = makeSUT({items: makeItems(0), initialValue: 0});
     expect(sut.result.current.index).toEqual(0);
   });
 
   it('Expect to find items by their object of {value, label} types', () => {
-    const {result} = makeSUT({items: makeItems(15, 'b'), selectedValue: {value: 'b6', label: 'abc'}});
+    const {result} = makeSUT({items: makeItems(15, 'b'), initialValue: {value: 'b6', label: 'abc'}});
     expect(result.current.index).toEqual(6);
   });
 
-  it('Expect component to be controlled and not change by offset', () => {
-    const {result} = makeSUT({selectedValue: 2, itemHeight: 100});
-    
-    let offset = 300;
-    expect(result.current.shouldControlComponent(offset)).toEqual(true);
-    
-    offset = 200;
-    expect(result.current.shouldControlComponent(offset)).toEqual(false);
-  });
-
   it('Expect getRowItemAtOffset to return the right row for offset', () => {
-    let sut = makeSUT({selectedValue: 2, itemHeight: 100});
+    let sut = makeSUT({initialValue: 2, itemHeight: 100});
     
     let offset = 300;
     expect(sut.result.current.getRowItemAtOffset(offset).value).toEqual(3);
 
-    sut = makeSUT({selectedValue: 0, itemHeight: 100});
+    sut = makeSUT({initialValue: 0, itemHeight: 100});
     offset = 0;
     expect(sut.result.current.getRowItemAtOffset(offset).value).toEqual(0);
   });

--- a/src/incubator/WheelPicker/index.tsx
+++ b/src/incubator/WheelPicker/index.tsx
@@ -134,12 +134,14 @@ const WheelPicker = ({
     } else {
       onChange?.(value, index);
     }
-  }, [initialValue, onChange]);
+  },
+  [initialValue, onChange]);
 
   const onValueChange = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
     const {index, value} = getRowItemAtOffset(event.nativeEvent.contentOffset.y);
     _onChange(value, index);
-  }, [_onChange, getRowItemAtOffset]);
+  },
+  [_onChange, getRowItemAtOffset]);
 
   const onMomentumScrollEndAndroid = (index: number) => {
     // handle Android bug: ScrollView does not call 'onMomentumScrollEnd' when scrolled programmatically (https://github.com/facebook/react-native/issues/26661)
@@ -172,7 +174,8 @@ const WheelPicker = ({
 
   const selectItem = useCallback(index => {
     scrollToIndex(index, true);
-  }, [itemHeight]);
+  },
+  [itemHeight]);
 
   const renderItem = useCallback(({item, index}) => {
     return (
@@ -192,11 +195,13 @@ const WheelPicker = ({
         testID={`${testID}.item_${index}`}
       />
     );
-  }, [itemHeight]);
+  },
+  [itemHeight]);
 
   const getItemLayout = useCallback((_data, index: number) => {
     return {length: itemHeight, offset: itemHeight * index, index};
-  }, [itemHeight]);
+  },
+  [itemHeight]);
 
   const updateFlatListWidth = useCallback((width: number) => {
     setFlatListWidth(width);
@@ -238,7 +243,8 @@ const WheelPicker = ({
 
   const fader = useMemo(() => (position: FaderPosition) => {
     return <Fader visible position={position} size={60}/>;
-  }, []);
+  },
+  []);
 
   const separators = useMemo(() => {
     return (

--- a/src/incubator/WheelPicker/index.tsx
+++ b/src/incubator/WheelPicker/index.tsx
@@ -21,13 +21,9 @@ export enum WheelPickerAlign {
 
 export interface WheelPickerProps {
   /**
-   * Initial value (doesn't work with selectedValue)
+   * Initial value
    */
   initialValue?: ItemProps | number | string;
-  /**
-   * The current selected value
-   */
-  selectedValue?: ItemProps | number | string;
   /**
    * Data source for WheelPicker
    */
@@ -99,8 +95,7 @@ const WheelPicker = ({
   align = WheelPickerAlign.CENTER,
   style,
   children,
-  initialValue,
-  selectedValue,
+  initialValue = 0,
   testID
 }: WheelPickerProps) => {
   const scrollView = useRef<Animated.ScrollView>();
@@ -112,12 +107,10 @@ const WheelPicker = ({
   const {
     height,
     items,
-    shouldControlComponent,
     index: currentIndex,
     getRowItemAtOffset
   } = usePresenter({
     initialValue,
-    selectedValue,
     items: propItems,
     children,
     itemHeight,
@@ -126,16 +119,8 @@ const WheelPicker = ({
 
   const prevInitialValue = useRef(initialValue);
   const prevIndex = useRef(currentIndex);
-  const [scrollOffset, setScrollOffset] = useState(currentIndex * itemHeight);
   const [flatListWidth, setFlatListWidth] = useState(0);
   const keyExtractor = useCallback((item: ItemProps, index: number) => `${item}.${index}`, []);
-
-  useEffect(() => {
-    // This effect enforce the index to be controlled by selectedValue passed by the user
-    if (shouldControlComponent(scrollOffset)) {
-      scrollToIndex(currentIndex, true);
-    }
-  });
 
   useEffect(() => {
     // This effect making sure to reset index if initialValue has changed
@@ -152,7 +137,6 @@ const WheelPicker = ({
   }, [initialValue, onChange]);
 
   const onValueChange = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
-    setScrollOffset(event.nativeEvent.contentOffset.y);
     const {index, value} = getRowItemAtOffset(event.nativeEvent.contentOffset.y);
     _onChange(value, index);
   }, [_onChange, getRowItemAtOffset]);

--- a/src/incubator/WheelPicker/usePresenter.ts
+++ b/src/incubator/WheelPicker/usePresenter.ts
@@ -48,7 +48,7 @@ const usePresenter = ({
     if (_.isString(value) || _.isNumber(value)) {
       return _.findIndex(items, {value});
     }
-    return _.findIndex(items, {value: (value)?.value});
+    return _.findIndex(items, {value: value?.value});
   };
 
   const getRowItemAtOffset = (offset: number): RowItem => {

--- a/src/incubator/WheelPicker/usePresenter.ts
+++ b/src/incubator/WheelPicker/usePresenter.ts
@@ -32,7 +32,6 @@ const usePresenter = ({
   itemHeight,
   preferredNumVisibleRows
 }: PropTypes): Presenter => {
-  const value = initialValue;
   const extractItemsFromChildren = (): ItemProps[] => {
     const items = React.Children.map(children, child => {
       const childAsType: ItemProps = {value: child?.props.value, label: child?.props.label};
@@ -45,10 +44,10 @@ const usePresenter = ({
   const middleIndex = useMiddleIndex({itemHeight, listSize: items.length});
 
   const getSelectedValueIndex = () => {
-    if (_.isString(value) || _.isNumber(value)) {
-      return _.findIndex(items, {value});
+    if (_.isString(initialValue) || _.isNumber(initialValue)) {
+      return _.findIndex(items, {value: initialValue});
     }
-    return _.findIndex(items, {value: value?.value});
+    return _.findIndex(items, {value: initialValue?.value});
   };
 
   const getRowItemAtOffset = (offset: number): RowItem => {

--- a/src/incubator/WheelPicker/usePresenter.ts
+++ b/src/incubator/WheelPicker/usePresenter.ts
@@ -7,7 +7,6 @@ export type ItemValueTypes = ItemProps | number | string;
 
 type PropTypes = {
   initialValue?: ItemValueTypes;
-  selectedValue?: ItemValueTypes;
   children?: JSX.Element | JSX.Element[];
   items?: ItemProps[];
   itemHeight: number;
@@ -21,21 +20,19 @@ type RowItem = {
 
 interface Presenter {
   items: ItemProps[];
-  shouldControlComponent: (offset: number) => boolean;
   index: number;
   height: number;
   getRowItemAtOffset: (offset: number) => RowItem;
 }
 
 const usePresenter = ({
-  initialValue,
-  selectedValue,
+  initialValue = 0,
   children,
   items: propItems,
   itemHeight,
   preferredNumVisibleRows
 }: PropTypes): Presenter => {
-  const value = !_.isUndefined(selectedValue) ? selectedValue : initialValue;
+  const value = initialValue;
   const extractItemsFromChildren = (): ItemProps[] => {
     const items = React.Children.map(children, child => {
       const childAsType: ItemProps = {value: child?.props.value, label: child?.props.label};
@@ -54,13 +51,6 @@ const usePresenter = ({
     return _.findIndex(items, {value: (value)?.value});
   };
 
-  const shouldControlComponent = (offset: number): boolean => {
-    if (!_.isUndefined(selectedValue)) {
-      return offset >= 0 && selectedValue !== getRowItemAtOffset(offset).value;
-    }
-    return false;
-  };
-
   const getRowItemAtOffset = (offset: number): RowItem => {
     const index = middleIndex(offset);
     const value = items[index].value;
@@ -68,7 +58,6 @@ const usePresenter = ({
   };
 
   return {
-    shouldControlComponent,
     index: getSelectedValueIndex(),
     items,
     height: itemHeight * preferredNumVisibleRows,


### PR DESCRIPTION
## Description
Deprecate Incubator.WheelPicker `selectedValue` prop in favor of `initialValue`
(All the relevant changes are in the first commit, the second is only about formatting) 
WOAUILIB-2308

## Changelog
BREAKING CHANGE - Deprecate Incubator.WheelPicker `selectedValue` prop in favor of `initialValue`
