### PR TITLE
WheelPicker - fix optionalDependencies

### DIFF
--- a/lib/components/WheelPicker/index.tsx
+++ b/lib/components/WheelPicker/index.tsx
@@ -10,14 +10,6 @@ import {Typography, Colors} from '../../../src/style';
 import {PickerPackage, CommunityPickerPackage} from '../../../src/optionalDependencies';
 const Picker = PickerPackage?.Picker || CommunityPickerPackage?.Picker || (() => null);
 
-if (!PickerPackage) {
-  if (CommunityPickerPackage) {
-    console.warn(`RNUILib Picker will soon migrate to use "@react-native-picker/picker" package instead of '@react-native-community/picker'`);
-  } else {
-    console.error(`RNUILib Picker requires installing "@react-native-picker/picker" dependency`);
-  }
-}
-
 const WheelPickerNative = requireNativeComponent('WheelPicker');
 
 export type WheelPickerProps = {

--- a/src/components/wheelPickerDialog/index.js
+++ b/src/components/wheelPickerDialog/index.js
@@ -6,7 +6,7 @@ import Typography from '../../style/typography';
 import View from '../view';
 import Text from '../text';
 import {WheelPicker} from '../../nativeComponents';
-
+import {PickerPackage, CommunityPickerPackage} from '../../../src/optionalDependencies';
 
 export default class WheelPickerDialog extends Component {
   static displayName = 'IGNORE';
@@ -50,10 +50,22 @@ export default class WheelPickerDialog extends Component {
     onValueChange: PropTypes.func
   }
 
-  state = {
-    initialSelectedValue: this.props.selectedValue,
-    currentValue: false
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      initialSelectedValue: props.selectedValue,
+      currentValue: false
+    };
+
+    if (!PickerPackage) {
+      if (CommunityPickerPackage) {
+        // eslint-disable-next-line max-len
+        console.warn(`RNUILib Picker will soon migrate to use "@react-native-picker/picker" package instead of '@react-native-community/picker'`);
+      } else {
+        console.error(`RNUILib Picker requires installing "@react-native-picker/picker" dependency`);
+      }
+    }
+  }
 
   onValueChange = (value, index) => {
     if (this.props.onValueChange) {


### PR DESCRIPTION
## Description
WheelPicker - optionalDependencies error should only show on usage (only `WheelPickerDialog` uses the native `WheelPicker`)
WOAUILIB-2838

## Changelog
WheelPicker - optionalDependencies error should only show on usage