### PR TITLE
Fix/ ColorPalette scrolling and extra renders 

### DIFF
--- a/src/components/colorPalette/index.tsx
+++ b/src/components/colorPalette/index.tsx
@@ -115,18 +115,14 @@ class ColorPalette extends PureComponent<Props, State> {
     _.times(this.props.colors.length, i => {
       this.itemsRefs.current[i] = React.createRef();
     });
-    setTimeout(() => {
-      this.scrollToSelected();
-    }, 100);
+    this.scrollToSelected();
   }
 
   componentDidUpdate(prevProps: Props) {
     if (this.props.colors !== prevProps.colors) {
       const newIndex = this.itemsRefs.current.length;
       this.itemsRefs.current[newIndex] = React.createRef();
-      setTimeout(() => {
-        this.scrollToSelected();
-      }, 100);
+      this.scrollToSelected();
     }
   }
 
@@ -223,10 +219,12 @@ class ColorPalette extends PureComponent<Props, State> {
     return (margin - 0.001) / 2;
   }
 
-  scrollToSelected() {
+  scrollToSelected = () => setTimeout(() => {
     const {scrollable, currentPage} = this.state;
 
     if (scrollable && this.selectedColorIndex !== undefined && this.itemsRefs.current) {
+      // The this.selectedColorIndex layout doesn't update on time
+      // so we use this.selectedColorIndex - 1 and add an offset of 1 Swatch
       const childRef: any = this.itemsRefs.current[this.selectedColorIndex - 1]?.current;
 
       if (childRef) {
@@ -244,7 +242,7 @@ class ColorPalette extends PureComponent<Props, State> {
         this.carousel?.current?.goToPage(this.selectedPage || currentPage, false);
       }
     }
-  }
+  }, 100)
 
   onContentSizeChange = (contentWidth: number) => {
     this.setState({

--- a/src/components/colorPalette/index.tsx
+++ b/src/components/colorPalette/index.tsx
@@ -8,7 +8,7 @@ import View from '../view';
 import Carousel from '../carousel';
 import ScrollBar from '../scrollBar';
 import PageControl from '../pageControl';
-import ColorSwatch, {SWATCH_SIZE} from '../colorSwatch';
+import ColorSwatch, {SWATCH_SIZE, SWATCH_MARGIN} from '../colorSwatch';
 
 interface Props {
   /**
@@ -115,6 +115,19 @@ class ColorPalette extends PureComponent<Props, State> {
     _.times(this.props.colors.length, i => {
       this.itemsRefs.current[i] = React.createRef();
     });
+    setTimeout(() => {
+      this.scrollToSelected();
+    }, 100);
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (this.props.colors !== prevProps.colors) {
+      const newIndex = this.itemsRefs.current.length;
+      this.itemsRefs.current[newIndex] = React.createRef();
+      setTimeout(() => {
+        this.scrollToSelected();
+      }, 100);
+    }
   }
 
   componentWillUnmount() {
@@ -214,13 +227,15 @@ class ColorPalette extends PureComponent<Props, State> {
     const {scrollable, currentPage} = this.state;
 
     if (scrollable && this.selectedColorIndex !== undefined && this.itemsRefs.current) {
-      const childRef: any = this.itemsRefs.current[this.selectedColorIndex].current;
+      const childRef: any = this.itemsRefs.current[this.selectedColorIndex - 1]?.current;
 
       if (childRef) {
         const childLayout = childRef.getLayout();
-        if (childLayout.x + childLayout.width > this.containerWidth) {
+        const leftMargins = this.getHorizontalMargins(this.selectedColorIndex).marginLeft;
+        const childX = childLayout.x + childLayout.width + SWATCH_MARGIN + leftMargins + SWATCH_SIZE;
+        if (childX > this.containerWidth) {
           this.scrollBar?.current?.scrollTo({
-            x: childLayout.x + childLayout.width + HORIZONTAL_PADDING - this.containerWidth,
+            x: childX + HORIZONTAL_PADDING - this.containerWidth,
             y: 0,
             animated: false
           });
@@ -244,12 +259,6 @@ class ColorPalette extends PureComponent<Props, State> {
 
   onValueChange = (value: string, options: object) => {
     this.props.onValueChange?.(value, options);
-  };
-
-  onLayout = () => {
-    setTimeout(() => {
-      this.scrollToSelected();
-    }, 0);
   };
 
   getHorizontalMargins = (index: number) => {
@@ -311,7 +320,7 @@ class ColorPalette extends PureComponent<Props, State> {
     const {style, ...others} = props;
 
     return (
-      <View key={pageIndex} {...others} style={[styles.paletteContainer, contentStyle, style]} onLayout={this.onLayout}>
+      <View key={pageIndex} {...others} style={[styles.paletteContainer, contentStyle, style]}>
         {_.map(colors, (color, i) => {
           if (color === this.value) {
             this.selectedColorIndex = i;


### PR DESCRIPTION
## Description
The issues:
1. ColorPalette renders all the swatches on every swatch selection because it creates new refs every time.
2. The scrolling to the selected Swatch doesn't work (both for existing palettes with many colors and for the added color in a ColorPicker)
This PR fixes the two issues.
I used a hack for the scrolling - the offset of the last added color is bad (always 10) , so I calculate the one before the last and add the extra offset.
Let me know I you have any ideas (setTimeout doesn't fix anything),

## Changelog
Fix ColorPalette scrolling and extra renders 