### PR TITLE
Migrate to deprecated-react-native-prop-types package

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,4 +2,4 @@
 *Enter description to help the reviewer understand what's the change about...*
 
 ## Changelog
-*Add a quick message for our users about this change (include Compoennt name, relevant props and general purpose of the PR)*
+*Add a quick message for our users about this change (include Component name, relevant props and general purpose of the PR)*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ When contributing to this repository, please first discuss the change you wish t
 ## Pull Request Process
 
 1. First make sure the environment is working and synced with master. For installation details go [here](https://github.com/wix/react-native-ui-lib/blob/master/markdowns/getting-started/setup.md#demo-app)
-2. Before submitting a PR we suggest running `npm run prepush` command that verifies our lint, TS and tests were not broken.
+2. Before submitting a PR we suggest running `npm run pre-push` command that verifies our lint, TS and tests were not broken.
 3. Please use our PR prefixes accordingly. `fix` for bugfix, `feat` for feature, `infra` for infrastructure changes and `docs` for documentation related changes (e.g `fix/ButtonStyle`, `feat/Avatar_colorProp`)
 4. Please don't change our PR template.
   - In the Description section add everything that can help the reviewer and the reviewing process, like a description of the issue and the way you decided to go about it, screenshots or gifs, etc.

--- a/demo/src/screens/MainScreen.js
+++ b/demo/src/screens/MainScreen.js
@@ -2,7 +2,8 @@ import _ from 'lodash';
 import React, {Component} from 'react';
 import AsyncStorage from '@react-native-community/async-storage';
 import PropTypes from 'prop-types';
-import {StyleSheet, FlatList, ViewPropTypes} from 'react-native';
+import {StyleSheet, FlatList} from 'react-native';
+import {ViewPropTypes} from 'deprecated-react-native-prop-types';
 import {Navigation} from 'react-native-navigation';
 import {gestureHandlerRootHOC} from 'react-native-gesture-handler';
 import {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-plugin-transform-inline-environment-variables": "^0.0.2",
     "color": "^3.1.0",
     "commons-validator-js": "^1.0.237",
+    "deprecated-react-native-prop-types": "^2.3.0",
     "hoist-non-react-statics": "^3.0.0",
     "lodash": "^4.17.21",
     "memoize-one": "^5.0.5",

--- a/src/components/animatedScanner/index.js
+++ b/src/components/animatedScanner/index.js
@@ -1,7 +1,8 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {ViewPropTypes, StyleSheet, Animated} from 'react-native';
+import {StyleSheet, Animated} from 'react-native';
+import {ViewPropTypes} from 'deprecated-react-native-prop-types';
 import {Colors} from '../../style';
 import {BaseComponent} from '../../commons';
 import View from '../../components/view';

--- a/src/components/baseInput/index.tsx
+++ b/src/components/baseInput/index.tsx
@@ -2,7 +2,7 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import 'react';
-import {ViewPropTypes, TextInput as RNTextInput} from 'react-native';
+import {ViewPropTypes, TextInputPropTypes} from 'deprecated-react-native-prop-types';
 import {Colors, Typography} from '../../style';
 import {BaseComponent} from '../../commons';
 import Validators from './Validators';
@@ -19,7 +19,7 @@ export default class BaseInput extends BaseComponent {
   static displayName = 'BaseInput';
 
   static propTypes = {
-    ...RNTextInput.propTypes,
+    ...TextInputPropTypes,
     // ...BaseComponent.propTypes,
     /**
      * text color

--- a/src/components/carousel/types.tsx
+++ b/src/components/carousel/types.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {ScrollViewProps, StyleProp, ViewStyle, NativeSyntheticEvent, NativeScrollEvent, Animated} from 'react-native';
-// @ts-expect-error
+// @ts-expect-error No typings available for 'deprecated-react-native-prop-types'
 import {PointPropType} from 'deprecated-react-native-prop-types';
 import {PageControlProps} from '../pageControl';
 

--- a/src/components/carousel/types.tsx
+++ b/src/components/carousel/types.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import {ScrollViewProps, StyleProp, ViewStyle, NativeSyntheticEvent, NativeScrollEvent, PointPropType, Animated} from 'react-native';
+import {ScrollViewProps, StyleProp, ViewStyle, NativeSyntheticEvent, NativeScrollEvent, Animated} from 'react-native';
+// @ts-expect-error
+import {PointPropType} from 'deprecated-react-native-prop-types';
 import {PageControlProps} from '../pageControl';
 
 export enum PageControlPosition {
@@ -91,7 +93,7 @@ export interface CarouselProps extends ScrollViewProps {
    */
   horizontal?: boolean | null;
   /**
-   * Pass to attach to ScrollView's Animated.event in order to animated elements base on 
+   * Pass to attach to ScrollView's Animated.event in order to animated elements base on
    * Carousel scroll offset (pass new Animated.ValueXY())
    */
   animatedScrollOffset?: Animated.ValueXY;

--- a/src/components/image/index.tsx
+++ b/src/components/image/index.tsx
@@ -9,7 +9,7 @@ import {
   NativeSyntheticEvent,
   ImageErrorEventData
 } from 'react-native';
-// @ts-expect-error
+// @ts-expect-error No typings available for 'deprecated-react-native-prop-types'
 import {ImagePropTypes} from 'deprecated-react-native-prop-types';
 import {
   Constants,

--- a/src/components/image/index.tsx
+++ b/src/components/image/index.tsx
@@ -6,10 +6,11 @@ import {
   Image as RNImage,
   ImageProps as RNImageProps,
   ImageBackground,
-  ImageSourcePropType,
   NativeSyntheticEvent,
   ImageErrorEventData
 } from 'react-native';
+// @ts-expect-error
+import {ImagePropTypes} from 'deprecated-react-native-prop-types';
 import {
   Constants,
   asBaseComponent,
@@ -28,7 +29,7 @@ export type ImageProps = RNImageProps &
     /**
      * custom source transform handler for manipulating the image source (great for size control)
      */
-    sourceTransformer?: (props: any) => ImageSourcePropType;
+    sourceTransformer?: (props: any) => ImagePropTypes.source;
     /**
      * if provided image source will be driven from asset name
      */
@@ -73,7 +74,7 @@ export type ImageProps = RNImageProps &
     /**
      * Default image source in case of an error
      */
-    errorSource?: ImageSourcePropType;
+    errorSource?: ImagePropTypes.source;
     /**
      * An imageId that can be used in sourceTransformer logic
      */
@@ -84,7 +85,7 @@ type Props = ImageProps & ForwardRefInjectedProps & BaseComponentInjectedProps;
 
 type State = {
   error: boolean;
-  prevSource: ImageSourcePropType;
+  prevSource: ImagePropTypes.source;
 };
 
 /**
@@ -105,7 +106,7 @@ class Image extends PureComponent<Props, State> {
   public static overlayTypes = Overlay.overlayTypes;
   public static overlayIntensityType = Overlay.intensityTypes;
 
-  sourceTransformer?: (props: any) => ImageSourcePropType;
+  sourceTransformer?: (props: any) => ImagePropTypes.source;
 
   constructor(props: Props) {
     super(props);
@@ -143,7 +144,7 @@ class Image extends PureComponent<Props, State> {
     return !!overlayType || this.isGif() || !_.isUndefined(customOverlayContent);
   }
 
-  getVerifiedSource(source?: ImageSourcePropType) {
+  getVerifiedSource(source?: ImagePropTypes.source) {
     if (_.get(source, 'uri') === null || _.get(source, 'uri') === '') {
       // @ts-ignore
       return {...source, uri: undefined};

--- a/src/components/maskedInput/old.js
+++ b/src/components/maskedInput/old.js
@@ -1,7 +1,8 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {StyleSheet, ViewPropTypes, Keyboard} from 'react-native';
+import {StyleSheet, Keyboard} from 'react-native';
+import {ViewPropTypes} from 'deprecated-react-native-prop-types';
 import BaseInput from '../baseInput';
 import TextField from '../textField';
 import View from '../view';

--- a/src/components/picker/PickerDialog.android.js
+++ b/src/components/picker/PickerDialog.android.js
@@ -50,23 +50,10 @@ class PickerDialog extends Component {
 
     return (
       <View style={styles.footer}>
-        <Text
-          text80
-          primary
-          onPress={onCancel}
-          accessibilityRole={onCancel ? 'button' : undefined}
-          style={cancelLabelStyle}
-        >
+        <Text text80 primary onPress={onCancel} accessibilityRole={onCancel ? 'button' : undefined} style={cancelLabelStyle}>
           {cancelLabel}
         </Text>
-        <Text
-          text80
-          primary
-          marginL-15
-          onPress={onDone}
-          accessibilityRole={onDone ? 'button' : undefined}
-          style={selectLabelStyle}
-        >
+        <Text text80 primary marginL-15 onPress={onDone} accessibilityRole={onDone ? 'button' : undefined} style={selectLabelStyle}>
           {doneLabel}
         </Text>
       </View>

--- a/src/components/picker/PickerDialog.android.js
+++ b/src/components/picker/PickerDialog.android.js
@@ -1,5 +1,6 @@
 import React, {Component} from 'react';
-import {StyleSheet, Text as RNText} from 'react-native';
+import {StyleSheet} from 'react-native';
+import {TextPropTypes} from 'deprecated-react-native-prop-types';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 
@@ -17,11 +18,11 @@ class PickerDialog extends Component {
     /**
      * select label style
      */
-    selectLabelStyle: RNText.propTypes.style,
+    selectLabelStyle: TextPropTypes.style,
     /**
      * cancel label style
      */
-    cancelLabelStyle: RNText.propTypes.style
+    cancelLabelStyle: TextPropTypes.style
   };
 
   state = {};
@@ -49,18 +50,30 @@ class PickerDialog extends Component {
 
     return (
       <View style={styles.footer}>
-        <Text text80 primary onPress={onCancel} accessibilityRole={onCancel ? 'button' : undefined} style={cancelLabelStyle}>
+        <Text
+          text80
+          primary
+          onPress={onCancel}
+          accessibilityRole={onCancel ? 'button' : undefined}
+          style={cancelLabelStyle}
+        >
           {cancelLabel}
         </Text>
-        <Text text80 primary marginL-15 onPress={onDone} accessibilityRole={onDone ? 'button' : undefined} style={selectLabelStyle}>
+        <Text
+          text80
+          primary
+          marginL-15
+          onPress={onDone}
+          accessibilityRole={onDone ? 'button' : undefined}
+          style={selectLabelStyle}
+        >
           {doneLabel}
         </Text>
       </View>
     );
   }
 
-
-  render() {  
+  render() {
     const {panDirection, visible, pickerModalProps} = this.props;
     return (
       <Dialog {...pickerModalProps} visible={visible} height="50%" width="77%" panDirection={panDirection}>

--- a/src/components/textArea/index.js
+++ b/src/components/textArea/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import {View, TextInput as RNTextInput, StyleSheet} from 'react-native';
+import {TextInputPropTypes} from 'deprecated-react-native-prop-types';
 import BaseInput from '../baseInput';
 
 /**
@@ -14,7 +15,7 @@ export default class TextArea extends BaseInput {
   static displayName = 'TextArea';
 
   static propTypes = {
-    ...RNTextInput.propTypes,
+    ...TextInputPropTypes,
     ...BaseInput.propTypes
   };
 

--- a/src/components/textField/index.tsx
+++ b/src/components/textField/index.tsx
@@ -224,7 +224,7 @@ export default class TextField extends BaseInput {
     }
   }
 
-  onPlaceholderLayout = event => {
+  onPlaceholderLayout = (event) => {
     const {width} = event.nativeEvent.layout;
     const translate = width / 2 - (width * FLOATING_PLACEHOLDER_SCALE) / 2;
     this.setState({floatingPlaceholderTranslate: translate / FLOATING_PLACEHOLDER_SCALE});
@@ -260,10 +260,10 @@ export default class TextField extends BaseInput {
     };
   }
 
-  toggleExpandableModal = value => {
+  toggleExpandableModal = (value) => {
     this.setState({showExpandableModal: value});
     _.invoke(this.props, 'onToggleExpandableModal', value);
-  };
+  }
 
   updateFloatingPlaceholderState = withoutAnimation => {
     if (withoutAnimation) {
@@ -323,8 +323,8 @@ export default class TextField extends BaseInput {
 
   setCharCountColor(key) {
     this.maxReached = key === Constants.backspaceKey ? false : this.isCounterLimit();
-    const color =
-      this.state.focused && this.maxReached ? CHAR_COUNTER_COLOR_BY_STATE.error : CHAR_COUNTER_COLOR_BY_STATE.default;
+    const color = this.state.focused && this.maxReached ?
+      CHAR_COUNTER_COLOR_BY_STATE.error : CHAR_COUNTER_COLOR_BY_STATE.default;
 
     if (color !== this.state.charCountColor) {
       this.setState({charCountColor: color});
@@ -415,8 +415,7 @@ export default class TextField extends BaseInput {
   /** Renders */
   renderPlaceholder() {
     const {floatingPlaceholderState, floatingPlaceholderTranslate} = this.state;
-    const {placeholder, placeholderTextColor, floatingPlaceholderColor, floatingPlaceholderStyle} =
-      this.getThemeProps();
+    const {placeholder, placeholderTextColor, floatingPlaceholderColor, floatingPlaceholderStyle} = this.getThemeProps();
     const typography = this.getTypography();
     const placeholderColor = this.getStateColor(placeholderTextColor || PLACEHOLDER_COLOR_BY_STATE.default);
 
@@ -590,7 +589,7 @@ export default class TextField extends BaseInput {
       expandable,
       rightIconSource,
       color,
-      placeholder,
+      placeholder, 
       helperText,
       ...others
     } = this.getThemeProps();
@@ -599,7 +598,7 @@ export default class TextField extends BaseInput {
     const {lineHeight, ...typographyStyle} = typography;
     const textColor = this.getStateColor(color || this.extractColorValue());
     const hasRightElement = this.shouldDisplayRightButton() || rightIconSource;
-    const shouldUseMultiline = multiline; /*  || expandable */
+    const shouldUseMultiline = multiline/*  || expandable */;
 
     const inputStyle = [
       hasRightElement && this.styles.rightElement,
@@ -650,10 +649,8 @@ export default class TextField extends BaseInput {
 
       return (
         <TouchableOpacity
-          {...others}
-          accessibilityLabel={accessibilityLabel}
-          style={[this.styles.rightButton, this.getTopErrorsPosition(), style]}
-          onPress={this.onPressRightButton}
+          {...others} accessibilityLabel={accessibilityLabel}
+          style={[this.styles.rightButton, this.getTopErrorsPosition(), style]} onPress={this.onPressRightButton}
         >
           <Image
             pointerEvents="none"
@@ -672,11 +669,7 @@ export default class TextField extends BaseInput {
     if (rightIconSource) {
       return (
         <View style={[this.styles.rightButton, this.getTopErrorsPosition()]} pointerEvents="none">
-          <Image
-            source={rightIconSource}
-            resizeMode={'center'}
-            style={[this.styles.rightButtonImage, rightIconStyle]}
-          />
+          <Image source={rightIconSource} resizeMode={'center'} style={[this.styles.rightButtonImage, rightIconStyle]}/>
         </View>
       );
     }
@@ -761,10 +754,11 @@ export default class TextField extends BaseInput {
 }
 
 function createStyles({centered, multiline}, rightItemTopPadding = 0) {
-  const itemTopPadding = Constants.isIOS ? rightItemTopPadding - 3 : rightItemTopPadding - 1;
+  const itemTopPadding = Constants.isIOS ? (rightItemTopPadding - 3) : (rightItemTopPadding - 1);
 
   return StyleSheet.create({
-    container: {},
+    container: {
+    },
     innerContainer: {
       // flexGrow: 1, // create bugs with lineHeight
       flexDirection: 'row',

--- a/src/components/textField/index.tsx
+++ b/src/components/textField/index.tsx
@@ -8,7 +8,8 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {StyleSheet, Animated, TextInput as RNTextInput, Image as RNImage} from 'react-native';
+import {StyleSheet, Animated, TextInput as RNTextInput} from 'react-native';
+import {TextInputPropTypes, ImagePropTypes} from 'deprecated-react-native-prop-types';
 import memoize from 'memoize-one';
 import {Constants} from '../../commons/new';
 import {Colors, Typography, Spacings} from '../../style';
@@ -57,7 +58,7 @@ export default class TextField extends BaseInput {
   static displayName = 'TextField';
 
   static propTypes = {
-    ...RNTextInput.propTypes,
+    ...TextInputPropTypes,
     ...BaseInput.propTypes,
     /**
      * should placeholder have floating behavior
@@ -174,7 +175,7 @@ export default class TextField extends BaseInput {
      * Props for the right button {iconSource, onPress, style}
      */
     rightButtonProps: PropTypes.shape({
-      iconSource: RNImage.propTypes.source,
+      iconSource: ImagePropTypes.source,
       iconColor: PropTypes.string,
       onPress: PropTypes.func,
       style: PropTypes.oneOfType([PropTypes.object, PropTypes.number]),
@@ -183,7 +184,7 @@ export default class TextField extends BaseInput {
     /**
      * Pass to render a leading icon to the TextInput value. Accepts Image props (doesn't work with floatingPlaceholder)
      */
-    leadingIcon: PropTypes.shape(Image.propTypes)
+    leadingIcon: PropTypes.shape(ImagePropTypes)
   };
 
   static defaultProps = {
@@ -223,7 +224,7 @@ export default class TextField extends BaseInput {
     }
   }
 
-  onPlaceholderLayout = (event) => {
+  onPlaceholderLayout = event => {
     const {width} = event.nativeEvent.layout;
     const translate = width / 2 - (width * FLOATING_PLACEHOLDER_SCALE) / 2;
     this.setState({floatingPlaceholderTranslate: translate / FLOATING_PLACEHOLDER_SCALE});
@@ -259,10 +260,10 @@ export default class TextField extends BaseInput {
     };
   }
 
-  toggleExpandableModal = (value) => {
+  toggleExpandableModal = value => {
     this.setState({showExpandableModal: value});
     _.invoke(this.props, 'onToggleExpandableModal', value);
-  }
+  };
 
   updateFloatingPlaceholderState = withoutAnimation => {
     if (withoutAnimation) {
@@ -322,8 +323,8 @@ export default class TextField extends BaseInput {
 
   setCharCountColor(key) {
     this.maxReached = key === Constants.backspaceKey ? false : this.isCounterLimit();
-    const color = this.state.focused && this.maxReached ?
-      CHAR_COUNTER_COLOR_BY_STATE.error : CHAR_COUNTER_COLOR_BY_STATE.default;
+    const color =
+      this.state.focused && this.maxReached ? CHAR_COUNTER_COLOR_BY_STATE.error : CHAR_COUNTER_COLOR_BY_STATE.default;
 
     if (color !== this.state.charCountColor) {
       this.setState({charCountColor: color});
@@ -414,7 +415,8 @@ export default class TextField extends BaseInput {
   /** Renders */
   renderPlaceholder() {
     const {floatingPlaceholderState, floatingPlaceholderTranslate} = this.state;
-    const {placeholder, placeholderTextColor, floatingPlaceholderColor, floatingPlaceholderStyle} = this.getThemeProps();
+    const {placeholder, placeholderTextColor, floatingPlaceholderColor, floatingPlaceholderStyle} =
+      this.getThemeProps();
     const typography = this.getTypography();
     const placeholderColor = this.getStateColor(placeholderTextColor || PLACEHOLDER_COLOR_BY_STATE.default);
 
@@ -588,7 +590,7 @@ export default class TextField extends BaseInput {
       expandable,
       rightIconSource,
       color,
-      placeholder, 
+      placeholder,
       helperText,
       ...others
     } = this.getThemeProps();
@@ -597,7 +599,7 @@ export default class TextField extends BaseInput {
     const {lineHeight, ...typographyStyle} = typography;
     const textColor = this.getStateColor(color || this.extractColorValue());
     const hasRightElement = this.shouldDisplayRightButton() || rightIconSource;
-    const shouldUseMultiline = multiline/*  || expandable */;
+    const shouldUseMultiline = multiline; /*  || expandable */
 
     const inputStyle = [
       hasRightElement && this.styles.rightElement,
@@ -648,8 +650,10 @@ export default class TextField extends BaseInput {
 
       return (
         <TouchableOpacity
-          {...others} accessibilityLabel={accessibilityLabel}
-          style={[this.styles.rightButton, this.getTopErrorsPosition(), style]} onPress={this.onPressRightButton}
+          {...others}
+          accessibilityLabel={accessibilityLabel}
+          style={[this.styles.rightButton, this.getTopErrorsPosition(), style]}
+          onPress={this.onPressRightButton}
         >
           <Image
             pointerEvents="none"
@@ -668,7 +672,11 @@ export default class TextField extends BaseInput {
     if (rightIconSource) {
       return (
         <View style={[this.styles.rightButton, this.getTopErrorsPosition()]} pointerEvents="none">
-          <Image source={rightIconSource} resizeMode={'center'} style={[this.styles.rightButtonImage, rightIconStyle]}/>
+          <Image
+            source={rightIconSource}
+            resizeMode={'center'}
+            style={[this.styles.rightButtonImage, rightIconStyle]}
+          />
         </View>
       );
     }
@@ -753,11 +761,10 @@ export default class TextField extends BaseInput {
 }
 
 function createStyles({centered, multiline}, rightItemTopPadding = 0) {
-  const itemTopPadding = Constants.isIOS ? (rightItemTopPadding - 3) : (rightItemTopPadding - 1);
+  const itemTopPadding = Constants.isIOS ? rightItemTopPadding - 3 : rightItemTopPadding - 1;
 
   return StyleSheet.create({
-    container: {
-    },
+    container: {},
     innerContainer: {
       // flexGrow: 1, // create bugs with lineHeight
       flexDirection: 'row',

--- a/src/components/wheelPickerDialog/index.js
+++ b/src/components/wheelPickerDialog/index.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import {StyleSheet, TouchableOpacity, Text as RNText} from 'react-native';
+import {StyleSheet, TouchableOpacity} from 'react-native';
+import {TextPropTypes} from 'deprecated-react-native-prop-types';
 import Colors from '../../style/colors';
 import Typography from '../../style/typography';
 import View from '../view';
@@ -31,11 +32,11 @@ export default class WheelPickerDialog extends Component {
     /**
     * select label style
     */
-    selectLabelStyle: RNText.propTypes.style,
+    selectLabelStyle: TextPropTypes.style,
     /**
     * cancel label style
     */
-    cancelLabelStyle: RNText.propTypes.style,
+    cancelLabelStyle: TextPropTypes.style,
     /**
      * onCancel callback invoked when 'Cancel' button is pressed
      */


### PR DESCRIPTION
## Description

Since version 0.68 React Native started to warn that prop types will be removed from the core and in the latest 0.69 version (see [breaking change in the release notes](https://reactnative.dev/blog/2022/06/21/version-069#breaking-changes)) it happened. Which made ui-lib incompatible with latest RN.

In this PR I migrated all imports of prop types from RN to imports from `deprecated-react-native-prop-types`. This package doesn't provide typings and there seem to be no `@types/` version of it available, so I went with `// @ts-expect-error` for imports, let me know if you prefer some other alternative (writing proper custom types seemed to be quite a huge effort).

And I fixed 2 typos in markdown files.

resolves #2126 
resolves #2094 

## Changelog

* Migrate PropTypes imports to `deprecated-react-native-prop-types` package.
