### PR TITLE
Incubator.TextField - fix initial validity

### DIFF
--- a/src/incubator/TextField/useFieldState.ts
+++ b/src/incubator/TextField/useFieldState.ts
@@ -15,7 +15,7 @@ export default function useFieldState({
 }: FieldStateProps) {
   const [value, setValue] = useState(props.value);
   const [isFocused, setIsFocused] = useState(false);
-  const [isValid, setIsValid] = useState(true);
+  const [isValid, setIsValid] = useState<boolean | undefined>(undefined);
   const [failingValidatorIndex, setFailingValidatorIndex] = useState<number | undefined>(undefined);
 
   useEffect(() => {
@@ -37,7 +37,9 @@ export default function useFieldState({
   }, [props.value, validateOnChange]);
 
   useDidUpdate(() => {
-    onChangeValidity?.(isValid);
+    if (!_.isUndefined(isValid)) {
+      onChangeValidity?.(isValid);
+    }
   }, [isValid]);
 
   const checkValidity = useCallback((valueToValidate = value) => {
@@ -86,7 +88,7 @@ export default function useFieldState({
     return {
       value,
       hasValue: !_.isEmpty(value),
-      isValid: validationMessage && !validate ? false : isValid,
+      isValid: validationMessage && !validate ? false : isValid ?? true,
       isFocused,
       failingValidatorIndex
     };


### PR DESCRIPTION
## Description
Incubator.TextField - fix initial validity

In private `Form`, fields were starting with validity `true` although they are not valid, thus making the `Form` not change validity to `true` and notifying about it.
This change fixes the issue while still keeping visual validity to "true" unless `validateOnStart` is sent.

WOAUILIB-2835

## Changelog
Incubator.TextField - fix initial validity