### PR TITLE
Native lib - bumping version to 3.0.8

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uilib-native",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "homepage": "https://github.com/wix/react-native-ui-lib",
   "description": "uilib native components (separated from js components)",
   "main": "components/index.js",


### PR DESCRIPTION

## Description
Native lib - bumping version to reflect last fix (https://github.com/wix/react-native-ui-lib/pull/2045)

## Changelog
Native lib - bumping version to 3.0.8