### PR TITLE
Feat/config

### DIFF
--- a/scripts/buildPackages.js
+++ b/scripts/buildPackages.js
@@ -7,6 +7,10 @@ const packages = [
     content: `module.exports = require('./lib/components/Keyboard').default;\n`
   },
   {
+    filename: 'config.js',
+    content: `module.exports = require('./src/commons/Config').default;\n`
+  },
+  {
     filename: 'core.js',
     components: ['View', 'Text', 'Image', 'TouchableOpacity', 'Button'],
     styleComponents: [
@@ -52,9 +56,7 @@ packages.forEach((package) => {
     content += 'module.exports = {\n';
     _.forEach(package.components, (component) => {
       content += `get ${component}() {\n`;
-      content += `return require('./src/components/${_.camelCase(
-        component
-      )}').default;`;
+      content += `return require('./src/components/${_.camelCase(component)}').default;`;
       content += `},\n`;
 
       typings = addTyping(typings, component);
@@ -62,9 +64,7 @@ packages.forEach((package) => {
 
     _.forEach(package.styleComponents, (component) => {
       content += `get ${component}() {\n`;
-      content += `return require('./src/style/${_.camelCase(
-        component
-      )}').default;`;
+      content += `return require('./src/style/${_.camelCase(component)}').default;`;
       content += `},\n`;
 
       typings = addTyping(typings, component);
@@ -88,15 +88,11 @@ fs.readdir(path, (err, files) => {
     files
       .filter((f) => f !== 'index.js')
       .forEach((file) => {
-        fs.writeFileSync(
-          `${file}.js`,
-          `module.exports = require('${path}/${file}').default;\n`
-        );
+        fs.writeFileSync(`${file}.js`,
+          `module.exports = require('${path}/${file}').default;\n`);
         const componentName = _.upperFirst(file);
-        fs.writeFileSync(
-          `${file}.d.ts`,
-          `import {${componentName}} from './generatedTypes';\nexport default ${componentName};\n`
-        );
+        fs.writeFileSync(`${file}.d.ts`,
+          `import {${componentName}} from './generatedTypes';\nexport default ${componentName};\n`);
       });
   }
 });

--- a/src/commons/Config.ts
+++ b/src/commons/Config.ts
@@ -1,4 +1,7 @@
 interface ConfigOptions {
+  /**
+   * Should use platform colors for design tokens
+   */
   usePlatformColors?: boolean;
 }
 

--- a/src/commons/Config.ts
+++ b/src/commons/Config.ts
@@ -1,0 +1,14 @@
+interface ConfigOptions {
+  usePlatformColors?: boolean;
+}
+
+class Config {
+  usePlatformColors = false;
+
+  public setConfig(options: ConfigOptions) {
+    const {usePlatformColors = false} = options;
+    this.usePlatformColors = usePlatformColors;
+  }
+}
+
+export default new Config();

--- a/src/commons/Config.ts
+++ b/src/commons/Config.ts
@@ -6,7 +6,11 @@ interface ConfigOptions {
 }
 
 class Config {
-  usePlatformColors = false;
+  usePlatformColors?: boolean;
+
+  constructor() {
+    this.setConfig({});
+  }
 
   public setConfig(options: ConfigOptions) {
     const {usePlatformColors = false} = options;

--- a/src/commons/new.ts
+++ b/src/commons/new.ts
@@ -5,6 +5,7 @@ export {default as forwardRef, ForwardRefInjectedProps} from './forwardRef';
 export {default as withScrollEnabler, WithScrollEnablerProps} from './withScrollEnabler';
 export {default as withScrollReached, WithScrollReachedProps} from './withScrollReached';
 export {default as Constants} from './Constants';
+export {default as Config} from './Config';
 
 export {
   ContainerModifiers,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export * from './services';
 export * from '../lib/components';
 export {
   asBaseComponent,
+  Config,
   Constants,
   forwardRef,
   withScrollEnabler,

--- a/src/style/scheme.ts
+++ b/src/style/scheme.ts
@@ -1,6 +1,7 @@
 import {Appearance, PlatformColor} from 'react-native';
 import {remove, xor, isEmpty, merge, forEach, cloneDeep} from 'lodash';
 import Constants from '../commons/Constants';
+import Config from '../commons/Config';
 
 export type Schemes = {light: {[key: string]: string}; dark: {[key: string]: string}};
 export type SchemeType = 'default' | 'light' | 'dark';
@@ -10,7 +11,6 @@ class Scheme {
   private currentScheme: SchemeType = 'default';
   private schemes: Schemes = {light: {}, dark: {}};
   private changeListeners: SchemeChangeListener[] = [];
-  private usePlatformColors = false;
 
   constructor() {
     Appearance.addChangeListener(() => {
@@ -71,7 +71,7 @@ class Scheme {
         Object.defineProperty(platformColorsSchemes[schemeKey], colorKey, {
           get: () => {
             let color: any = colorValue;
-            if (this.usePlatformColors) {
+            if (Config.usePlatformColors) {
               if (Constants.isAndroid) {
                 // Remove the $ prefix cause it's not allowed in Android and add the @color prefix
                 color = PlatformColor(`@color/${colorKey.replace(/^[$]/, '')}`);
@@ -97,11 +97,12 @@ class Scheme {
     return this.schemes[this.getSchemeType()];
   }
 
+  // TODO: Remove this method, use config instead
   /**
    * Should use RN PlatformColor API for retrieving design token colors from native
    */
   enablePlatformColors() {
-    this.usePlatformColors = true;
+    // this.usePlatformColors = true;
   }
 
   /**


### PR DESCRIPTION
## Description
The idea of the config class is to allow users set initial configurations that we'll take into account when initialization various components and classes 
For example: whether to use platform colors for design tokens

I considered a few options to implement it: 
- Support some sort of a config file (like babel and eslint) that the user can create and we can read - the problem with this solution is that our project is not a Node project (like babel/eslint) and it can read files using `fs` API
- [This solution] I created a (very) simple config class that the users can use to load their configurations, for this solution I had to create a standalone package for the config file so the user can load it independently without loading other uilib classes (colors, schemes) and give the users the chance to set the configurations before anything is using it. 


## Changelog
Support a config file for setting initial configuration for uilib