### PR TITLE
SvgImage - add missing optional chaining

### DIFF
--- a/src/utils/imageUtils.ts
+++ b/src/utils/imageUtils.ts
@@ -4,7 +4,7 @@ import Assets from '../assets';
 
 export function isSvgUri(source: ImageProps['source']) {
   // @ts-expect-error
-  return typeof source === 'object' && source?.uri?.endsWith('.svg');
+  return typeof source === 'object' && source?.uri?.endsWith?.('.svg');
 }
 
 export function isSvg(source: ImageProps['source']) {


### PR DESCRIPTION
## Description
SvgImage - add missing optional chaining

Should fix #1809

## Changelog
Fix #1809 - SvgImage - add missing optional chaining