### PR TITLE
TextField - Support isValid ref method

### DIFF
--- a/src/incubator/TextField/FieldContext.ts
+++ b/src/incubator/TextField/FieldContext.ts
@@ -8,7 +8,8 @@ const FieldContext = createContext<FieldContextType>({
   isValid: true,
   failingValidatorIndex: undefined,
   disabled: false,
-  validateField: _.noop
+  validateField: _.noop,
+  checkValidity: () => true
 });
 
 export default FieldContext;

--- a/src/incubator/TextField/index.tsx
+++ b/src/incubator/TextField/index.tsx
@@ -67,11 +67,11 @@ const TextField = (props: InternalTextFieldProps) => {
     ...others
   } = usePreset(props);
   const {ref: leadingAccessoryRef, measurements: leadingAccessoryMeasurements} = useMeasure();
-  const {onFocus, onBlur, onChangeText, fieldState, validateField} = useFieldState(others);
+  const {onFocus, onBlur, onChangeText, fieldState, validateField, checkValidity} = useFieldState(others);
 
   const context = useMemo(() => {
-    return {...fieldState, disabled: others.editable === false, validateField};
-  }, [fieldState, others.editable, validateField]);
+    return {...fieldState, disabled: others.editable === false, validateField, checkValidity};
+  }, [fieldState, others.editable, validateField, checkValidity]);
 
   const leadingAccessoryClone = useMemo(() => {
     if (leadingAccessory) {

--- a/src/incubator/TextField/types.ts
+++ b/src/incubator/TextField/types.ts
@@ -226,6 +226,7 @@ export type FieldContextType = {
   failingValidatorIndex?: number;
   disabled: boolean;
   validateField: () => void;
+  checkValidity: () => boolean;
 };
 
 export interface TextFieldMethods {
@@ -234,4 +235,5 @@ export interface TextFieldMethods {
   blur: () => void;
   clear: () => void;
   validate: () => boolean;
+  isValid: () => boolean;
 }

--- a/src/incubator/TextField/useFieldState.ts
+++ b/src/incubator/TextField/useFieldState.ts
@@ -40,6 +40,11 @@ export default function useFieldState({
     onChangeValidity?.(isValid);
   }, [isValid]);
 
+  const checkValidity = useCallback((valueToValidate = value) => {
+    const [_isValid] = Presenter.validate(valueToValidate, validate);
+    return _isValid;
+  }, [value, validate]);
+
   const validateField = useCallback((valueToValidate = value) => {
     const [_isValid, _failingValidatorIndex] = Presenter.validate(valueToValidate, validate);
 
@@ -92,6 +97,7 @@ export default function useFieldState({
     onBlur,
     onChangeText,
     fieldState,
-    validateField
+    validateField,
+    checkValidity
   };
 }

--- a/src/incubator/TextField/useImperativeInputHandle.ts
+++ b/src/incubator/TextField/useImperativeInputHandle.ts
@@ -17,6 +17,10 @@ const useImperativeInputHandle = (ref: React.Ref<any>, props: Pick<TextInputProp
       },
       validate: () => {
         return context.validateField();
+      },
+      // Note: This returns field validity without actually validating it
+      isValid: () => {
+        return context.checkValidity();
       }
     };
   });


### PR DESCRIPTION
## Description
Allow to call isValid on TextField ref to check if it's valid. 
Unlike the `validate` method, the `isValid` doesn't validate the field (which makes the validation message appear)

WOAUILIB-2757

## Changelog
Allow to call `isValid` on TextField ref to check if it's valid without triggering field validation
