### PR TITLE
Fix PlatfromColor issue in TabController.TabBarItem

### DIFF
--- a/src/components/tabController/TabBarItem.tsx
+++ b/src/components/tabController/TabBarItem.tsx
@@ -131,6 +131,8 @@ export default function TabBarItem({
   const sharedLabelStyle = useSharedValue(JSON.parse(JSON.stringify(labelStyle)));
   const sharedSelectedLabelStyle = useSharedValue(JSON.parse(JSON.stringify(selectedLabelStyle)));
 
+  // NOTE: We clone these color values in refs because they might contain a PlatformColor value
+  //       which throws an error (see https://github.com/software-mansion/react-native-reanimated/issues/3164)
   const inactiveColor = useRef(_.cloneDeep(labelColor));
   const activeColor = useRef(_.cloneDeep(!ignore ? selectedLabelColor : inactiveColor.current));
 

--- a/src/components/tabController/TabBarItem.tsx
+++ b/src/components/tabController/TabBarItem.tsx
@@ -108,8 +108,8 @@ interface Props extends TabControllerItemProps {
 export default function TabBarItem({
   index,
   label,
-  labelColor,
-  selectedLabelColor,
+  labelColor = DEFAULT_LABEL_COLOR,
+  selectedLabelColor = DEFAULT_SELECTED_LABEL_COLOR,
   labelStyle,
   selectedLabelStyle,
   icon,
@@ -130,6 +130,9 @@ export default function TabBarItem({
   // JSON.parse(JSON.stringify is due to an issue with reanimated
   const sharedLabelStyle = useSharedValue(JSON.parse(JSON.stringify(labelStyle)));
   const sharedSelectedLabelStyle = useSharedValue(JSON.parse(JSON.stringify(selectedLabelStyle)));
+
+  const inactiveColor = useRef(_.cloneDeep(labelColor));
+  const activeColor = useRef(_.cloneDeep(!ignore ? selectedLabelColor : inactiveColor.current));
 
   useEffect(() => {
     if (props.width) {
@@ -165,21 +168,15 @@ export default function TabBarItem({
 
   const animatedLabelColorStyle = useAnimatedStyle(() => {
     const isActive = currentPage.value === index;
-    const inactiveColor = labelColor || DEFAULT_LABEL_COLOR;
-    const activeColor = !ignore ? selectedLabelColor || DEFAULT_SELECTED_LABEL_COLOR : inactiveColor;
-
     return {
-      color: isActive ? activeColor : inactiveColor
+      color: isActive ? activeColor.current : inactiveColor.current
     };
   });
 
   const animatedIconStyle = useAnimatedStyle(() => {
     const isActive = currentPage.value === index;
-    const inactiveColor = labelColor || DEFAULT_LABEL_COLOR;
-    const activeColor = !ignore ? selectedLabelColor || DEFAULT_SELECTED_LABEL_COLOR : inactiveColor;
-
     return {
-      tintColor: isActive ? activeColor : inactiveColor
+      tintColor: isActive ? activeColor.current : inactiveColor.current
     };
   });
 


### PR DESCRIPTION
## Description
There's a bug when using a color that connected to a PlatformColor in useAnimatedStyle hook. 
I opened a issue here that explain it better https://github.com/software-mansion/react-native-reanimated/issues/3164

Anyway, for now, in order to resolve it, I clone the colors in the TabBarItem code. 

## Changelog
Fix usages of PlatformColor in TabController TabBaritem