### PR TITLE
Allow migration of ChipsInput's TextField

### DIFF
--- a/src/components/chipsInput/index.tsx
+++ b/src/components/chipsInput/index.tsx
@@ -5,8 +5,7 @@ import {Colors, BorderRadiuses, ThemeManager, Typography, Spacings} from '../../
 import Assets from '../../assets';
 import {LogService} from '../../services';
 import {Constants, asBaseComponent, BaseComponentInjectedProps, TypographyModifiers} from '../../commons/new';
-// @ts-expect-error
-import {TextField} from '../inputs';
+import TextFieldMigrator from '../textField/TextFieldMigrator';
 import View from '../view';
 import TouchableOpacity from '../touchableOpacity';
 import Text from '../text';
@@ -453,7 +452,7 @@ class ChipsInput extends Component<OwnProps, State> {
 
     return (
       <View style={styles.inputWrapper}>
-        <TextField
+        <TextFieldMigrator
           ref={this.input}
           text80
           blurOnSubmit={false}


### PR DESCRIPTION
## Description
Allow migration of ChipsInput's TextField
WOAUILIB-2818 (SearchInput uses the old ChipsInput which in turn uses the old TextField 🤷‍♂️)

## Changelog
Allow migration of ChipsInput's TextField