### PR TITLE
Design Tokens - TextField - fix string check

### DIFF
--- a/src/components/textField/index.tsx
+++ b/src/components/textField/index.tsx
@@ -293,7 +293,7 @@ export default class TextField extends BaseInput {
     const error = this.getErrorMessage();
     const {disabledColor} = this.getThemeProps();
 
-    if (_.isString(colorProp)) {
+    if (_.isString(Colors.getColorName(colorProp))) {
       return colorProp || Colors.grey10;
     } else if (_.isPlainObject(colorProp)) {
       const mergedColorState = {...COLOR_BY_STATE, ...colorProp};


### PR DESCRIPTION
## Description
Design Tokens - TextField - fix string check
WOAUILIB-2818 (SearchInput uses the old ChipsInput which in turn uses the old TextField 🤷‍♂️)

## Changelog
None