### PR TITLE
Avoid blocking TabBarItem re-onLayout callback

### DIFF
--- a/src/components/tabController/TabBarItem.tsx
+++ b/src/components/tabController/TabBarItem.tsx
@@ -132,7 +132,7 @@ export default function TabBarItem({
   const sharedSelectedLabelStyle = useSharedValue(JSON.parse(JSON.stringify(selectedLabelStyle)));
 
   useEffect(() => {
-    if (itemWidth.current) {
+    if (props.width) {
       props.onLayout?.({nativeEvent: {layout: {x: 0, y: 0, width: itemWidth.current, height: 0}}} as LayoutChangeEvent,
         index);
     }
@@ -149,7 +149,7 @@ export default function TabBarItem({
   const onLayout = useCallback((event: LayoutChangeEvent) => {
     const {width} = event.nativeEvent.layout;
 
-    if (!itemWidth.current && itemRef?.current) {
+    if (!props.width && itemRef?.current) {
       itemWidth.current = width;
       // @ts-ignore
       itemRef.current?.setNativeProps({style: {width, paddingHorizontal: null, flex: null}});


### PR DESCRIPTION
## Description
Avoid blocking TabBarItem re-onLayout callback

To reproduce (copy in playground) 
```
const twoItems = [
  {label: 'February', key: 'feb'},
  {label: 'April', key: 'apr'}
];
const threeItems = [
  {label: 'February', key: 'feb'},
  {label: 'March', key: 'mar'},
  {label: 'April', key: 'apr'}
];

export default class PlaygroundScreen extends Component {
  state = {
    items: twoItems
  };

  onPress = () => {
    this.setState({
      items: this.state.items.length === 2 ? threeItems : twoItems
    });
  };

  render() {
    return (
      <View bg-grey80 flex>
        <View center padding-page>
          <Button label="Change items" onPress={this.onPress}/>
        </View>
        <TabController items={this.state.items}>
          <TabController.TabBar/>
        </TabController>
      </View>
    );
  }
}
```


## Changelog
Fix issue with TabController items not calculating their layout after change in items 
