### PR TITLE
Docs - fix broken links

### DIFF
--- a/lib/components/Keyboard/KeyboardInput/KeyboardAccessoryView.tsx
+++ b/lib/components/Keyboard/KeyboardInput/KeyboardAccessoryView.tsx
@@ -64,7 +64,7 @@ export type KeyboardAccessoryViewProps = kbTrackingViewProps & {
 
 /**
  * @description: View that allows replacing the default keyboard with other components
- * @example: https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/nativeComponentScreens/keyboardInput/KeyboardInputViewScreen.js
+ * @example: https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/nativeComponentScreens/keyboardAccessory/KeyboardAccessoryViewScreen.js
  * @gif: https://github.com/wix/react-native-ui-lib/blob/master/demo/showcase/KeyboardAccessoryView/KeyboardAccessoryView.gif?raw=true
  */
 class KeyboardAccessoryView extends Component<KeyboardAccessoryViewProps> {

--- a/lib/components/Keyboard/KeyboardInput/KeyboardRegistry.ts
+++ b/lib/components/Keyboard/KeyboardInput/KeyboardRegistry.ts
@@ -17,7 +17,7 @@ const getKeyboardsWithIDs = (keyboardIDs: string[]) => {
 
 /**
  * @description: used for registering keyboards and performing certain actions on the keyboards.
- * @example: https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/nativeComponentScreens/keyboardInput/demoKeyboards.js
+ * @example: https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/nativeComponentScreens/keyboardAccessory/demoKeyboards.js
  */
 export default class KeyboardRegistry {
   static displayName = 'KeyboardRegistry';

--- a/lib/components/Keyboard/KeyboardInput/keyboardAccessoryView.api.json
+++ b/lib/components/Keyboard/KeyboardInput/keyboardAccessoryView.api.json
@@ -2,7 +2,7 @@
   "name": "KeyboardAccessoryView",
   "category": "keyboard",
   "description": "View that allows replacing the default keyboard with other components",
-  "example": "https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/nativeComponentScreens/keyboardInput/KeyboardInputViewScreen.js",
+  "example": "https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/nativeComponentScreens/keyboardAccessory/KeyboardAccessoryViewScreen.js",
   "images": [
     "https://github.com/wix/react-native-ui-lib/blob/master/demo/showcase/KeyboardAccessoryView/KeyboardAccessoryView.gif?raw=true"
   ],

--- a/lib/components/Keyboard/KeyboardInput/keyboardRegistry.api.json
+++ b/lib/components/Keyboard/KeyboardInput/keyboardRegistry.api.json
@@ -2,7 +2,7 @@
   "name": "KeyboardRegistry",
   "category": "keyboard",
   "description": "used for registering keyboards and performing certain actions on the keyboards.",
-  "example": "https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/nativeComponentScreens/keyboardInput/demoKeyboards.js",
+  "example": "https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/nativeComponentScreens/keyboardAccessory/demoKeyboards.js",
   "props": [
     {
       "name": "registerKeyboard",

--- a/src/components/chipsInput/chipsInput.api.json
+++ b/src/components/chipsInput/chipsInput.api.json
@@ -4,7 +4,7 @@
   "description": "Chips input component",
   "extends": ["incubator/TextField"],
   "modifiers": ["typography"],
-  "example": "https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/ChipsInputScreen.js",
+  "example": "https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/ChipsInputScreen.tsx",
   "images": ["https://github.com/wix/react-native-ui-lib/blob/master/demo/showcase/ChipsInput/ChipsInput.gif?raw=true"],
   "props": [
     {

--- a/src/components/dateTimePicker/dateTimePicker.api.json
+++ b/src/components/dateTimePicker/dateTimePicker.api.json
@@ -4,7 +4,7 @@
   "description": "Date and Time Picker Component that wraps RNDateTimePicker for date and time modes. See: https://github.com/react-native-community/react-native-datetimepicker#react-native-datetimepicker",
   "note": "DateTimePicker uses a native library. You MUST add and link the native library to both iOS and Android projects",
   "extends": ["incubator/TextField"],
-  "example": "https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/DateTimePickerScreen.js",
+  "example": "https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/DateTimePickerScreen.tsx",
   "images": [
     "https://github.com/wix/react-native-ui-lib/blob/master/demo/showcase/DateTimePicker/DateTimePicker_iOS.gif?raw=true, https://github.com/wix/react-native-ui-lib/blob/master/demo/showcase/DateTimePicker/DateTimePicker_Android.gif?raw=true"
   ],

--- a/src/components/dateTimePicker/index.tsx
+++ b/src/components/dateTimePicker/index.tsx
@@ -19,7 +19,7 @@ const MODES = {
 /*eslint-disable*/
 /**
  * @description: Date and Time Picker Component that wraps RNDateTimePicker for date and time modes.
- * @example: https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/DateTimePickerScreen.js
+ * @example: https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/DateTimePickerScreen.tsx
  * @important: DateTimePicker uses a native library. You MUST add and link the native library to both iOS and Android projects.
  * @extends: TextField, react-native-community/datetimepicker
  * @extendsLink: https://github.com/react-native-community/react-native-datetimepicker#react-native-datetimepicker

--- a/src/components/maskedInput/maskedInput.api.json
+++ b/src/components/maskedInput/maskedInput.api.json
@@ -4,7 +4,7 @@
   "description": "Mask Input to create custom looking inputs with custom formats",
   "extends": ["TextInput"],
   "extendsLink": ["https://reactnative.dev/docs/textinput"],
-  "example": "https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/MaskedInputScreen.js",
+  "example": "https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/MaskedInputScreen.tsx",
   "images": [
     "https://camo.githubusercontent.com/61eedb65e968845d5eac713dcd21a69691571fb1/68747470733a2f2f6d656469612e67697068792e636f6d2f6d656469612f4b5a5a7446666f486f454b334b2f67697068792e676966"
   ],

--- a/src/components/maskedInput/new.tsx
+++ b/src/components/maskedInput/new.tsx
@@ -36,7 +36,7 @@ export interface MaskedInputProps extends Omit<TextInputProps, 'value'> {
 /**
  * @description: Mask Input to create custom looking inputs with custom formats
  * @gif: https://camo.githubusercontent.com/61eedb65e968845d5eac713dcd21a69691571fb1/68747470733a2f2f6d656469612e67697068792e636f6d2f6d656469612f4b5a5a7446666f486f454b334b2f67697068792e676966
- * @example: https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/MaskedInputScreen.js
+ * @example: https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/MaskedInputScreen.tsx
  */
 function MaskedInput(props: MaskedInputProps, ref: ForwardedRef<any>) {
   const {initialValue, formatter = _.identity, containerStyle, renderMaskedText, onChangeText, ...others} = props;

--- a/src/components/maskedInput/old.js
+++ b/src/components/maskedInput/old.js
@@ -11,7 +11,7 @@ import TouchableOpacity from '../touchableOpacity';
 /**
  * @description: Mask Input to create custom looking inputs with custom formats
  * @gif: https://camo.githubusercontent.com/61eedb65e968845d5eac713dcd21a69691571fb1/68747470733a2f2f6d656469612e67697068792e636f6d2f6d656469612f4b5a5a7446666f486f454b334b2f67697068792e676966
- * @example: https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/MaskedInputScreen.js
+ * @example: https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/MaskedInputScreen.tsx
  */
 export default class MaskedInput extends BaseInput {
   static displayName = 'MaskedInput';

--- a/src/components/picker/PickerItem.tsx
+++ b/src/components/picker/PickerItem.tsx
@@ -15,7 +15,7 @@ import {PickerItemProps} from './types';
 
 /**
  * @description: Picker.Item, for configuring the Picker's selectable options
- * @example: https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/PickerScreen.js
+ * @example: https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/PickerScreen.tsx
  */
 const PickerItem = (props: PickerItemProps) => {
   const {

--- a/src/components/picker/api/picker.api.json
+++ b/src/components/picker/api/picker.api.json
@@ -3,7 +3,7 @@
   "category": "form",
   "description": "Picker Component, support single or multiple selection, blurModel and native wheel picker",
   "modifiers": ["margin", "padding", "position"],
-  "example": "https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/PickerScreen.js",
+  "example": "https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/PickerScreen.tsx",
   "images": [
     "https://github.com/wix/react-native-ui-lib/blob/master/demo/showcase/Picker/Default.gif?raw=true",
     "https://github.com/wix/react-native-ui-lib/blob/master/demo/showcase/Picker/MultiPicker.gif?raw=true",

--- a/src/components/picker/api/pickerItem.api.json
+++ b/src/components/picker/api/pickerItem.api.json
@@ -2,7 +2,7 @@
   "name": "Picker.Item",
   "category": "form",
   "description": "Picker.Item, for configuring the Picker's selectable options",
-  "example": "https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/PickerScreen.js",
+  "example": "https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/PickerScreen.tsx",
   "images": [
     "https://github.com/wix/react-native-ui-lib/blob/master/demo/showcase/Picker/Default.gif?raw=true",
     "https://github.com/wix/react-native-ui-lib/blob/master/demo/showcase/Picker/MultiPicker.gif?raw=true",

--- a/src/components/progressBar/index.tsx
+++ b/src/components/progressBar/index.tsx
@@ -14,7 +14,7 @@ const DEFAULT_COLOR = Colors.$backgroundPrimaryHeavy;
 
 /**
  * @description: Progress bar
- * @example:https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/ProgressBarScreen.js
+ * @example:https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/ProgressBarScreen.tsx
  */
 interface Props {
   /**

--- a/src/components/progressBar/progressBar.api.json
+++ b/src/components/progressBar/progressBar.api.json
@@ -2,7 +2,7 @@
   "name": "ProgressBar",
   "category": "basic",
   "description": "Progress bar",
-  "example": "https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/ProgressBarScreen.js",
+  "example": "https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/ProgressBarScreen.tsx",
   "props": [
     {"name": "progress", "type": "number", "description": "The progress of the bar from 0 to 100", "default": "0"},
     {"name": "fullWidth", "type": "boolean", "description": "FullWidth Ui preset"},

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -57,7 +57,7 @@ type PropsTypes = BaseComponentInjectedProps & ForwardRefInjectedProps & TextPro
  * @extends: Text
  * @extendsLink: https://reactnative.dev/docs/text
  * @modifiers: margins, color, typography
- * @example: https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/TextScreen.js
+ * @example: https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/TextScreen.tsx
  * @image: https://github.com/wix/react-native-ui-lib/blob/master/demo/showcase/Text/Modifiers.png?raw=true, https://github.com/wix/react-native-ui-lib/blob/master/demo/showcase/Text/Transformation.png?raw=true, https://github.com/wix/react-native-ui-lib/blob/master/demo/showcase/Text/Highlights.png?raw=true
  */
 class Text extends PureComponent<PropsTypes> {

--- a/src/components/text/text.api.json
+++ b/src/components/text/text.api.json
@@ -5,7 +5,7 @@
   "extends": ["Text"],
   "extendsLink": ["https://reactnative.dev/docs/text"],
   "modifiers": ["margins", "color", "typography"],
-  "example": "https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/TextScreen.js",
+  "example": "https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/TextScreen.tsx",
   "images": [
     "https://github.com/wix/react-native-ui-lib/blob/master/demo/showcase/Text/Modifiers.png?raw=true, https://github.com/wix/react-native-ui-lib/blob/master/demo/showcase/Text/Transformation.png?raw=true, https://github.com/wix/react-native-ui-lib/blob/master/demo/showcase/Text/Highlights.png?raw=true"
   ],

--- a/src/incubator/Dialog/dialog.api.json
+++ b/src/incubator/Dialog/dialog.api.json
@@ -4,7 +4,7 @@
   "description": "Component for displaying custom content inside a popup dialog",
   "note": "Use alignment modifiers to control the dialog position (top, bottom, centerV, centerH, etc... by default the dialog is aligned to center)",
   "modifiers": ["alignment"],
-  "example": "https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/incubatorScreens/IncubatorDialogScreen.js",
+  "example": "https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/incubatorScreens/IncubatorDialogScreen.tsx",
   "props": [
     {"name": "visible", "type": "boolean", "description": "The visibility of the dialog"},
     {"name": "onDismiss", "type": "(props?: ImperativeDialogProps) => void", "description": "Callback that is called after the dialog's dismiss (after the animation has ended)."},


### PR DESCRIPTION
## Description
Some components in the docs have a broken link when clicking "code example"

## Changelog
### Update broken link for these components:
- KeyboardAccessoryView
- KeyboardRegistry
- ChipsInput
- DateTimePicker
- MaskedInput
- Picker
- ProgressBar
- Text
- Incubator.Dialog
