### PR TITLE
Button - support paddings modifier

### DIFF
--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -321,7 +321,7 @@ class Button extends PureComponent<Props, ButtonState> {
   render() {
     const {onPress, disabled, style, testID, animateLayout, modifiers, forwardedRef, ...others} = this.props;
     const shadowStyle = this.getShadowStyle();
-    const {margins} = modifiers;
+    const {margins, paddings} = modifiers;
     const backgroundColor = this.getBackgroundColor();
     const outlineStyle = this.getOutlineStyle();
     const containerSizeStyle = this.getContainerSizeStyle();
@@ -338,6 +338,7 @@ class Button extends PureComponent<Props, ButtonState> {
           this.isLink && this.styles.innerContainerLink,
           shadowStyle,
           margins,
+          paddings,
           {backgroundColor},
           borderRadiusStyle,
           outlineStyle,


### PR DESCRIPTION
## Description
Button - support paddings modifier
WOAUILIB-2005
The original ticket was on `paddingH`, I don't see how this is useful since if the button is full width paddingH should not matter and with fixed width the only thing it can do is cut the text (unless it's some custom usage which I cannot think about ATM).
However vertical part can be supported, so I'll fix the modifier.

## Changelog
Button - support paddings modifier