### PR TITLE
eslint no-hard-coded-colors allow null

### DIFF
--- a/eslint-rules/lib/rules/no-hard-coded-color.js
+++ b/eslint-rules/lib/rules/no-hard-coded-color.js
@@ -79,6 +79,10 @@ module.exports = {
     const colorExceptions = ['transparent'];
 
     function isColorException(colorString = '') {
+      if (colorString === null) {
+        return true;
+      }
+
       const lowerCaseColorString = colorString.toLowerCase();
       return colorExceptions.indexOf(lowerCaseColorString) !== -1;
     }

--- a/eslint-rules/package.json
+++ b/eslint-rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-uilib",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "uilib set of eslint rules",
   "keywords": [
     "eslint",


### PR DESCRIPTION
## Description
eslint no-hard-coded-colors allow null
This is relevant for the `Icon Component Migration`

## Changelog
eslint no-hard-coded-colors allow null