### PR TITLE
Image - support size (width, height) modifiers on Android

### DIFF
--- a/src/components/image/index.tsx
+++ b/src/components/image/index.tsx
@@ -126,7 +126,7 @@ class Image extends PureComponent<Props, State> {
     if (Constants.isAndroid) {
       const {source} = this.props;
       const url = _.get(source, 'uri');
-      const isGif = /(http(s?):)([/|.|\w|\s|-])*\.(?:jpg|gif|png)/.test(url);
+      const isGif = /(http(s?):)([/|.|\w|\s|-])*\.gif/.test(url);
       return isGif;
     }
   }


### PR DESCRIPTION
## Description
Image - support size (width, height) modifiers on Android.
We should lookout for overflow bugs in the next release.
WOAUILIB-2310

## Changelog
Image - support size (width, height) modifiers on Android