### PR TITLE
bundle's entry file names `demo.js` not `index.js`

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -4,7 +4,7 @@ import com.android.build.OutputFile
 import org.apache.tools.ant.taskdefs.condition.Os
 
 project.ext.react = [
-    entryFile: "index.js",
+    entryFile: "demo.js",
     enableHermes: true,  // clean and rebuild if changing
 ]
 


### PR DESCRIPTION
```diff
project.ext.react = [
+    bundleInDebug: true,
-     entryFile: "index.js",
+    entryFile: "demo.js",
    enableHermes: true,  // clean and rebuild if changing
]
```

## Description

when open `bundleInDebug: true`, the demo's packager can't found the bundle that names `index.js.bundle` because it names `demo.js.bundle`
