### PR TITLE
Infra/ remove asBaseComponent from color components

### DIFF
--- a/src/components/colorPalette/index.tsx
+++ b/src/components/colorPalette/index.tsx
@@ -3,7 +3,7 @@ import memoize from 'memoize-one';
 import React, {PureComponent} from 'react';
 import {StyleSheet, UIManager, findNodeHandle, StyleProp, ViewStyle} from 'react-native';
 import {Colors} from '../../style';
-import {Constants, asBaseComponent} from '../../commons/new';
+import {Constants} from '../../commons/new';
 import View from '../view';
 import Carousel from '../carousel';
 import ScrollBar from '../scrollBar';
@@ -383,7 +383,7 @@ class ColorPalette extends PureComponent<Props, State> {
   }
 }
 
-export default asBaseComponent<Props>(ColorPalette);
+export default ColorPalette;
 
 const styles = StyleSheet.create({
   paletteContainer: {

--- a/src/components/colorPicker/index.tsx
+++ b/src/components/colorPicker/index.tsx
@@ -1,6 +1,5 @@
 import React, {PureComponent} from 'react';
 import {StyleSheet, StyleProp, ViewStyle} from 'react-native';
-import {asBaseComponent} from '../../commons/new';
 import Assets from '../../assets';
 import {Colors} from '../../style';
 import View from '../view';
@@ -136,7 +135,7 @@ class ColorPicker extends PureComponent<Props> {
   };
 }
 
-export default asBaseComponent<Props>(ColorPicker);
+export default ColorPicker;
 
 
 const plusButtonContainerWidth = SWATCH_SIZE + 20 + 12;

--- a/src/components/colorSwatch/index.tsx
+++ b/src/components/colorSwatch/index.tsx
@@ -2,7 +2,7 @@ import React, {PureComponent} from 'react';
 import {StyleSheet, Animated, Easing, LayoutChangeEvent, StyleProp, ViewStyle} from 'react-native';
 import Assets from '../../assets';
 import {BorderRadiuses, Colors} from '../../style';
-import {Constants, asBaseComponent} from '../../commons/new';
+import {Constants} from '../../commons/new';
 import View from '../view';
 import TouchableOpacity from '../touchableOpacity';
 import Image from '../image';
@@ -190,7 +190,7 @@ class ColorSwatch extends PureComponent<Props> {
   }
 }
 
-export default asBaseComponent<Props>(ColorSwatch);
+export default ColorSwatch;
 
 function createStyles({color = Colors.grey30}) {
   return StyleSheet.create({


### PR DESCRIPTION
## Description
remove asBaseComponent from color components

## Changelog
Remove asBaseComponent from ColorSwatch, ColorPalette and ColorPicker
