### PR TITLE
KeyboardAccessoryView - prop deprecation - phase 1

### DIFF
--- a/eslint-rules/tests/component_prop_deprecation.json
+++ b/eslint-rules/tests/component_prop_deprecation.json
@@ -1,84 +1,93 @@
 [
-    {
-      "component": "Avatar",
-      "source": "module-with-deprecations",
-      "props": [
-        {
-          "prop": "url",
-          "message": "Please use the 'source' prop instead."
-        }
-      ]
-    },
-    {
-      "component": "Thumbnail",
-      "source": "module-with-deprecations",
-      "props": [
-        {
-          "prop": "url",
-          "message": "Please use the 'uri' prop instead.",
-          "fix": {"propName": "uri"}
-        }
-      ]
-    },
-    {
-      "component": "Button",
-      "source": "module-with-deprecations",
-      "props": [
-        {
-          "prop": "text",
-          "message": "Please use the 'label' prop instead.",
-          "fix": {"propName": "label"}
-        }
-      ]
-    },
-    {
-      "component": "List",
-      "source": "another-module-with-deprecations",
-      "props": [
-        {
-          "prop": "text",
-          "message": "Please use the 'label' prop instead.",
-          "fix": {"propName": "label"}
-        }
-      ]
-    },
-    {
-      "component": "List.Item",
-      "source": "module-with-deprecations",
-      "props": [
-        {
-          "prop": "text",
-          "message": "Please use the 'label' prop instead.",
-          "fix": {"propName": "label"}
-        }
-      ]
-    },
-    {
-      "component": "Text",
-      "source": "module-with-deprecations",
-      "props": [
-        {
-          "prop": "t",
-          "message": "Please use the 'title' prop instead.",
-          "fix": {"propName": "title"}
-        },
-        {
-          "prop": "s",
-          "message": "Please use the 'subtitle' prop instead.",
-          "fix": {"propName": "subtitle"}
-        }
-      ]
-    }, 
-    {
-      "component": "Picker",
-      "source": "module-with-deprecations",
-      "props": [
-        {
-          "prop": "migrate",
-          "message": "Please make sure to pass the 'migrate' prop.",
-          "isRequired": true
-        }
-      ]
-    }
-  ]
-  
+  {
+    "component": "Keyboard.KeyboardAccessoryView",
+    "source": "module-with-deprecations",
+    "props": [
+      {
+        "prop": "iOSScrollBehavior",
+        "message": "'iOSScrollBehavior' prop is deprecated. Please use 'scrollBehavior' prop instead and pass it 'scrollBehaviors' ('iosScrollBehaviors' enum is deprecated)."
+      }
+    ]
+  },
+  {
+    "component": "Avatar",
+    "source": "module-with-deprecations",
+    "props": [
+      {
+        "prop": "url",
+        "message": "Please use the 'source' prop instead."
+      }
+    ]
+  },
+  {
+    "component": "Thumbnail",
+    "source": "module-with-deprecations",
+    "props": [
+      {
+        "prop": "url",
+        "message": "Please use the 'uri' prop instead.",
+        "fix": {"propName": "uri"}
+      }
+    ]
+  },
+  {
+    "component": "Button",
+    "source": "module-with-deprecations",
+    "props": [
+      {
+        "prop": "text",
+        "message": "Please use the 'label' prop instead.",
+        "fix": {"propName": "label"}
+      }
+    ]
+  },
+  {
+    "component": "List",
+    "source": "another-module-with-deprecations",
+    "props": [
+      {
+        "prop": "text",
+        "message": "Please use the 'label' prop instead.",
+        "fix": {"propName": "label"}
+      }
+    ]
+  },
+  {
+    "component": "List.Item",
+    "source": "module-with-deprecations",
+    "props": [
+      {
+        "prop": "text",
+        "message": "Please use the 'label' prop instead.",
+        "fix": {"propName": "label"}
+      }
+    ]
+  },
+  {
+    "component": "Text",
+    "source": "module-with-deprecations",
+    "props": [
+      {
+        "prop": "t",
+        "message": "Please use the 'title' prop instead.",
+        "fix": {"propName": "title"}
+      },
+      {
+        "prop": "s",
+        "message": "Please use the 'subtitle' prop instead.",
+        "fix": {"propName": "subtitle"}
+      }
+    ]
+  }, 
+  {
+    "component": "Picker",
+    "source": "module-with-deprecations",
+    "props": [
+      {
+        "prop": "migrate",
+        "message": "Please make sure to pass the 'migrate' prop.",
+        "isRequired": true
+      }
+    ]
+  }
+]

--- a/eslint-rules/tests/lib/rules/component-prop-deprecation.js
+++ b/eslint-rules/tests/lib/rules/component-prop-deprecation.js
@@ -13,10 +13,18 @@ const ruleTester = new RuleTester();
 
 const ruleOptions = [{deprecations: deprecationsJson}];
 const invalidExample =
-  "import {Avatar} from 'module-with-deprecations'; const test = <Avatar url={'some_uri_string'}/>";
+  `import {Avatar} from 'module-with-deprecations'; const test = <Avatar url={'some_uri_string'}/>`;
+const validKeyboardExample =
+  `import {Keyboard} from 'module-with-deprecations'; const test = <Keyboard.KeyboardAccessoryView scrollBehavior={Keyboard.KeyboardAccessoryView.scrollBehaviors.NONE}/>`;
+const invalidKeyboardExample =
+  `import {Keyboard} from 'module-with-deprecations'; const test = <Keyboard.KeyboardAccessoryView iOSScrollBehavior={Keyboard.KeyboardAccessoryView.iosScrollBehaviors.NONE}/>`;
 
 ruleTester.run('component-prop-deprecation', rule, {
   valid: [
+    {
+      options: ruleOptions,
+      code: validKeyboardExample
+    },
     {
       options: ruleOptions,
       code: `const Avatar = require('another-module').Avatar;
@@ -117,8 +125,17 @@ ruleTester.run('component-prop-deprecation', rule, {
   invalid: [
     {
       options: ruleOptions,
+      code: invalidKeyboardExample,
+      errors: [{
+        message: `The 'Keyboard.KeyboardAccessoryView' component's prop 'iOSScrollBehavior' is deprecated. 'iOSScrollBehavior' prop is deprecated. Please use 'scrollBehavior' prop instead and pass it 'scrollBehaviors' ('iosScrollBehaviors' enum is deprecated).`
+      }]
+    },
+    {
+      options: ruleOptions,
       code: invalidExample,
-      errors: [{message: "The 'Avatar' component's prop 'url' is deprecated. Please use the 'source' prop instead."}]
+      errors: [{
+        message: `The 'Avatar' component's prop 'url' is deprecated. Please use the 'source' prop instead.`
+      }]
     },
     {
       options: [{...ruleOptions[0], dueDate: '10/11/18'}],
@@ -126,7 +143,7 @@ ruleTester.run('component-prop-deprecation', rule, {
       errors: [
         {
           message:
-            "The 'Avatar' component's prop 'url' is deprecated. Please use the 'source' prop instead. Please fix this issue by 10/11/18!" // eslint-disable-line
+            `The 'Avatar' component's prop 'url' is deprecated. Please use the 'source' prop instead. Please fix this issue by 10/11/18!`
         }
       ]
     },
@@ -137,7 +154,7 @@ ruleTester.run('component-prop-deprecation', rule, {
       errors: [
         {
           message:
-            "The 'Thumbnail' component's prop 'url' is deprecated. Please use the 'uri' prop instead. Please fix this issue by 10/11/18!" // eslint-disable-line
+            `The 'Thumbnail' component's prop 'url' is deprecated. Please use the 'uri' prop instead. Please fix this issue by 10/11/18!`
         }
       ]
     },
@@ -145,13 +162,13 @@ ruleTester.run('component-prop-deprecation', rule, {
       options: ruleOptions,
       code: 'import {Button} from \'module-with-deprecations\'; <Button text="my button"/>',
       output: 'import {Button} from \'module-with-deprecations\'; <Button label="my button"/>',
-      errors: [{message: "The 'Button' component's prop 'text' is deprecated. Please use the 'label' prop instead."}]
+      errors: [{message: `The 'Button' component's prop 'text' is deprecated. Please use the 'label' prop instead.`}]
     },
     {
       options: ruleOptions,
       code: 'import {List} from \'another-module-with-deprecations\'; <List text="my list"/>',
       output: 'import {List} from \'another-module-with-deprecations\'; <List label="my list"/>',
-      errors: [{message: "The 'List' component's prop 'text' is deprecated. Please use the 'label' prop instead."}]
+      errors: [{message: `The 'List' component's prop 'text' is deprecated. Please use the 'label' prop instead.`}]
     },
     {
       options: ruleOptions,
@@ -161,7 +178,7 @@ ruleTester.run('component-prop-deprecation', rule, {
       output: `import {Button} from 'module-with-deprecations';
         const props = {label: "button", color: "red"};
         <Button {...props} value="value"/>`,
-      errors: [{message: "The 'Button' component's prop 'text' is deprecated. Please use the 'label' prop instead."}]
+      errors: [{message: `The 'Button' component's prop 'text' is deprecated. Please use the 'label' prop instead.`}]
     },
     {
       options: ruleOptions,
@@ -171,7 +188,7 @@ ruleTester.run('component-prop-deprecation', rule, {
       output: `import {Button as B} from 'module-with-deprecations';
         const props = {label: "button", color: "red"};
         <B {...props} value="value"/>`,
-      errors: [{message: "The 'Button' component's prop 'text' is deprecated. Please use the 'label' prop instead."}]
+      errors: [{message: `The 'Button' component's prop 'text' is deprecated. Please use the 'label' prop instead.`}]
     },
     {
       options: ruleOptions,
@@ -183,7 +200,7 @@ ruleTester.run('component-prop-deprecation', rule, {
         const {Button} = module;
         const props = {label: "button", color: "red"};
         <Button {...props} value="value"/>`,
-      errors: [{message: "The 'Button' component's prop 'text' is deprecated. Please use the 'label' prop instead."}]
+      errors: [{message: `The 'Button' component's prop 'text' is deprecated. Please use the 'label' prop instead.`}]
     },
     {
       options: ruleOptions,
@@ -193,7 +210,7 @@ ruleTester.run('component-prop-deprecation', rule, {
       output: `import * as module from 'module-with-deprecations';
         const props = {label: "button", color: "red"};
         <module.Button {...props} value="value"/>`,
-      errors: [{message: "The 'Button' component's prop 'text' is deprecated. Please use the 'label' prop instead."}]
+      errors: [{message: `The 'Button' component's prop 'text' is deprecated. Please use the 'label' prop instead.`}]
     },
     {
       options: ruleOptions,
@@ -203,7 +220,7 @@ ruleTester.run('component-prop-deprecation', rule, {
       output: `const Button = require('module-with-deprecations').Button
         const props = {label: "button", color: "red"};
         <Button {...props} value="value"/>`,
-      errors: [{message: "The 'Button' component's prop 'text' is deprecated. Please use the 'label' prop instead."}]
+      errors: [{message: `The 'Button' component's prop 'text' is deprecated. Please use the 'label' prop instead.`}]
     },
     {
       options: ruleOptions,
@@ -213,7 +230,7 @@ ruleTester.run('component-prop-deprecation', rule, {
       output: `const {Button, List} = require('module-with-deprecations')
         const props = {label: "button", color: "red"};
         const test = <Button {...props} value="value"/>;`,
-      errors: [{message: "The 'Button' component's prop 'text' is deprecated. Please use the 'label' prop instead."}]
+      errors: [{message: `The 'Button' component's prop 'text' is deprecated. Please use the 'label' prop instead.`}]
     },
     {
       options: ruleOptions,
@@ -227,7 +244,7 @@ ruleTester.run('component-prop-deprecation', rule, {
         const props = {label: "button", color: "red"};
         const test1 = <Button {...props} value="value"/>;
         const test2 = <TextField>Bla</TextField>;`,
-      errors: [{message: "The 'Button' component's prop 'text' is deprecated. Please use the 'label' prop instead."}]
+      errors: [{message: `The 'Button' component's prop 'text' is deprecated. Please use the 'label' prop instead.`}]
     },
     {
       options: [{...ruleOptions[0], dueDate: '10/11/18'}],
@@ -252,19 +269,19 @@ ruleTester.run('component-prop-deprecation', rule, {
       errors: [
         {
           message:
-            "The 'Button' component's prop 'text' is deprecated. Please use the 'label' prop instead. Please fix this issue by 10/11/18!"
+            `The 'Button' component's prop 'text' is deprecated. Please use the 'label' prop instead. Please fix this issue by 10/11/18!`
         },
         {
           message:
-            "The 'Avatar' component's prop 'url' is deprecated. Please use the 'source' prop instead. Please fix this issue by 10/11/18!"
+            `The 'Avatar' component's prop 'url' is deprecated. Please use the 'source' prop instead. Please fix this issue by 10/11/18!`
         },
         {
           message:
-            "The 'Thumbnail' component's prop 'url' is deprecated. Please use the 'uri' prop instead. Please fix this issue by 10/11/18!"
+            `The 'Thumbnail' component's prop 'url' is deprecated. Please use the 'uri' prop instead. Please fix this issue by 10/11/18!`
         },
         {
           message:
-            "The 'List' component's prop 'text' is deprecated. Please use the 'label' prop instead. Please fix this issue by 10/11/18!"
+            `The 'List' component's prop 'text' is deprecated. Please use the 'label' prop instead. Please fix this issue by 10/11/18!`
         }
       ]
     },
@@ -293,19 +310,19 @@ ruleTester.run('component-prop-deprecation', rule, {
       errors: [
         {
           message:
-            "The 'Button' component's prop 'text' is deprecated. Please use the 'label' prop instead. Please fix this issue by 10/11/18!"
+            `The 'Button' component's prop 'text' is deprecated. Please use the 'label' prop instead. Please fix this issue by 10/11/18!`
         },
         {
           message:
-            "The 'Avatar' component's prop 'url' is deprecated. Please use the 'source' prop instead. Please fix this issue by 10/11/18!"
+            `The 'Avatar' component's prop 'url' is deprecated. Please use the 'source' prop instead. Please fix this issue by 10/11/18!`
         },
         {
           message:
-            "The 'Thumbnail' component's prop 'url' is deprecated. Please use the 'uri' prop instead. Please fix this issue by 10/11/18!"
+            `The 'Thumbnail' component's prop 'url' is deprecated. Please use the 'uri' prop instead. Please fix this issue by 10/11/18!`
         },
         {
           message:
-            "The 'List' component's prop 'text' is deprecated. Please use the 'label' prop instead. Please fix this issue by 10/11/18!"
+            `The 'List' component's prop 'text' is deprecated. Please use the 'label' prop instead. Please fix this issue by 10/11/18!`
         }
       ]
     },
@@ -334,19 +351,19 @@ ruleTester.run('component-prop-deprecation', rule, {
       errors: [
         {
           message:
-            "The 'Button' component's prop 'text' is deprecated. Please use the 'label' prop instead. Please fix this issue by 10/11/18!"
+            `The 'Button' component's prop 'text' is deprecated. Please use the 'label' prop instead. Please fix this issue by 10/11/18!`
         },
         {
           message:
-            "The 'Avatar' component's prop 'url' is deprecated. Please use the 'source' prop instead. Please fix this issue by 10/11/18!"
+            `The 'Avatar' component's prop 'url' is deprecated. Please use the 'source' prop instead. Please fix this issue by 10/11/18!`
         },
         {
           message:
-            "The 'Thumbnail' component's prop 'url' is deprecated. Please use the 'uri' prop instead. Please fix this issue by 10/11/18!"
+            `The 'Thumbnail' component's prop 'url' is deprecated. Please use the 'uri' prop instead. Please fix this issue by 10/11/18!`
         },
         {
           message:
-            "The 'List' component's prop 'text' is deprecated. Please use the 'label' prop instead. Please fix this issue by 10/11/18!"
+            `The 'List' component's prop 'text' is deprecated. Please use the 'label' prop instead. Please fix this issue by 10/11/18!`
         }
       ]
     },
@@ -358,7 +375,7 @@ ruleTester.run('component-prop-deprecation', rule, {
       output: `const {List} = require('module-with-deprecations')
         const props = {label: "list"};
         const test = <List.Item {...props} value="value"/>;`,
-      errors: [{message: "The 'List.Item' component's prop 'text' is deprecated. Please use the 'label' prop instead."}]
+      errors: [{message: `The 'List.Item' component's prop 'text' is deprecated. Please use the 'label' prop instead.`}]
     },
     {
       options: ruleOptions,
@@ -368,22 +385,22 @@ ruleTester.run('component-prop-deprecation', rule, {
       output: `import * as module from 'module-with-deprecations';
         const props = {label: "list"};
         <module.List.Item {...props} value="value"/>`,
-      errors: [{message: "The 'List.Item' component's prop 'text' is deprecated. Please use the 'label' prop instead."}]
+      errors: [{message: `The 'List.Item' component's prop 'text' is deprecated. Please use the 'label' prop instead.`}]
     },
     {
       options: ruleOptions,
       code: 'import {Text} from \'module-with-deprecations\'; <Text t="title" s="subtitle"/>',
       output: 'import {Text} from \'module-with-deprecations\'; <Text title="title" subtitle="subtitle"/>',
       errors: [
-        {message: "The 'Text' component's prop 't' is deprecated. Please use the 'title' prop instead."},
-        {message: "The 'Text' component's prop 's' is deprecated. Please use the 'subtitle' prop instead."}
+        {message: `The 'Text' component's prop 't' is deprecated. Please use the 'title' prop instead.`},
+        {message: `The 'Text' component's prop 's' is deprecated. Please use the 'subtitle' prop instead.`}
       ]
     },
     {
       options: ruleOptions,
       code: 'import {Picker} from \'module-with-deprecations\'; <Picker t="title" s="subtitle"/>',
       errors: [
-        {message: "The 'Picker' component's prop 'migrate' is required. Please make sure to pass the 'migrate' prop."}
+        {message: `The 'Picker' component's prop 'migrate' is required. Please make sure to pass the 'migrate' prop.`}
       ]
     }
   ]

--- a/lib/components/Keyboard/KeyboardInput/KeyboardAccessoryView.tsx
+++ b/lib/components/Keyboard/KeyboardInput/KeyboardAccessoryView.tsx
@@ -98,6 +98,10 @@ class KeyboardAccessoryView extends Component<KeyboardAccessoryViewProps> {
 
     this.registerForKeyboardResignedEvent();
     this.registerAndroidBackHandler();
+
+    if (props.iOSScrollBehavior) {
+      console.warn(`The 'Keyboard.KeyboardAccessoryView' component's prop 'iOSScrollBehavior' is deprecated. 'iOSScrollBehavior' prop is deprecated. Please use 'scrollBehavior' prop instead and pass it 'scrollBehaviors' ('iosScrollBehaviors' enum is deprecated).`);
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
## Description
**DON'T MERGE** - waiting for the engine pr to merge to cover both props and statics...
KeyboardAccessoryView - prop deprecation - adding a warning in the component. Adding tests to the lint rule.

## Changelog
KeyboardAccessoryView - start deprecation for `iOSScrollBehavior` prop and `iosScrollBehaviors` enum.