### PR TITLE
remove testID used on second element

### DIFF
--- a/src/components/drawer/Swipeable.tsx
+++ b/src/components/drawer/Swipeable.tsx
@@ -520,7 +520,6 @@ export default class Swipeable extends Component<Props, State> {
           {right}
           <TapGestureHandler onHandlerStateChange={this._onTapHandlerStateChange}>
             <Animated.View
-              testID={testID}
               style={[
                 {transform: [{translateX: this.getTransX()}]},
                 childrenContainerStyle


### PR DESCRIPTION
## Description
Swipeable component has two elements with the same testID. [First element](https://github.com/wix/react-native-ui-lib/blob/master/src/components/drawer/Swipeable.tsx#L512), [second element](https://github.com/wix/react-native-ui-lib/blob/master/src/components/drawer/Swipeable.tsx#L523). Can't rely on querying elements by testID in react-test-renderer tests.

## Changelog
remove duplicate testID used on second element
