### PR TITLE
Retain TextField top validation message when needed

### DIFF
--- a/src/incubator/TextField/index.tsx
+++ b/src/incubator/TextField/index.tsx
@@ -6,7 +6,7 @@
  * other elements (leading/trailing accessories). It usually best to set lineHeight with undefined
  */
 import React, {useMemo} from 'react';
-import {omit} from 'lodash';
+import {isEmpty, trim, omit} from 'lodash';
 import {asBaseComponent, forwardRef} from '../../commons/new';
 import View from '../../components/view';
 import {Colors} from '../../style';
@@ -87,6 +87,7 @@ const TextField = (props: InternalTextFieldProps) => {
 
   const fieldStyle = [fieldStyleProp, dynamicFieldStyle?.(context, {preset: props.preset})];
   const hidePlaceholder = shouldHidePlaceholder(props, fieldState.isFocused);
+  const retainTopMessageSpace = !floatingPlaceholder && isEmpty(trim(label));
 
   return (
     <FieldContext.Provider value={context}>
@@ -106,6 +107,7 @@ const TextField = (props: InternalTextFieldProps) => {
             validate={others.validate}
             validationMessage={others.validationMessage}
             validationMessageStyle={validationMessageStyle}
+            retainSpace={retainTopMessageSpace}
             testID={`${props.testID}.validationMessage`}
           />
         )}


### PR DESCRIPTION
## Description
In the case when the user pass `floatingPlaceholder` as false, empty `label` and validationMessagePosition as top 
The TextField "jumps" when it shows the validation message 
This PR fix it by retaining a space for this use case (we already doing it for the bottom validation message) 

WOAUILIB-2471

## Changelog
Fix TextField jumping issue when passing there's no label or floating placeholder and the validation message positioned at top
