### PR TITLE
enh: allow Incubator.WheelPicker to take custom properties for the Fader

### DIFF
--- a/src/components/sectionsWheelPicker/sectionsWheelPicker.api.json
+++ b/src/components/sectionsWheelPicker/sectionsWheelPicker.api.json
@@ -24,9 +24,8 @@
     {"name": "inactiveTextColor", "type": "string", "description": "Text color for other, non-focused rows"},
     {"name": "textStyle", "type": "TextStyle", "description": "Row text style"},
     {"name": "xxx", "type": "xxxx", "description": "xxxxx"},
-    {"name": "testID", "type": "string", "description": "The component test id"}
+    {"name": "testID", "type": "string", "description": "The component test id"},
+    {"name": "faderProps", "type": "FaderProps", "description": "Custom props for fader."}
   ],
-  "snippet": [
-    "<SectionsWheelPicker sections={$1}/>"
-  ]
+  "snippet": ["<SectionsWheelPicker sections={$1}/>"]
 }

--- a/src/incubator/WheelPicker/index.tsx
+++ b/src/incubator/WheelPicker/index.tsx
@@ -6,7 +6,7 @@ import Animated, {useSharedValue, useAnimatedScrollHandler} from 'react-native-r
 import {Colors, Spacings} from 'style';
 import {Constants, asBaseComponent} from '../../commons/new';
 import View from '../../components/view';
-import Fader, {FaderPosition} from '../../components/fader';
+import Fader, {FaderPosition, FaderProps} from '../../components/fader';
 import Item, {ItemProps} from './Item';
 import Text, {TextProps} from '../../components/text';
 import usePresenter from './usePresenter';
@@ -78,6 +78,10 @@ export interface WheelPickerProps {
    */
   separatorsStyle?: ViewStyle;
   testID?: string;
+  /**
+   * Change the default (white) tint color of the fade view.
+   */
+  faderProps?: Omit<FaderProps, 'visible' | 'position'>;
 }
 
 const WheelPicker = ({
@@ -96,7 +100,8 @@ const WheelPicker = ({
   children,
   initialValue = 0,
   separatorsStyle,
-  testID
+  testID,
+  faderProps
 }: WheelPickerProps) => {
   const scrollView = useRef<Animated.ScrollView>();
   const offset = useSharedValue(0);
@@ -242,7 +247,7 @@ const WheelPicker = ({
   }, [flatListWidth, labelContainerStyle, label, labelProps, activeTextColor, labelStyle]);
 
   const fader = useMemo(() => (position: FaderPosition) => {
-    return <Fader visible position={position} size={60}/>;
+    return <Fader visible position={position} size={60} {...faderProps} />;
   },
   []);
 


### PR DESCRIPTION
## Description

`Incubator.WheelPicker` did not allow changing the fader tint. Which makes it hard to style for Dark mode 

<img width="424" alt="Screen Shot 2022-04-04 at 8 11 41 PM" src="https://user-images.githubusercontent.com/755568/161872252-d7849e1a-1075-49bb-9ab2-deb3183a97c9.png">

This PR allows users to pass in `tintColor` to the `Incubator.WheelPicker` and forward it to the `<Fader />` component.

## Changelog
- Allows to pass in `tintColor` to the `Incubator.WheelPicker` and forward it to the `<Fader />` component.
