### PR TITLE
KeyboardAccessoryView - fix 'addBottomView' not working

### DIFF
--- a/demo/src/screens/nativeComponentScreens/keyboardAccessory/KeyboardAccessoryViewScreen.js
+++ b/demo/src/screens/nativeComponentScreens/keyboardAccessory/KeyboardAccessoryViewScreen.js
@@ -206,6 +206,7 @@ export default class KeyboardAccessoryViewScreen extends PureComponent {
           revealKeyboardInteractive
           onRequestShowKeyboard={this.onRequestShowKeyboard}
           useSafeArea={useSafeArea}
+          addBottomView={useSafeArea}
           // usesBottomTabs={!isModal}
         />
       </View>

--- a/lib/components/Keyboard/KeyboardInput/KeyboardAccessoryView.tsx
+++ b/lib/components/Keyboard/KeyboardInput/KeyboardAccessoryView.tsx
@@ -185,7 +185,6 @@ class KeyboardAccessoryView extends Component<KeyboardAccessoryViewProps> {
       kbComponent,
       onItemSelected,
       onRequestShowKeyboard,
-      useSafeArea,
       scrollBehavior,
       iOSScrollBehavior,
       ...others
@@ -206,7 +205,7 @@ class KeyboardAccessoryView extends Component<KeyboardAccessoryViewProps> {
           initialProps={this.processInitialProps()}
           onItemSelected={onItemSelected}
           onRequestShowKeyboard={onRequestShowKeyboard}
-          useSafeArea={useSafeArea}
+          useSafeArea={others.useSafeArea}
         />
       </KeyboardTrackingView>
     );


### PR DESCRIPTION
## Description
KeyboardAccessoryView - fix 'addBottomView' not working ('useSafeArea' not passed to KeyboardTrackingView).
Solves issue #2034 

## Changelog
KeyboardAccessoryView - fix 'addBottomView' not working
