### PR TITLE
disable scroll for less than 1 pixel

### DIFF
--- a/src/commons/withScrollEnabler.tsx
+++ b/src/commons/withScrollEnabler.tsx
@@ -25,7 +25,7 @@ function withScrollEnabler<PROPS, STATICS = {}>(WrappedComponent: React.Componen
     const layoutSize = useRef(0);
 
     const checkScroll = useCallback(() => {
-      const isScrollEnabled = contentSize.current > layoutSize.current;
+      const isScrollEnabled = (contentSize.current - 1) > layoutSize.current;
       if (isScrollEnabled !== scrollEnabled) {
         setScrollEnabled(isScrollEnabled);
       }


### PR DESCRIPTION
## Description
should prevent situations where a friction of pixel enables scroll and hence causes the scrollview-fader appear with no reason
