### PR TITLE
KeyboardAccessoryViewProps - fix 'onItemSelected' params for types

### DIFF
--- a/lib/components/Keyboard/KeyboardInput/KeyboardAccessoryView.tsx
+++ b/lib/components/Keyboard/KeyboardInput/KeyboardAccessoryView.tsx
@@ -51,7 +51,7 @@ export type KeyboardAccessoryViewProps = {
   /**
    * Callback that will be called when an item on the keyboard has been pressed.
    */
-  onItemSelected?: () => void;
+  onItemSelected?: (component?: string, args?: any) => void;
   /**
    * Callback that will be called if KeyboardRegistry.requestShowKeyboard is called.
    */


### PR DESCRIPTION
## Description
KeyboardAccessoryViewProps - fix 'onItemSelected' params for types.

## Changelog
KeyboardAccessoryViewProps - fix 'onItemSelected' params for types