### PR TITLE
SvgImage - remove tintColor to fix Android crash

### DIFF
--- a/generatedTypes/src/components/svgImage/index.d.ts
+++ b/generatedTypes/src/components/svgImage/index.d.ts
@@ -1,5 +1,9 @@
 /// <reference types="react" />
 export interface SvgImageProps {
+    /**
+     * the asset tint
+     */
+    tintColor?: string | null;
     data: any;
 }
 declare function SvgImage(props: SvgImageProps): JSX.Element | null;

--- a/src/components/svgImage/index.tsx
+++ b/src/components/svgImage/index.tsx
@@ -15,7 +15,7 @@ export interface SvgImageProps {
 
 function SvgImage(props: SvgImageProps) {
   // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
-  const {data, tintColor: _tintColor, ...others} = props;
+  const {data, tintColor, ...others} = props;
 
   if (!SvgXml) {
     // eslint-disable-next-line max-len

--- a/src/components/svgImage/index.tsx
+++ b/src/components/svgImage/index.tsx
@@ -6,11 +6,16 @@ const SvgCssUri = SvgPackage?.SvgCssUri;
 // const SvgProps = SvgPackage?.SvgProps; TODO: not sure how (or if) we can use their props
 
 export interface SvgImageProps {
+  /**
+   * the asset tint
+   */
+  tintColor?: string | null;
   data: any; // TODO: I thought this should be string | React.ReactNode but it doesn't work properly
 }
 
 function SvgImage(props: SvgImageProps) {
-  const {data, ...others} = props;
+  // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+  const {data, tintColor: _tintColor, ...others} = props;
 
   if (!SvgXml) {
     // eslint-disable-next-line max-len


### PR DESCRIPTION
## Description
SvgImage - remove tintColor to fix Android crash

## Changelog
SvgImage - remove tintColor to fix Android crash