### PR TITLE
Infra/babel index exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@babel/cli": "^7.16.8",
     "@babel/core": "^7.12.9",
+    "@babel/plugin-transform-modules-commonjs": "^7.17.9",
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-react": "^7.10.1",
     "@babel/runtime": "^7.12.5",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,4 +1,5 @@
 const childProcess = require('child_process');
+const fs = require('fs');
 
 const BABEL_OPTIONS = `--config-file ./src/.babelrc.json --extensions '.ts,.tsx' --ignore "src/**/*.d.ts"`;
 const BABEL_INDEX_EXPORTS_OPTIONS = `--config-file ./src/.babelrc.exports.js`;
@@ -19,5 +20,10 @@ childProcess.execSync(`./node_modules/.bin/babel ./src/index.js -o ./src/index.j
 
 console.info('## Build standalone components packages ##');
 require('./buildPackages');
+
+console.info('## Override package.json main entry to use src/index.js file ##');
+const package = JSON.parse(fs.readFileSync('./package.json'));
+package.main = 'src/index.js';
+fs.writeFileSync('./package.json', JSON.stringify(package, null, 2), {encoding: 'utf8'});
 
 console.info('## Complete RNUILib Build ##');

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,6 +1,7 @@
 const childProcess = require('child_process');
 
 const BABEL_OPTIONS = `--config-file ./src/.babelrc.json --extensions '.ts,.tsx' --ignore "src/**/*.d.ts"`;
+const BABEL_INDEX_EXPORTS_OPTIONS = `--config-file ./src/.babelrc.exports.js`;
 
 console.info('## Start RNUILib Build ##');
 
@@ -12,6 +13,9 @@ childProcess.execSync(`./node_modules/.bin/babel src --out-dir src ${BABEL_OPTIO
 
 console.info('## Build lib (native component) files - convert TS to JS files ##');
 childProcess.execSync(`./node_modules/.bin/babel lib --out-dir lib ${BABEL_OPTIONS}`);
+
+console.info('## Build main index file - for lazy load exports ##');
+childProcess.execSync(`./node_modules/.bin/babel ./src/index.js -o ./src/index.js ${BABEL_INDEX_EXPORTS_OPTIONS}`);
 
 console.info('## Build standalone components packages ##');
 require('./buildPackages');

--- a/src/.babelrc.exports.js
+++ b/src/.babelrc.exports.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: [
+    ['@babel/plugin-transform-modules-commonjs', {lazy: () => true}]
+  ],
+  compact: false
+};


### PR DESCRIPTION
## Description
Babel src/index file in order to support lazy loading
This seem to fix issues with old render test tools that probably need the code to be written in an old format

## Changelog
Babel main index file to support components lazy loading 