### PR TITLE
Carousel - fix initial page offset (contentOffset)

### DIFF
--- a/src/components/carousel/CarouselPresenter.ts
+++ b/src/components/carousel/CarouselPresenter.ts
@@ -6,6 +6,7 @@ export function getChildrenLength(props: PropsWithChildren<CarouselProps>): numb
   return React.Children.count(props.children);
 }
 
+// TODO: This should probably be replaced with carousel.getContentOffset
 export function calcOffset(props: CarouselProps, state: Omit<CarouselState, 'initialOffset' | 'prevProps' | 'currentStandingPage'>) {
   const {currentPage, pageWidth, pageHeight} = state;
   const {loop, containerMarginHorizontal = 0} = props;

--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -246,6 +246,21 @@ class Carousel extends Component<CarouselProps, CarouselState> {
     }
   };
 
+  getContentOffset = (snapToOffsets: number[] | undefined) => {
+    const {horizontal, initialPage} = this.props;
+    const {initialOffset} = this.state;
+    let contentOffset = initialOffset;
+    if (snapToOffsets && initialPage !== undefined) {
+      const offset = snapToOffsets[initialPage];
+      contentOffset = {
+        x: horizontal ? offset : 0,
+        y: horizontal ? 0 : offset
+      };
+    }
+
+    return contentOffset;
+  }
+
   shouldUsePageWidth() {
     const {loop, pageWidth} = this.props;
     return !loop && pageWidth;
@@ -477,13 +492,13 @@ class Carousel extends Component<CarouselProps, CarouselState> {
 
   renderCarousel() {
     const {containerStyle, animated, horizontal, animatedScrollOffset, ...others} = this.props;
-    const {initialOffset} = this.state;
     const scrollContainerStyle = this.shouldUsePageWidth()
       ? {paddingRight: this.getItemSpacings(this.props)}
       : undefined;
     const snapToOffsets = this.getSnapToOffsets();
     const marginBottom = Math.max(0, this.getContainerPaddingVertical() - 16);
     const ScrollContainer = animatedScrollOffset ? Animated.ScrollView : ScrollView;
+    const contentOffset = this.getContentOffset(snapToOffsets);
     return (
       <View
         animated={animated}
@@ -502,8 +517,7 @@ class Carousel extends Component<CarouselProps, CarouselState> {
           horizontal={horizontal}
           pagingEnabled={this.shouldEnablePagination()}
           snapToOffsets={snapToOffsets}
-          contentOffset={initialOffset} // iOS only
-          onContentSizeChange={this.onContentSizeChange}
+          contentOffset={contentOffset}
           onMomentumScrollEnd={this.onMomentumScrollEnd}
         >
           {this.renderChildren()}

--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -518,6 +518,7 @@ class Carousel extends Component<CarouselProps, CarouselState> {
           pagingEnabled={this.shouldEnablePagination()}
           snapToOffsets={snapToOffsets}
           contentOffset={contentOffset}
+          // onContentSizeChange={this.onContentSizeChange}
           onMomentumScrollEnd={this.onMomentumScrollEnd}
         >
           {this.renderChildren()}

--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -246,7 +246,7 @@ class Carousel extends Component<CarouselProps, CarouselState> {
     }
   };
 
-  getContentOffset = (snapToOffsets: number[] | undefined) => {
+  getInitialContentOffset = (snapToOffsets: number[] | undefined) => {
     const {horizontal, initialPage} = this.props;
     const {initialOffset} = this.state;
     let contentOffset = initialOffset;
@@ -498,7 +498,7 @@ class Carousel extends Component<CarouselProps, CarouselState> {
     const snapToOffsets = this.getSnapToOffsets();
     const marginBottom = Math.max(0, this.getContainerPaddingVertical() - 16);
     const ScrollContainer = animatedScrollOffset ? Animated.ScrollView : ScrollView;
-    const contentOffset = this.getContentOffset(snapToOffsets);
+    const contentOffset = this.getInitialContentOffset(snapToOffsets);
     return (
       <View
         animated={animated}


### PR DESCRIPTION
## Description
Carousel - fix initial page offset (contentOffset)
WOAUILIB-2668
Generally I'd like to replace all `calcOffset` usages to the new `getContentOffset` (since `snapToOffsets` seem to have the correct data) but I fear of edge cases and bugs.
TBH, I think we should rewrite this component as a function component.

Testing snippet:
```
<Carousel
  onChangePage={this.onChangePage}
  pageWidth={249 + (Spacings.s5 * 2)}
  itemSpacings={Spacings.s5}
  initialPage={1}
  containerStyle={{height: 160}}
>
  {_.map([...Array(numberOfPagesShown)], (item, index) => (
    <Page style={{backgroundColor: BACKGROUND_COLORS[index]}} key={index}>
      <Text margin-15>CARD {index}</Text>
    </Page>
  ))}
</Carousel>
...
page: {
  flex: 1,
  width: 249,
  borderWidth: 1,
  borderRadius: 8
}
```


## Changelog
Carousel - fix initial page offset (contentOffset)