### PR TITLE
Avoid redundant setState in TouchableOpacity

### DIFF
--- a/src/components/touchableOpacity/index.tsx
+++ b/src/components/touchableOpacity/index.tsx
@@ -78,13 +78,17 @@ class TouchableOpacity extends PureComponent<Props, {active: boolean}> {
   }
 
   onPressIn = (...args: any) => {
-    this.setState({active: true});
+    if (this.props.activeBackgroundColor) {
+      this.setState({active: true});
+    }
     //@ts-expect-error
     this.props.onPressIn?.(...args);
   };
 
   onPressOut = (...args: any) => {
-    this.setState({active: false});
+    if (this.props.activeBackgroundColor) {
+      this.setState({active: false});
+    }
     //@ts-expect-error
     this.props.onPressOut?.(...args);
   };


### PR DESCRIPTION
## Description
Avoid redundant setState in TouchableOpacity. 
We currently call setState to keep an "active" state for the color logic of activeBackgroundColor. 
I added a condition on this setState 

## Changelog
Avoid redundant setState in TouchableOpacity. 