### PR TITLE
Refactor DateTimePicker expandable overlay

### DIFF
--- a/demo/src/screens/componentScreens/DateTimePickerScreen.tsx
+++ b/demo/src/screens/componentScreens/DateTimePickerScreen.tsx
@@ -1,81 +1,75 @@
 import React, {Component} from 'react';
 import {ScrollView} from 'react-native';
-import {DateTimePicker, Text, TouchableOpacity} from 'react-native-ui-lib'; // eslint-disable-line
+import {DateTimePicker, DateTimePickerProps, View, Text, TouchableOpacity} from 'react-native-ui-lib'; // eslint-disable-line
 
 export default class DateTimePickerScreen extends Component {
-  getCustomInputValue = (value: string) => {
+  getCustomInputValue = (value?: string) => {
     if (!value) {
       return 'Default';
     }
     return value.includes((new Date().getFullYear() + 1).toString()) ? 'Next Year' : value;
   };
 
-  renderCustomInput = (props: {value: string}, toggle: (shouldToggle: boolean) => void) => {
-    const {value} = props;
+  renderCustomInput: DateTimePickerProps['renderInput'] = ({value}) => {
     return (
-      <TouchableOpacity
-        flex
-        row
-        spread
-        onPress={() => {
-          toggle(true);
-        }}
-      >
+      <View flex row spread>
         <Text>Valid from</Text>
         <Text absR $textPrimary text80BO>
           {this.getCustomInputValue(value)}
         </Text>
-      </TouchableOpacity>
+      </View>
     );
   };
 
   render() {
     return (
-      <ScrollView style={{padding: 14}}>
-        <Text text40>Date Time Picker</Text>
-        <DateTimePicker
-          // @ts-expect-error
-          containerStyle={{marginVertical: 20}}
-          title={'Date'}
-          placeholder={'Select a date'}
-          // dateFormat={'MMM D, YYYY'}
-          // value={new Date('October 13, 2014')}
-        />
-        <DateTimePicker
-          mode={'time'}
-          title={'Time'}
-          placeholder={'Select time'}
-          // timeFormat={'h:mm A'}
-          // value={new Date('2015-03-25T12:00:00-06:30')}
-        />
+      <ScrollView>
+        <View padding-page>
+          <Text text40>Date Time Picker</Text>
+          <DateTimePicker
+            // @ts-expect-error
+            containerStyle={{marginVertical: 20}}
+            title={'Date'}
+            placeholder={'Select a date'}
+            // dateFormat={'MMM D, YYYY'}
+            // value={new Date('October 13, 2014')}
+          />
+          <DateTimePicker
+            mode={'time'}
+            title={'Time'}
+            placeholder={'Select time'}
+            // timeFormat={'h:mm A'}
+            // value={new Date('2015-03-25T12:00:00-06:30')}
+          />
 
-        <Text text60R marginT-40>
-          Disabled
-        </Text>
-        <DateTimePicker
-          containerStyle={{marginBottom: 20}}
-          editable={false}
-          title={'Date'}
-          placeholder={'Select a date'}
-        />
-        <DateTimePicker
-          editable={false}
-          mode={'time'}
-          title={'Time'}
-          placeholder={'Select time'}
-          value={new Date('2015-03-25T12:00:00-06:30')}
-        />
-        <Text text60R marginT-40>
-          Custom Input
-        </Text>
-        <DateTimePicker
-          containerStyle={{marginVertical: 20}}
-          title={'Date'}
-          placeholder={'Select a date'}
-          renderInput={this.renderCustomInput}
-          dateFormat={'MMM D, YYYY'}
-          // value={new Date('2015-03-25T12:00:00-06:30')}
-        />
+          <Text text60R marginT-40>
+            Disabled
+          </Text>
+          <DateTimePicker
+            containerStyle={{marginBottom: 20}}
+            editable={false}
+            title={'Date'}
+            placeholder={'Select a date'}
+          />
+          <DateTimePicker
+            editable={false}
+            mode={'time'}
+            title={'Time'}
+            placeholder={'Select time'}
+            value={new Date('2015-03-25T12:00:00-06:30')}
+          />
+          <Text text60R marginT-40>
+            Custom Input
+          </Text>
+          <DateTimePicker
+            containerStyle={{marginVertical: 20}}
+            title={'Date'}
+            placeholder={'Select a date'}
+            renderInput={this.renderCustomInput}
+            dateFormat={'MMM D, YYYY'}
+            // value={new Date('2015-03-25T12:00:00-06:30')}
+          />
+        </View>
       </ScrollView>
     );
   }

--- a/src/components/dateTimePicker/dateTimePicker.api.json
+++ b/src/components/dateTimePicker/dateTimePicker.api.json
@@ -23,6 +23,7 @@
       "note": "Defaults to device's date and time"
     },
     {"name": "onChange", "type": "() => Date", "description": "Called when the date/time change"},
+    {"name": "editable", "type": "boolean", "description": "Should this input be editable or disabled"},
     {"name": "minimumDate", "type": "Date", "description": "The minimum date or time value to use"},
     {"name": "maximumDate", "type": "Date", "description": "The maximum date or time value to use"},
     {"name": "dateFormat", "type": "string", "description": "The date format for the text display"},

--- a/src/incubator/expandableOverlay/index.tsx
+++ b/src/incubator/expandableOverlay/index.tsx
@@ -41,7 +41,7 @@ export type ExpandableOverlayProps = TouchableOpacityProps &
     /**
      * A custom overlay to render instead of Modal or Dialog components
      */
-    renderCustomOverlay?: (props: RenderCustomOverlayProps) => React.ReactElement | undefined;
+    renderCustomOverlay?: (props: RenderCustomOverlayProps) => React.ReactElement | undefined | null;
     /**
      * Disabled opening expandable overlay
      */


### PR DESCRIPTION
## Description
Refactor DateTimePicker expandable overlay
Remove usage of old TextField expandable prop and replace it with out ExpandableOverlay component. 
This is required so we can eventually migrate to the next TextField implementation

## Changelog
Refactor DateTimePicker expandable overlay