### PR TITLE
Resolves uncaught error ViewPropTypes

### DIFF
--- a/demo/src/screens/MainScreen.js
+++ b/demo/src/screens/MainScreen.js
@@ -2,7 +2,8 @@ import _ from 'lodash';
 import React, {Component} from 'react';
 import AsyncStorage from '@react-native-community/async-storage';
 import PropTypes from 'prop-types';
-import {StyleSheet, FlatList, ViewPropTypes} from 'react-native';
+import {StyleSheet, FlatList} from 'react-native';
+import {ViewPropTypes} from 'deprecated-react-native-prop-types';
 import {Navigation} from 'react-native-navigation';
 import {gestureHandlerRootHOC} from 'react-native-gesture-handler';
 import {

--- a/src/components/baseInput/index.tsx
+++ b/src/components/baseInput/index.tsx
@@ -2,7 +2,8 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import 'react';
-import {ViewPropTypes, TextInput as RNTextInput} from 'react-native';
+import { TextInput as RNTextInput } from 'react-native';
+import {ViewPropTypes} from 'deprecated-react-native-prop-types';
 import {Colors, Typography} from '../../style';
 import {BaseComponent} from '../../commons';
 import Validators from './Validators';


### PR DESCRIPTION
Fix: ViewPropTypes has been removed from React Native. Migrate to ViewPropTypes exported from 'deprecated-react-native-prop-types'.

## Description
*Enter description to help the reviewer understand what's the change about...*

## Changelog
*Add a quick message for our users about this change (include Compoennt name, relevant props and general purpose of the PR)*
