### PR TITLE
Keyboard.KeyboardAccessoryView - start prop deprecation

### DIFF
--- a/eslint-rules/tests/component_prop_deprecation.json
+++ b/eslint-rules/tests/component_prop_deprecation.json
@@ -1,5 +1,15 @@
 [
   {
+    "component": "Keyboard.KeyboardAccessoryView",
+    "source": "module-with-deprecations",
+    "props": [
+      {
+        "prop": "iOSScrollBehavior",
+        "message": "'iOSScrollBehavior' prop is deprecated. Please use 'scrollBehavior' prop instead and pass it 'scrollBehaviors' ('iosScrollBehaviors' enum is deprecated)."
+      }
+    ]
+  },
+  {
     "component": "Avatar",
     "source": "module-with-deprecations",
     "props": [

--- a/eslint-rules/tests/lib/rules/component-prop-deprecation.js
+++ b/eslint-rules/tests/lib/rules/component-prop-deprecation.js
@@ -14,9 +14,17 @@ const ruleTester = new RuleTester();
 const ruleOptions = [{deprecations: deprecationsJson}];
 const invalidExample =
   `import {Avatar} from 'module-with-deprecations'; const test = <Avatar url={'some_uri_string'}/>`;
+const validKeyboardExample =
+  `import {Keyboard} from 'module-with-deprecations'; const test = <Keyboard.KeyboardAccessoryView scrollBehavior={Keyboard.KeyboardAccessoryView.scrollBehaviors.NONE}/>`;
+const invalidKeyboardExample =
+  `import {Keyboard} from 'module-with-deprecations'; const test = <Keyboard.KeyboardAccessoryView iOSScrollBehavior={Keyboard.KeyboardAccessoryView.iosScrollBehaviors.NONE}/>`;
 
 ruleTester.run('component-prop-deprecation', rule, {
   valid: [
+    {
+      options: ruleOptions,
+      code: validKeyboardExample
+    },
     {
       options: ruleOptions,
       code: `const Avatar = require('another-module').Avatar;
@@ -115,6 +123,13 @@ ruleTester.run('component-prop-deprecation', rule, {
     }
   ],
   invalid: [
+    {
+      options: ruleOptions,
+      code: invalidKeyboardExample,
+      errors: [{
+        message: `The 'Keyboard.KeyboardAccessoryView' component's prop 'iOSScrollBehavior' is deprecated. 'iOSScrollBehavior' prop is deprecated. Please use 'scrollBehavior' prop instead and pass it 'scrollBehaviors' ('iosScrollBehaviors' enum is deprecated).`
+      }]
+    },
     {
       options: ruleOptions,
       code: invalidExample,

--- a/lib/components/Keyboard/KeyboardInput/KeyboardAccessoryView.tsx
+++ b/lib/components/Keyboard/KeyboardInput/KeyboardAccessoryView.tsx
@@ -9,6 +9,7 @@ import {
   BackHandler,
   LayoutChangeEvent
 } from 'react-native';
+import {LogService} from '../../../../src/services';
 import KeyboardTrackingView, {KeyboardTrackingViewProps} from '../KeyboardTracking/KeyboardTrackingView';
 import CustomKeyboardView from './CustomKeyboardView';
 import KeyboardUtils from './utils/KeyboardUtils';
@@ -98,6 +99,12 @@ class KeyboardAccessoryView extends Component<KeyboardAccessoryViewProps> {
 
     this.registerForKeyboardResignedEvent();
     this.registerAndroidBackHandler();
+
+    if (props.iOSScrollBehavior) {
+      LogService.warn(`The 'Keyboard.KeyboardAccessoryView' component's prop 'iOSScrollBehavior' is deprecated. 
+        Please use 'scrollBehavior' prop instead and pass it 'scrollBehaviors' 
+        ('iosScrollBehaviors' enum is deprecated).`);
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
## Description
Keyboard.KeyboardAccessoryView - start prop deprecation for 'iOSScrollBehavior'

## Changelog
Keyboard.KeyboardAccessoryView - start prop deprecation for 'iOSScrollBehavior'
