### PR TITLE
Remove babel plugin for prop types

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "babel-jest": "^26.6.3",
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-module-resolver": "^4.1.0",
-    "babel-plugin-typescript-to-proptypes": "^1.3.2",
     "babel-preset-react-native": "*",
     "eslint": "^7.27.0",
     "eslint-config-wix": "2.0.0",

--- a/src/.babelrc.json
+++ b/src/.babelrc.json
@@ -1,7 +1,6 @@
 {
   "presets": ["@babel/preset-typescript" /* , "@babel/preset-react" */],
   "plugins": [
-    ["babel-plugin-typescript-to-proptypes", {"comments": true}],
     [
       "module-resolver",
       {


### PR DESCRIPTION
## Description
Remove babel plugin responsible for transforming TS types to React prop types. 
We needed that for the extractOwnProps which now we only use on the TextField component and TextField is the last component that still has prop types. 
So we don't need plugin anymore. 

## Changelog
Remove babel plugin responsible for transforming TS types to React prop types. 