### PR TITLE
Toast - support keyboard awareness (KeyboardAwareInsetsView)

### DIFF
--- a/src/incubator/toast/index.tsx
+++ b/src/incubator/toast/index.tsx
@@ -13,6 +13,7 @@ import {ToastProps, ToastPresets} from './types';
 import useToastTimer from './helpers/useToastTimer';
 import useToastPresets from './helpers/useToastPresets';
 import useToastAnimation from './helpers/useToastAnimation';
+import KeyboardAwareInsetsView from '../../../lib/components/Keyboard/KeyboardTracking/KeyboardAwareInsetsView';
 
 const THRESHOLD = {x: Constants.screenWidth / 4, y: 10};
 
@@ -38,6 +39,8 @@ const Toast = (props: PropsWithChildren<ToastProps>) => {
     backgroundColor,
     onDismiss,
     onAnimationEnd,
+    useKeyboardAwareInsetsView,
+    keyboardAwareInsetsViewProps,
     children,
     testID
   } = props;
@@ -229,10 +232,15 @@ const Toast = (props: PropsWithChildren<ToastProps>) => {
     return renderAttachment ? _renderAttachment(positionStyle, zIndex) : null;
   }
 
+  const useKeyboardAwareInsets = useKeyboardAwareInsetsView && Constants.isIOS;
+  const KeyboardAwareContainer = useKeyboardAwareInsets ? KeyboardAwareInsetsView : React.Fragment;
+
   return (
-    <View key="toast" animated testID={testID} style={toastContainerStyle} pointerEvents={'box-none'}>
-      {renderToast()}
-    </View>
+    <KeyboardAwareContainer {...keyboardAwareInsetsViewProps}>
+      <View key="toast" animated testID={testID} style={toastContainerStyle} pointerEvents={'box-none'}>
+        {renderToast()}
+      </View>
+    </KeyboardAwareContainer>
   );
 };
 

--- a/src/incubator/toast/toast.api.json
+++ b/src/incubator/toast/toast.api.json
@@ -58,7 +58,9 @@
       "description": "A custom icon to render on the left side of the toast"
     },
     {"name": "iconColor", "type": "string", "description": "The icon color"},
-    {"name": "backgroundColor", "type": "string", "description": "The toast background color"}
+    {"name": "backgroundColor", "type": "string", "description": "The toast background color"},
+    {"name": "useKeyboardAwareInsetsView", "type": "boolean", "description": "Should add a KeyboardAwareInsetsView (iOS only)\nWhen this is applied the 'action' prop cannot be used (the click will not go through)"},
+    {"name": "keyboardAwareInsetsViewProps", "type": "KeyboardTrackingViewProps", "description": "Send additional props to the KeyboardAwareInsetsView (iOS only)"}
   ],
   "snippet": [
     "<Toast",

--- a/src/incubator/toast/types.ts
+++ b/src/incubator/toast/types.ts
@@ -1,6 +1,7 @@
 import {ReactElement} from 'react';
 import {ImageSourcePropType, StyleProp, TextStyle, ViewStyle} from 'react-native';
 import {ButtonProps} from '../../components/button';
+import {KeyboardTrackingViewProps} from '../../../lib/components/Keyboard/KeyboardTracking/KeyboardTrackingView';
 
 export enum ToastPresets {
   GENERAL = 'general',
@@ -105,4 +106,13 @@ export interface ToastProps {
    * The background color of the toast
    */
   backgroundColor?: string;
+  /**
+   * Should add a KeyboardAwareInsetsView (iOS only)
+   * When this is applied the "action" prop cannot be used (the click will not go through)
+   */
+  useKeyboardAwareInsetsView?: boolean;
+  /**
+   * Send additional props to the KeyboardAwareInsetsView (iOS only)
+   */
+  keyboardAwareInsetsViewProps?: KeyboardTrackingViewProps;
 }


### PR DESCRIPTION
## Description
Toast - support keyboard awareness (KeyboardAwareInsetsView)
Known issues: `action` is not supported, sending `pointerEvents: 'box-none'` will cause the following error:
```
UIView base class does not support pointerEvent value: box-none
```
I am unsure if it's our native that needs change in order for this to be fixed.
Changing the text of the `Toast` "on-the-fly" does not work properly.

WOAUILIB-2685

## Changelog
Toast - support keyboard awareness (KeyboardAwareInsetsView)