### PR TITLE
Fix Incubator TextField placeholder's disabled color

### DIFF
--- a/src/incubator/TextField/index.tsx
+++ b/src/incubator/TextField/index.tsx
@@ -9,7 +9,6 @@ import React, {useMemo} from 'react';
 import {isEmpty, trim, omit} from 'lodash';
 import {asBaseComponent, forwardRef} from '../../commons/new';
 import View from '../../components/view';
-import {Colors} from '../../style';
 import {useMeasure} from '../../hooks';
 import {TextFieldProps, InternalTextFieldProps, ValidationMessagePosition, FieldContextType, TextFieldMethods} from './types';
 import {shouldHidePlaceholder} from './Presenter';
@@ -44,6 +43,7 @@ const TextField = (props: InternalTextFieldProps) => {
     floatingPlaceholderColor,
     floatingPlaceholderStyle,
     floatOnFocus,
+    placeholderColor,
     hint,
     // Label
     label,
@@ -128,7 +128,7 @@ const TextField = (props: InternalTextFieldProps) => {
             )}
             {children || (
               <Input
-                placeholderTextColor={hidePlaceholder ? 'transparent' : Colors.$textNeutral}
+                placeholderTextColor={hidePlaceholder ? 'transparent' : placeholderColor}
                 {...others}
                 style={[typographyStyle, colorStyle, others.style]}
                 onFocus={onFocus}

--- a/src/incubator/TextField/index.tsx
+++ b/src/incubator/TextField/index.tsx
@@ -43,7 +43,7 @@ const TextField = (props: InternalTextFieldProps) => {
     floatingPlaceholderColor,
     floatingPlaceholderStyle,
     floatOnFocus,
-    placeholderColor,
+    placeholderTextColor,
     hint,
     // Label
     label,
@@ -128,7 +128,7 @@ const TextField = (props: InternalTextFieldProps) => {
             )}
             {children || (
               <Input
-                placeholderTextColor={hidePlaceholder ? 'transparent' : placeholderColor}
+                placeholderTextColor={hidePlaceholder ? 'transparent' : placeholderTextColor}
                 {...others}
                 style={[typographyStyle, colorStyle, others.style]}
                 onFocus={onFocus}

--- a/src/incubator/TextField/presets/default.ts
+++ b/src/incubator/TextField/presets/default.ts
@@ -7,7 +7,7 @@ const colorByState = {
   disabled: Colors.$textDisabled
 };
 
-const placeHolderColorByState = {
+const placeHolderTextColorByState = {
   default: Colors.$textNeutral,
   error: Colors.$textNeutral,
   focus: Colors.$textNeutral,
@@ -32,7 +32,7 @@ export default {
   enableErrors: true,
   validateOnBlur: true,
   floatingPlaceholderColor: colorByState,
-  placeholderColor: placeHolderColorByState,
+  placeholderTextColor: placeHolderTextColorByState,
   labelColor: colorByState,
   fieldStyle: styles.field,
   style: styles.input,

--- a/src/incubator/TextField/presets/default.ts
+++ b/src/incubator/TextField/presets/default.ts
@@ -7,7 +7,7 @@ const colorByState = {
   disabled: Colors.$textDisabled
 };
 
-const placeHolderTextColorByState = {
+const placeholderTextColorByState = {
   default: Colors.$textNeutral,
   error: Colors.$textNeutral,
   focus: Colors.$textNeutral,
@@ -32,7 +32,7 @@ export default {
   enableErrors: true,
   validateOnBlur: true,
   floatingPlaceholderColor: colorByState,
-  placeholderTextColor: placeHolderTextColorByState,
+  placeholderTextColor: placeholderTextColorByState,
   labelColor: colorByState,
   fieldStyle: styles.field,
   style: styles.input,

--- a/src/incubator/TextField/presets/default.ts
+++ b/src/incubator/TextField/presets/default.ts
@@ -7,6 +7,13 @@ const colorByState = {
   disabled: Colors.$textDisabled
 };
 
+const placeHolderColorByState = {
+  default: Colors.$textNeutral,
+  error: Colors.$textNeutral,
+  focus: Colors.$textNeutral,
+  disabled: Colors.$textDisabled
+};
+
 const styles = StyleSheet.create({
   field: {
     borderBottomWidth: 1,
@@ -25,6 +32,7 @@ export default {
   enableErrors: true,
   validateOnBlur: true,
   floatingPlaceholderColor: colorByState,
+  placeholderColor: placeHolderColorByState,
   labelColor: colorByState,
   fieldStyle: styles.field,
   style: styles.input,

--- a/src/incubator/TextField/types.ts
+++ b/src/incubator/TextField/types.ts
@@ -215,7 +215,7 @@ export type TextFieldProps = MarginModifiers &
   };
 
 export type InternalTextFieldProps = PropsWithChildren<
-  TextFieldProps & BaseComponentInjectedProps & ForwardRefInjectedProps & {placeholderColor: ColorType}
+  TextFieldProps & BaseComponentInjectedProps & ForwardRefInjectedProps
 >;
 
 export type FieldContextType = {

--- a/src/incubator/TextField/types.ts
+++ b/src/incubator/TextField/types.ts
@@ -215,7 +215,7 @@ export type TextFieldProps = MarginModifiers &
   };
 
 export type InternalTextFieldProps = PropsWithChildren<
-  TextFieldProps & BaseComponentInjectedProps & ForwardRefInjectedProps
+  TextFieldProps & BaseComponentInjectedProps & ForwardRefInjectedProps & {placeholderColor: ColorType}
 >;
 
 export type FieldContextType = {


### PR DESCRIPTION
## Description
Fix Incubator TextField placeholder's disabled color (when floating is also disabled).
There are 4 examples below, the 4th has a wrong color for the placeholder, this happens when both `floatingPlaceholder={false}` and  `editable={false}`.

Snippet:
```
<TextField migrate floatingPlaceholder editable placeholder="Placeholder"/>
<TextField migrate floatingPlaceholder editable={false} placeholder="Placeholder"/>
<TextField migrate floatingPlaceholder={false} editable placeholder="Placeholder"/>
<TextField migrate floatingPlaceholder={false} editable={false} placeholder="Placeholder"/>
```

## Changelog
Fix Incubator TextField placeholder's disabled color (when floating is also disabled).