### PR TITLE
Support passing asBaseComponent options

### DIFF
--- a/src/commons/asBaseComponent.tsx
+++ b/src/commons/asBaseComponent.tsx
@@ -12,12 +12,21 @@ export interface BaseComponentInjectedProps {
   modifiers: ReturnType<typeof Modifiers.generateModifiersStyle>;
 }
 
+export interface AsBaseComponentOptions {
+  ignoreModifiers?: boolean;
+  ignoreTheme?: boolean;
+  modifiersOptions?: Modifiers.ModifiersOptions;
+}
+
 // TODO: find a proper way to inject this type in the private repo
 type ThemeComponent = {
   useCustomTheme?: boolean;
 };
 
-function asBaseComponent<PROPS, STATICS = {}>(WrappedComponent: React.ComponentType<any>): React.ComponentClass<PROPS & ThemeComponent> & STATICS {
+const EMPTY_MODIFIERS = {};
+
+function asBaseComponent<PROPS, STATICS = {}>(WrappedComponent: React.ComponentType<any>,
+  options: AsBaseComponentOptions = {}): React.ComponentClass<PROPS & ThemeComponent> & STATICS {
   class BaseComponent extends UIComponent {
     static displayName: string | undefined;
     static propTypes: any;
@@ -52,8 +61,10 @@ function asBaseComponent<PROPS, STATICS = {}>(WrappedComponent: React.ComponentT
     }
 
     render() {
-      const themeProps = BaseComponent.getThemeProps(this.props, this.context);
-      const modifiers = Modifiers.generateModifiersStyle(undefined, themeProps);
+      const themeProps = options.ignoreTheme ? this.props : BaseComponent.getThemeProps(this.props, this.context);
+      const modifiers = options.ignoreModifiers
+        ? EMPTY_MODIFIERS
+        : Modifiers.generateModifiersStyle(options.modifiersOptions, themeProps);
       // TODO: omit original modifiers props (left, right, flex, etc..)
       // Because they throws an error when being passed to RNView on Android
       const {forwardedRef, ...others} = themeProps;

--- a/src/commons/modifiers.ts
+++ b/src/commons/modifiers.ts
@@ -32,6 +32,18 @@ export interface ExtractedStyle {
   positionStyle?: ReturnType<typeof extractPositionStyle>;
 }
 
+export type ModifiersOptions = {
+  color?: boolean;
+  typography?: boolean;
+  backgroundColor?: boolean;
+  borderRadius?: boolean;
+  paddings?: boolean;
+  margins?: boolean;
+  alignments?: boolean;
+  flex?: boolean;
+  position?: boolean;
+}
+
 const PADDING_VARIATIONS = {
   padding: 'padding',
   paddingL: 'paddingLeft',
@@ -342,7 +354,7 @@ export function getThemeProps(props = this.props, context = this.context) {
   return {...themeProps, ...props, ...forcedThemeProps};
 }
 
-export function generateModifiersStyle(options = {
+export function generateModifiersStyle(options: ModifiersOptions = {
   color: true,
   typography: true,
   backgroundColor: true,

--- a/src/components/view/index.tsx
+++ b/src/components/view/index.tsx
@@ -20,7 +20,7 @@ export interface ViewProps extends Omit<RNViewProps, 'style'>, ContainerModifier
    */
   animated?: boolean;
   /**
-    * Use Animate.View (from react-native-reanimated) as a container
+   * Use Animate.View (from react-native-reanimated) as a container
    */
   reanimated?: boolean;
   /**
@@ -138,4 +138,14 @@ class View extends PureComponent<PropsTypes, ViewState> {
   }
 }
 
-export default asBaseComponent<ViewProps>(forwardRef(View));
+const modifiersOptions = {
+  backgroundColor: true,
+  borderRadius: true,
+  paddings: true,
+  margins: true,
+  alignments: true,
+  flex: true,
+  position: true
+};
+
+export default asBaseComponent<ViewProps>(forwardRef(View), {modifiersOptions});


### PR DESCRIPTION
## Description
Support passing asBaseComponent options to allow ignoring theme/modifiers support
It also allow passing modifier options so each component can decide which modifiers to calculate

## Changelog
Add support for passing options to asBaseComponent for optimizations 
