### PR TITLE
Support passing useSafeArea for Picker modal content

### DIFF
--- a/generatedTypes/src/components/picker/types.d.ts
+++ b/generatedTypes/src/components/picker/types.d.ts
@@ -146,6 +146,10 @@ export interface PickerBaseProps extends Omit<TextFieldProps, 'value' | 'onChang
      */
     onShow?: () => void;
     /**
+     * Add safe area in the Picker modal view
+     */
+    useSafeArea?: boolean;
+    /**
      * Component test id
      */
     testID?: string;
@@ -211,5 +215,5 @@ export interface PickerContextProps extends Pick<PickerProps, 'migrate' | 'value
     onSelectedLayout: (event: any) => any;
     selectionLimit: PickerProps['selectionLimit'];
 }
-export declare type PickerItemsListProps = Pick<PropsWithChildren<PickerProps>, 'topBarProps' | 'listProps' | 'children' | 'showSearch' | 'searchStyle' | 'searchPlaceholder' | 'onSearchChange' | 'renderCustomSearch' | 'testID'>;
+export declare type PickerItemsListProps = Pick<PropsWithChildren<PickerProps>, 'topBarProps' | 'listProps' | 'children' | 'showSearch' | 'searchStyle' | 'searchPlaceholder' | 'onSearchChange' | 'renderCustomSearch' | 'useSafeArea' | 'testID'>;
 export {};

--- a/src/components/picker/PickerItemsList.tsx
+++ b/src/components/picker/PickerItemsList.tsx
@@ -20,6 +20,7 @@ const PickerItemsList = (props: PickerItemsListProps) => {
     searchPlaceholder = 'Search...',
     onSearchChange,
     renderCustomSearch,
+    useSafeArea,
     testID
   } = props;
 
@@ -51,10 +52,11 @@ const PickerItemsList = (props: PickerItemsListProps) => {
 
   const renderItem = useCallback(({index}) => {
     return React.Children.toArray(children)[index];
-  }, [children]);
+  },
+  [children]);
 
   return (
-    <>
+    <View useSafeArea={useSafeArea}>
       <Modal.TopBar {...topBarProps}/>
       {renderSearchInput()}
 
@@ -65,7 +67,7 @@ const PickerItemsList = (props: PickerItemsListProps) => {
         keyExtractor={keyExtractor}
         {...listProps}
       />
-    </>
+    </View>
   );
 };
 

--- a/src/components/picker/api/picker.api.json
+++ b/src/components/picker/api/picker.api.json
@@ -90,7 +90,8 @@
       "type": "FlatListProps",
       "description": "Pass props to the list component that wraps the picker options (allows to control FlatList behavior)"
     },
-    {"name": "pickerModalProps", "type": "ModalProps", "description": "Pass props to the picker modal"}
+    {"name": "pickerModalProps", "type": "ModalProps", "description": "Pass props to the picker modal"},
+    {"name": "useSafeArea", "type": "boolean", "description": "Add safe area in the Picker modal view"}
   ],
   "snippet": [
     "<Picker",
@@ -104,3 +105,4 @@
     "</Picker>"
   ]
 }
+   

--- a/src/components/picker/new.tsx
+++ b/src/components/picker/new.tsx
@@ -5,7 +5,7 @@
 // TODO: consider deprecating renderCustomModal prop
 // TODO: deprecate onShow cause it's already supported by passing it in pickerModalProps
 import _ from 'lodash';
-import React, {useMemo, useState, useRef, PropsWithChildren} from 'react';
+import React, {useMemo, useState, useRef, PropsWithChildren, useCallback} from 'react';
 import {LayoutChangeEvent} from 'react-native';
 import {
   Constants,
@@ -59,6 +59,7 @@ const Picker = (props: PropsWithChildren<PickerProps> & ForwardRefInjectedProps 
     getItemValue,
     renderItem,
     children,
+    useSafeArea,
     migrate,
     migrateTextField,
     ...others
@@ -168,6 +169,7 @@ const Picker = (props: PropsWithChildren<PickerProps> & ForwardRefInjectedProps 
         onSearchChange={_onSearchChange}
         renderCustomSearch={renderCustomSearch}
         listProps={listProps}
+        useSafeArea={useSafeArea}
       >
         {filteredChildren}
       </PickerItemsList>
@@ -186,7 +188,8 @@ const Picker = (props: PropsWithChildren<PickerProps> & ForwardRefInjectedProps 
     _onSearchChange,
     renderCustomSearch,
     listProps,
-    filteredChildren
+    filteredChildren,
+    useSafeArea
   ]);
 
   if (useNativePicker) {

--- a/src/components/picker/types.tsx
+++ b/src/components/picker/types.tsx
@@ -159,6 +159,10 @@ export interface PickerBaseProps extends Omit<TextFieldProps, 'value' | 'onChang
    */
   onShow?: () => void;
   /**
+   * Add safe area in the Picker modal view
+   */
+  useSafeArea?: boolean;
+  /**
    * Component test id
    */
   testID?: string;
@@ -241,5 +245,6 @@ export type PickerItemsListProps = Pick<
   | 'searchPlaceholder'
   | 'onSearchChange'
   | 'renderCustomSearch'
+  | 'useSafeArea'
   | 'testID'
 >;


### PR DESCRIPTION
## Description
Support useSafeArea prop for Picker that is passed into the Modal content

This should fix #1710 

## Changelog
Fix #1710 - Support adding safe area to Picker modal content by passing useSafeArea prop (useful for Expo users)