### PR TITLE
Handle undefined ref when user use renderPicker

### DIFF
--- a/src/components/picker/helpers/useImperativePickerHandle.ts
+++ b/src/components/picker/helpers/useImperativePickerHandle.ts
@@ -6,8 +6,7 @@ const useImperativePickerHandle = (ref: React.Ref<any>,
   expandableRef: React.MutableRefObject<ExpandableOverlayMethods | null>) => {
   const pickerRef = useRef<TextFieldMethods>();
   useImperativeHandle(ref, () => {
-    // @ts-expect-error useRef return type is possible null therefor it throw TS error
-    const {isFocused, focus, blur, clear, validate} = pickerRef.current;
+    const {isFocused, focus, blur, clear, validate} = pickerRef.current ?? {};
     // @ts-expect-error useRef return type is possible null therefor it throw TS error
     const {openExpandable, closeExpandable, toggleExpandable} = expandableRef.current;
 


### PR DESCRIPTION
## Description
Handle Picker internal undefined ref when user pass custom `renderPicker`

## Changelog
Handle Picker internal undefined ref when user pass custom `renderPicker`