### PR TITLE
Infra/modifiers perf improvement

### DIFF
--- a/src/commons/modifiers.ts
+++ b/src/commons/modifiers.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import {StyleSheet} from 'react-native';
-import {Typography, Colors, Scheme, DesignTokens, BorderRadiuses, Spacings, ThemeManager} from '../style';
+import {Typography, Colors, DesignTokens, BorderRadiuses, Spacings, ThemeManager} from '../style';
 import {BorderRadiusesLiterals} from '../style/borderRadiuses';
 import TypographyPresets from '../style/typographyPresets';
 import {SpacingLiterals} from '../style/spacings';
@@ -10,9 +10,7 @@ export const PADDING_KEY_PATTERN = new RegExp(`padding[LTRBHV]?-([0-9]*|${Spacin
 export const MARGIN_KEY_PATTERN = new RegExp(`margin[LTRBHV]?-([0-9]*|${Spacings.getKeysPattern()})`);
 export const ALIGNMENT_KEY_PATTERN = /(left|top|right|bottom|center|centerV|centerH|spread)/;
 export const POSITION_KEY_PATTERN = /^abs([F|L|R|T|B|V|H])?$/;
-let SCHEME_COLORS = Scheme.getScheme();
-let ALL_COLORS = {...Colors, ...SCHEME_COLORS};
-let BACKGROUND_COLOR_KEYS_PATTERN = Colors.getBackgroundKeysPattern();
+const BACKGROUND_COLOR_KEYS_PATTERN = Colors.getBackgroundKeysPattern();
 
 export interface AlteredOptions {
   flex?: boolean;
@@ -103,17 +101,11 @@ export type ContainerModifiers = AlignmentModifiers &
   BorderRadiusModifiers &
   BackgroundColorModifier;
 
-export function updateColorModifiers() {
-  SCHEME_COLORS = Scheme.getScheme();
-  ALL_COLORS = {...Colors, ...SCHEME_COLORS};
-  BACKGROUND_COLOR_KEYS_PATTERN = Colors.getBackgroundKeysPattern();
-}
-
 export function extractColorValue(props: Dictionary<any>) {
-  const colorPropsKeys = Object.keys(props).filter(key => ALL_COLORS[key] !== undefined);
+  const colorPropsKeys = Object.keys(props).filter(key => Colors[key] !== undefined);
   const colorKey = _.findLast(colorPropsKeys, colorKey => props[colorKey] === true)!;
 
-  return SCHEME_COLORS[colorKey] || Colors[colorKey];
+  return Colors[colorKey];
 }
 
 export function extractBackgroundColorValue(props: Dictionary<any>) {
@@ -123,7 +115,7 @@ export function extractBackgroundColorValue(props: Dictionary<any>) {
   const bgProp = _.findLast(keys, prop => BACKGROUND_COLOR_KEYS_PATTERN.test(prop) && !!props[prop])!;
   if (props[bgProp]) {
     const key = bgProp.replace(BACKGROUND_COLOR_KEYS_PATTERN, '');
-    backgroundColor = SCHEME_COLORS[key] || Colors[key];
+    backgroundColor = Colors[key];
   }
 
   return backgroundColor;

--- a/src/commons/modifiers.ts
+++ b/src/commons/modifiers.ts
@@ -103,7 +103,7 @@ export type ContainerModifiers = AlignmentModifiers &
   BorderRadiusModifiers &
   BackgroundColorModifier;
 
-export function updateModifiers() {
+export function updateColorModifiers() {
   SCHEME_COLORS = Scheme.getScheme();
   ALL_COLORS = {...Colors, ...SCHEME_COLORS};
   BACKGROUND_COLOR_KEYS_PATTERN = Colors.getBackgroundKeysPattern();

--- a/src/commons/modifiers.ts
+++ b/src/commons/modifiers.ts
@@ -10,6 +10,9 @@ export const PADDING_KEY_PATTERN = new RegExp(`padding[LTRBHV]?-([0-9]*|${Spacin
 export const MARGIN_KEY_PATTERN = new RegExp(`margin[LTRBHV]?-([0-9]*|${Spacings.getKeysPattern()})`);
 export const ALIGNMENT_KEY_PATTERN = /(left|top|right|bottom|center|centerV|centerH|spread)/;
 export const POSITION_KEY_PATTERN = /^abs([F|L|R|T|B|V|H])?$/;
+let SCHEME_COLORS = Scheme.getScheme();
+let ALL_COLORS = {...Colors, ...SCHEME_COLORS};
+let BACKGROUND_COLOR_KEYS_PATTERN = Colors.getBackgroundKeysPattern();
 
 export interface AlteredOptions {
   flex?: boolean;
@@ -100,30 +103,34 @@ export type ContainerModifiers = AlignmentModifiers &
   BorderRadiusModifiers &
   BackgroundColorModifier;
 
+export function updateModifiers() {
+  SCHEME_COLORS = Scheme.getScheme();
+  ALL_COLORS = {...Colors, ...SCHEME_COLORS};
+  BACKGROUND_COLOR_KEYS_PATTERN = Colors.getBackgroundKeysPattern();
+}
+
 export function extractColorValue(props: Dictionary<any>) {
-  const schemeColors = Scheme.getScheme();
-  const allColorsKeys: Array<keyof typeof Colors> = [..._.keys(Colors), ..._.keys(schemeColors)];
-  const colorPropsKeys = Object.keys(props).filter(key => _.includes(allColorsKeys, key));
+  const colorPropsKeys = Object.keys(props).filter(key => ALL_COLORS[key] !== undefined);
   const colorKey = _.findLast(colorPropsKeys, colorKey => props[colorKey] === true)!;
-  return schemeColors[colorKey] || Colors[colorKey];
+
+  return SCHEME_COLORS[colorKey] || Colors[colorKey];
 }
 
 export function extractBackgroundColorValue(props: Dictionary<any>) {
   let backgroundColor;
 
-  const schemeColors = Scheme.getScheme();
-
   const keys = Object.keys(props);
-  const bgProp = _.findLast(keys, prop => Colors.getBackgroundKeysPattern().test(prop) && !!props[prop])!;
+  const bgProp = _.findLast(keys, prop => BACKGROUND_COLOR_KEYS_PATTERN.test(prop) && !!props[prop])!;
   if (props[bgProp]) {
-    const key = bgProp.replace(Colors.getBackgroundKeysPattern(), '');
-    backgroundColor = schemeColors[key] || Colors[key];
+    const key = bgProp.replace(BACKGROUND_COLOR_KEYS_PATTERN, '');
+    backgroundColor = SCHEME_COLORS[key] || Colors[key];
   }
 
   return backgroundColor;
 }
 export function extractTypographyValue(props: Dictionary<any>): object | undefined {
-  const typographyPropsKeys = Object.keys(props).filter(key => Typography.getKeysPattern().test(key));
+  const typographyPropsKeys = Object.keys(props).filter(key => Typography[key] !== undefined);
+
   let typography: any;
   _.forEach(typographyPropsKeys, key => {
     if (props[key] === true) {


### PR DESCRIPTION
## Description
Update some modifiers extraction methods to improve performance. 
I checked a specific session (on the private demo app, iOS) before and after these changes. the results are in ms: 
```
before: {
  "backgroundColor": 291.95974069833755,
  "color": 1362.02895539999,
  "typography": 878.3454459905624
},
after: {
  "backgroundColor": 54.971199452877045,
  "color": 97.36799198389053,
  "typography": 85.1839787364006
},
```
Also, I added a function to update the modifiers' colors that should be called after loading some colors/scheme.
(and I call it on private in `preset.config.ts`)

## Changelog
Improve modifiers' performance
