### PR TITLE
Use Gesture to handle TabBarItem presses

### DIFF
--- a/demo/src/screens/componentScreens/TabControllerScreen/index.tsx
+++ b/demo/src/screens/componentScreens/TabControllerScreen/index.tsx
@@ -174,7 +174,7 @@ class TabControllerScreen extends Component<{}, State> {
             // iconColor={'green'}
             // selectedIconColor={'blue'}
             enableShadow
-            activeBackgroundColor={Colors.$backgroundGeneralLight}
+            activeBackgroundColor={Colors.$backgroundPrimaryLight}
             centerSelected={centerSelected}
           >
             {/* {this.renderTabItems()} */}


### PR DESCRIPTION
## Description
This is a small improvement for performance in TabController component. 
In TabBarItem I replaced the `TouchableOpacity` with gesture-handler `Gesture` component. 
Instead of having a round trip (Native side -> JS side) to invoke the `onPress` callback in order to change the `currIndex` shared value, I now use the Gesture API to do that, this way we avoid the round trip. 


## Changelog
Small performance improvement in TabController transitions