### PR TITLE
Modal - support - KeyboardAvoidingView

### DIFF
--- a/demo/src/screens/incubatorScreens/IncubatorDialogScreen.tsx
+++ b/demo/src/screens/incubatorScreens/IncubatorDialogScreen.tsx
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
-import {StyleSheet, ModalProps} from 'react-native';
+import {StyleSheet} from 'react-native';
 import {FlatList} from 'react-native-gesture-handler';
-import {View, Text, Card, Button, Incubator, Colors, Spacings} from 'react-native-ui-lib';
+import {View, Text, Card, Button, Incubator, Colors, Spacings, ModalProps} from 'react-native-ui-lib';
 
 interface Item {
   value: string;

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -6,7 +6,9 @@ import {
   Modal as RNModal,
   ModalProps as RNModalProps,
   TouchableWithoutFeedback,
-  GestureResponderEvent
+  GestureResponderEvent,
+  KeyboardAvoidingView,
+  KeyboardAvoidingViewProps
 } from 'react-native';
 import {BlurViewPackage} from '../../optionalDependencies';
 import {Constants, asBaseComponent} from '../../commons/new';
@@ -46,6 +48,10 @@ export interface ModalProps extends RNModalProps {
    * Should add a GestureHandlerRootView (Android only)
    */
   useGestureHandlerRootView?: boolean;
+  /**
+   * Send in order to add a KeyboardAvoidingView (iOS only)
+   */
+  keyboardAvoidingViewProps?: KeyboardAvoidingViewProps;
 }
 
 /**
@@ -93,20 +99,28 @@ class Modal extends Component<ModalProps> {
   }
 
   render() {
-    const {blurView, enableModalBlur, visible, useGestureHandlerRootView, ...others} = this.props;
+    const {blurView, enableModalBlur, visible, useGestureHandlerRootView, keyboardAvoidingViewProps, ...others} =
+      this.props;
     const defaultContainer = enableModalBlur && Constants.isIOS && BlurView ? BlurView : View;
     const useGestureHandler = useGestureHandlerRootView && Constants.isAndroid;
     const GestureContainer = useGestureHandler ? GestureHandlerRootView : React.Fragment;
     const gestureContainerProps = useGestureHandler ? {style: styles.fill} : {};
+    const useKeyboardAvoiding = keyboardAvoidingViewProps && Constants.isIOS;
+    const KeyboardAvoidingContainer = useKeyboardAvoiding ? KeyboardAvoidingView : React.Fragment;
+    const keyboardAvoidingContainerProps = useKeyboardAvoiding
+      ? {behavior: 'padding', ...keyboardAvoidingViewProps, style: [styles.fill, keyboardAvoidingViewProps.style]}
+      : {};
     const Container: any = blurView ? blurView : defaultContainer;
 
     return (
       <RNModal visible={Boolean(visible)} {...others}>
         <GestureContainer {...gestureContainerProps}>
-          <Container style={styles.fill} blurType="light">
-            {this.renderTouchableOverlay()}
-            {this.props.children}
-          </Container>
+          <KeyboardAvoidingContainer {...keyboardAvoidingContainerProps}>
+            <Container style={styles.fill} blurType="light">
+              {this.renderTouchableOverlay()}
+              {this.props.children}
+            </Container>
+          </KeyboardAvoidingContainer>
         </GestureContainer>
       </RNModal>
     );

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -49,7 +49,11 @@ export interface ModalProps extends RNModalProps {
    */
   useGestureHandlerRootView?: boolean;
   /**
-   * Send in order to add a KeyboardAvoidingView (iOS only)
+   * Should add a KeyboardAvoidingView (iOS only)
+   */
+  useKeyboardAvoidingView?: boolean;
+  /**
+   * Send additional props to the KeyboardAvoidingView (iOS only)
    */
   keyboardAvoidingViewProps?: KeyboardAvoidingViewProps;
 }
@@ -99,16 +103,23 @@ class Modal extends Component<ModalProps> {
   }
 
   render() {
-    const {blurView, enableModalBlur, visible, useGestureHandlerRootView, keyboardAvoidingViewProps, ...others} =
-      this.props;
+    const {
+      blurView,
+      enableModalBlur,
+      visible,
+      useGestureHandlerRootView,
+      useKeyboardAvoidingView,
+      keyboardAvoidingViewProps,
+      ...others
+    } = this.props;
     const defaultContainer = enableModalBlur && Constants.isIOS && BlurView ? BlurView : View;
     const useGestureHandler = useGestureHandlerRootView && Constants.isAndroid;
     const GestureContainer = useGestureHandler ? GestureHandlerRootView : React.Fragment;
     const gestureContainerProps = useGestureHandler ? {style: styles.fill} : {};
-    const useKeyboardAvoiding = keyboardAvoidingViewProps && Constants.isIOS;
+    const useKeyboardAvoiding = useKeyboardAvoidingView && Constants.isIOS;
     const KeyboardAvoidingContainer = useKeyboardAvoiding ? KeyboardAvoidingView : React.Fragment;
     const keyboardAvoidingContainerProps = useKeyboardAvoiding
-      ? {behavior: 'padding', ...keyboardAvoidingViewProps, style: [styles.fill, keyboardAvoidingViewProps.style]}
+      ? {behavior: 'padding', ...keyboardAvoidingViewProps, style: [styles.fill, keyboardAvoidingViewProps?.style]}
       : {};
     const Container: any = blurView ? blurView : defaultContainer;
 


### PR DESCRIPTION
## Description
Modal - support - KeyboardAvoidingView
It seems that there is a limitation for `KeyboardAvoidingView` in a `Modal` see this [SO answer](https://stackoverflow.com/a/65029356/4759619).
WOAUILIB-2719
This will allow using this in the `Incubator.Dialog`, not sure if we want to add support in the current `Dialog` or perhaps tell the user to use the new one.

## Changelog
Modal - support - KeyboardAvoidingView