### PR TITLE
Support using PlatformColor for designTokens

### DIFF
--- a/src/style/colors.ts
+++ b/src/style/colors.ts
@@ -4,7 +4,7 @@ import Color from 'color';
 import tinycolor from 'tinycolor2';
 import {colorsPalette, themeColors} from './colorsPalette';
 import DesignTokens from './designTokens';
-import DesignTokensDM from './designTokensDM';
+// import DesignTokensDM from './designTokensDM';
 //@ts-ignore
 import ColorName from './colorName';
 import Scheme, {Schemes, SchemeType} from './scheme';
@@ -16,7 +16,9 @@ export class Colors {
   constructor() {
     const colors = Object.assign(colorsPalette, themeColors);
     Object.assign(this, colors);
-    this.loadSchemes({light: DesignTokens, dark: DesignTokensDM});
+    // TODO: For now we load the same design tokens for both schemes to not force it until it's ready
+    this.loadSchemes({light: DesignTokens, dark: DesignTokens});
+    // this.loadSchemes({light: DesignTokens, dark: DesignTokensDM});
 
     Scheme.addChangeListener(() => {
       Object.assign(this, Scheme.getScheme());

--- a/src/style/colors.ts
+++ b/src/style/colors.ts
@@ -14,8 +14,9 @@ export class Colors {
   private shouldSupportDarkMode = false;
 
   constructor() {
-    const colors = Object.assign(colorsPalette, DesignTokens, themeColors);
+    const colors = Object.assign(colorsPalette, themeColors);
     Object.assign(this, colors);
+    this.loadSchemes({light: DesignTokens, dark: DesignTokensDM});
 
     Scheme.addChangeListener(() => {
       Object.assign(this, Scheme.getScheme());
@@ -62,9 +63,14 @@ export class Colors {
    * and change the design tokens accordingly
    */
   supportDarkMode() {
-    const designTokensColors = Scheme.getSchemeType() === 'dark' ? DesignTokensDM : DesignTokens;
     this.shouldSupportDarkMode = true;
-    Object.assign(this, designTokensColors);
+  }
+
+  /**
+   * Should use RN PlatformColor API for retrieving design token colors from native
+   */
+  enablePlatformColors() {
+    Scheme.enablePlatformColors();
   }
 
   /**

--- a/src/style/scheme.ts
+++ b/src/style/scheme.ts
@@ -1,6 +1,6 @@
 import {Appearance, PlatformColor} from 'react-native';
 import {remove, xor, isEmpty, merge, forEach, cloneDeep} from 'lodash';
-import {Constants} from '../commons/new';
+import Constants from '../commons/Constants';
 
 export type Schemes = {light: {[key: string]: string}; dark: {[key: string]: string}};
 export type SchemeType = 'default' | 'light' | 'dark';

--- a/src/style/scheme.ts
+++ b/src/style/scheme.ts
@@ -1,5 +1,5 @@
 import {Appearance, PlatformColor} from 'react-native';
-import {remove, xor, isEmpty, merge, forEach} from 'lodash';
+import {remove, xor, isEmpty, merge, forEach, cloneDeep} from 'lodash';
 
 export type Schemes = {light: {[key: string]: string}; dark: {[key: string]: string}};
 export type SchemeType = 'default' | 'light' | 'dark';
@@ -62,7 +62,7 @@ class Scheme {
       throw new Error(`There is a mismatch in scheme keys: ${missingKeys.join(', ')}`);
     }
 
-    const platformColorsSchemes: Schemes = {...schemes};
+    const platformColorsSchemes: Schemes = cloneDeep(schemes);
 
     forEach(schemes, (scheme, schemeKey) => {
       forEach(scheme, (colorValue, colorKey) => {
@@ -70,7 +70,7 @@ class Scheme {
         Object.defineProperty(platformColorsSchemes[schemeKey], colorKey, {
           get: () => {
             if (this.usePlatformColors) {
-              PlatformColor(colorKey);
+              return PlatformColor(colorKey);
             } else {
               return colorValue;
             }

--- a/src/style/scheme.ts
+++ b/src/style/scheme.ts
@@ -1,5 +1,6 @@
 import {Appearance, PlatformColor} from 'react-native';
 import {remove, xor, isEmpty, merge, forEach, cloneDeep} from 'lodash';
+import {Constants} from '../commons/new';
 
 export type Schemes = {light: {[key: string]: string}; dark: {[key: string]: string}};
 export type SchemeType = 'default' | 'light' | 'dark';
@@ -70,7 +71,12 @@ class Scheme {
         Object.defineProperty(platformColorsSchemes[schemeKey], colorKey, {
           get: () => {
             if (this.usePlatformColors) {
-              return PlatformColor(colorKey);
+              if (Constants.isAndroid) {
+                // Remove the $ prefix cause it's not allowed in Android and add the @color prefix
+                return PlatformColor(`@color/${colorKey.replace(/^[$]/, '')}`);
+              } else {
+                return PlatformColor(colorKey);
+              }
             } else {
               return colorValue;
             }


### PR DESCRIPTION
## Description
I added support for reading native colors using RN PlatfomColor API for loaded design tokens. 
This will only work when the user purposely enable this feature by calling `Colors.enabledPlatformColors`
The reason for that is that the users must load the relevant colors in their native code. 

For now, this will be false in the public code. 
We will enable this and load the platform colors in native only in private for now. 

Unfortunately, PlatformColor API is not so flexible, for instance I can't try/catch it and return the original JS color, like this
```
try {
  return PlatformColor('$myToken');
} catch (error) {
  return actualTokenValue;
}
```

## Changelog
Support using RN PlatformColor API for loaded design tokens
