### PR TITLE
Reanimated 2.4 - fix error in Incubator.TouchableOpacity

### DIFF
--- a/src/incubator/TouchableOpacity.tsx
+++ b/src/incubator/TouchableOpacity.tsx
@@ -12,6 +12,7 @@ import Reanimated, {
 import {TapGestureHandler, LongPressGestureHandler, State} from 'react-native-gesture-handler';
 import {asBaseComponent, forwardRef, BaseComponentInjectedProps, ForwardRefInjectedProps} from '../commons/new';
 import View, {ViewProps} from '../components/view';
+import {Colors} from '../../src/style';
 
 export type TouchableOpacityProps = {
   /**
@@ -85,7 +86,7 @@ function TouchableOpacity(props: Props) {
   const isLongPressed = useSharedValue(false);
 
   const backgroundColor = useMemo(() => {
-    return props.backgroundColor || modifiers.backgroundColor;
+    return props.backgroundColor || modifiers.backgroundColor || Colors.transparent;
   }, [props.backgroundColor, modifiers.backgroundColor]);
 
   const onPress = useCallback(() => {
@@ -164,7 +165,7 @@ function TouchableOpacity(props: Props) {
               paddings,
               margins,
               alignments,
-              backgroundColor && {backgroundColor},
+              {backgroundColor},
               style,
               animatedStyle
             ]}


### PR DESCRIPTION
## Description
Reanimated 2.4 - fix error in Incubator.TouchableOpacity
`Error: Interpolation input and output should contain at least two values.`

The user does not `have` to pass any color, and reanimated requires values in the interpolation, instead of skipping the interpolation I chose to initialize with `transparent`.

## Changelog
Reanimated 2.4 - fix error in Incubator.TouchableOpacity