### PR TITLE
not enable scroll if content is less than 1 pixel than it container

### DIFF
--- a/src/commons/withScrollEnabler.tsx
+++ b/src/commons/withScrollEnabler.tsx
@@ -25,7 +25,7 @@ function withScrollEnabler<PROPS, STATICS = {}>(WrappedComponent: React.Componen
     const layoutSize = useRef(0);
 
     const checkScroll = useCallback(() => {
-      const isScrollEnabled = contentSize.current > layoutSize.current;
+      const isScrollEnabled = (contentSize.current - 1) > layoutSize.current;
       if (isScrollEnabled !== scrollEnabled) {
         setScrollEnabled(isScrollEnabled);
       }

--- a/src/commons/withScrollEnabler.tsx
+++ b/src/commons/withScrollEnabler.tsx
@@ -25,7 +25,7 @@ function withScrollEnabler<PROPS, STATICS = {}>(WrappedComponent: React.Componen
     const layoutSize = useRef(0);
 
     const checkScroll = useCallback(() => {
-      const isScrollEnabled = (contentSize.current - 1) > layoutSize.current;
+      const isScrollEnabled = Math.floor(contentSize.current) > layoutSize.current;
       if (isScrollEnabled !== scrollEnabled) {
         setScrollEnabled(isScrollEnabled);
       }


### PR DESCRIPTION
## Description
should prevent situations where a friction of pixel enables scroll and hence causes the scrollview-fader appear for no reason

## Example
![Screen Shot 2022-04-12 at 15 19 54](https://user-images.githubusercontent.com/37651196/162961150-bdcbd569-1cf7-4ca2-8b3e-c92b0074f390.png)

