### PR TITLE
Revert - Handle borderColor styles of TextField in Android

### DIFF
--- a/demo/src/screens/incubatorScreens/IncubatorTextFieldScreen.tsx
+++ b/demo/src/screens/incubatorScreens/IncubatorTextFieldScreen.tsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React, {Component} from 'react';
 import {TextInput, StyleSheet, ScrollView, ActivityIndicator} from 'react-native';
-import {Assets, Colors, Spacings, Typography, View, Text, Button, Keyboard, Incubator, Constants} from 'react-native-ui-lib'; //eslint-disable-line
+import {Assets, Colors, Spacings, Typography, View, Text, Button, Keyboard, Incubator} from 'react-native-ui-lib'; //eslint-disable-line
 const {TextField} = Incubator;
 const {KeyboardAwareInsetsView} = Keyboard;
 
@@ -283,12 +283,12 @@ const styles = StyleSheet.create({
   container: {},
   withUnderline: {
     borderBottomWidth: 1,
-    borderColor: Constants.isAndroid ? Colors.$outlineDisabledHeavy.toString() : Colors.$outlineDisabledHeavy,
+    borderColor: Colors.$outlineDisabledHeavy,
     paddingBottom: 4
   },
   withFrame: {
     borderWidth: 1,
-    borderColor: Constants.isAndroid ? Colors.$outlineDisabledHeavy.toString() : Colors.$outlineDisabledHeavy,
+    borderColor: Colors.$outlineDisabledHeavy,
     padding: 4,
     borderRadius: 2
   }

--- a/src/incubator/TextField/presets/default.ts
+++ b/src/incubator/TextField/presets/default.ts
@@ -1,5 +1,4 @@
 import {StyleSheet} from 'react-native';
-import {Constants} from '../../../commons/new';
 import {Colors, Spacings, Typography} from '../../../style';
 
 const colorByState = {
@@ -11,7 +10,7 @@ const colorByState = {
 const styles = StyleSheet.create({
   field: {
     borderBottomWidth: 1,
-    borderBottomColor: Constants.isAndroid ? Colors.$outlineDisabled.toString() : Colors.$outlineDisabled,
+    borderBottomColor: Colors.$outlineDisabled,
     paddingBottom: Spacings.s2
   },
   input: {


### PR DESCRIPTION
## Description
Reverts wix/react-native-ui-lib#1961
Since the problem with platform colors and borderColor style prop is bigger than we thought there's no reason to fix it only here, so it's better reverting this change 

## Changelog
Reverts wix/react-native-ui-lib#1961


