### PR TITLE
Fix range slider initial values

### DIFF
--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -65,7 +65,7 @@ Icon.displayName = 'Icon';
 Icon.defaultProps = {
   assetGroup: 'icons'
 };
-export default asBaseComponent<IconProps, typeof Icon>(Icon);
+export default asBaseComponent<IconProps, typeof Icon>(Icon, {modifiersOptions: {margins: true}});
 
 const styles = StyleSheet.create({
   rtlFlipped: {

--- a/src/components/slider/index.tsx
+++ b/src/components/slider/index.tsx
@@ -37,11 +37,19 @@ export type SliderProps = Omit<ThumbProps, 'ref'> & {
    */
   value?: number;
   /**
-   * Minimum value
+   * Initial minimum value (when using range slider)
+   */
+  initialMinimumValue?: number;
+  /**
+   * Initial maximum value (when using range slider)
+   */
+  initialMaximumValue?: number;
+   /**
+   * Track minimum value
    */
   minimumValue?: number;
   /**
-   * Maximum value
+   * Track maximum value
    */
   maximumValue?: number;
   /**
@@ -127,6 +135,8 @@ type MeasuredVariableName = 'containerSize' | 'trackSize' | 'thumbSize';
 
 const defaultProps = {
   value: 0,
+  initialMinimumValue: 0,
+  initialMaximumValue: 1,
   minimumValue: 0,
   maximumValue: 1,
   step: 0,
@@ -155,8 +165,9 @@ export default class Slider extends PureComponent<SliderProps, State> {
   private _x_min = 0;
   private lastDx = 0;
 
-  private initialValue = this.getRoundedValue(this.props.useRange ? this.props.maximumValue : this.props.value);
-  private minInitialValue = this.getRoundedValue(this.props.minimumValue);
+  private initialValue = this.getRoundedValue(this.props.useRange ? this.props.initialMaximumValue : this.props.value);
+  private minInitialValue = this.getRoundedValue(this.props.initialMinimumValue);
+
   private lastValue = this.initialValue;
   private lastMinValue = this.minInitialValue;
 

--- a/src/components/slider/index.tsx
+++ b/src/components/slider/index.tsx
@@ -334,7 +334,7 @@ export default class Slider extends PureComponent<SliderProps, State> {
     if (this.isDefaultThumbActive()) {
       if (this.thumb.current) {
         const {useRange} = this.props;
-        const {trackSize, thumbSize} = this.state;
+        const {trackSize} = this.state;
         const nonOverlappingTrackWidth = trackSize.width - this.initialThumbSize.width;
         const _x = this.shouldForceLTR ? trackSize.width - x : x; // adjust for RTL
         const left = trackSize.width === 0 ? _x : (_x * nonOverlappingTrackWidth) / trackSize.width; // do not render above prefix\suffix icon\text
@@ -363,7 +363,7 @@ export default class Slider extends PureComponent<SliderProps, State> {
   }
 
   moveMinTo(x: number) {
-    const {trackSize, thumbSize} = this.state;
+    const {trackSize} = this.state;
 
     if (this.minThumb.current) {
       const nonOverlappingTrackWidth = trackSize.width - this.initialThumbSize.width;
@@ -678,7 +678,7 @@ export default class Slider extends PureComponent<SliderProps, State> {
       >
         {this.renderTrack()}
         <View style={styles.touchArea} onTouchEnd={this.handleTrackPress}/>
-        <View style={[!this.isDefaultThumbActive() ? {zIndex: 1}: {zIndex: 0}, {top: '-50%'}]}>
+        <View style={[!this.isDefaultThumbActive() ? {zIndex: 1} : {zIndex: 0}, {top: '-50%'}]}>
           {useRange && this.renderMinThumb()}
         </View>
         {this.renderThumb()}

--- a/src/components/slider/index.tsx
+++ b/src/components/slider/index.tsx
@@ -1,23 +1,24 @@
-import _ from 'lodash';
-import React, {PureComponent, ReactElement} from 'react';
 import {
-  StyleSheet,
-  PanResponder,
+  AccessibilityActionEvent,
   AccessibilityInfo,
+  AccessibilityRole,
   Animated,
-  StyleProp,
-  ViewStyle,
-  PanResponderGestureState,
   GestureResponderEvent,
   LayoutChangeEvent,
-  AccessibilityActionEvent,
-  AccessibilityRole,
-  View as RNView
+  PanResponder,
+  PanResponderGestureState,
+  View as RNView,
+  StyleProp,
+  StyleSheet,
+  ViewStyle
 } from 'react-native';
-import {Constants} from '../../commons/new';
-import {Colors} from '../../style';
-import View from '../view';
+import React, {PureComponent, ReactElement} from 'react';
 import Thumb, {ThumbProps} from './Thumb';
+
+import {Colors} from '../../style';
+import {Constants} from '../../commons/new';
+import View from '../view';
+import _ from 'lodash';
 import {extractAccessibilityProps} from '../../commons/modifiers';
 
 const TRACK_SIZE = 6;
@@ -26,7 +27,6 @@ const SHADOW_RADIUS = 4;
 const DEFAULT_COLOR = Colors.$backgroundDisabled;
 const ACTIVE_COLOR = Colors.$backgroundPrimaryHeavy;
 const INACTIVE_COLOR = Colors.$backgroundNeutralMedium;
-const MIN_RANGE_GAP = 4;
 
 export type SliderOnValueChange = (value: number) => void;
 export type SliderOnRangeChange = (values: {min: number, max: number}) => void;
@@ -161,7 +161,7 @@ export default class Slider extends PureComponent<SliderProps, State> {
   private lastMinValue = this.minInitialValue;
 
   private _thumbStyles: ThumbStyle = {};
-  private _minThumbStyles: ThumbStyle = {left: this.minInitialValue};
+  private _minThumbStyles: ThumbStyle = {left: 0};
 
   private initialThumbSize: Measurements = {width: THUMB_SIZE, height: THUMB_SIZE};
   private containerSize: Measurements | undefined;
@@ -341,7 +341,7 @@ export default class Slider extends PureComponent<SliderProps, State> {
         
         if (useRange) {
           const minThumbPosition = this._minThumbStyles?.left as number;
-          if (left > minThumbPosition + thumbSize.width + MIN_RANGE_GAP) {
+          if (left >= minThumbPosition) {
             this._thumbStyles.left = left;
             
             const width = left - minThumbPosition;
@@ -371,7 +371,7 @@ export default class Slider extends PureComponent<SliderProps, State> {
       const left = trackSize.width === 0 ? _x : (_x * nonOverlappingTrackWidth) / trackSize.width; // do not render above prefix\suffix icon\text
       
       const maxThumbPosition = this._thumbStyles?.left as number;
-      if (left < maxThumbPosition - thumbSize.width - MIN_RANGE_GAP) {
+      if (left <= maxThumbPosition) {
         this._minThumbStyles.left = left;
         
         this._minTrackStyles.width = maxThumbPosition - x;
@@ -678,7 +678,9 @@ export default class Slider extends PureComponent<SliderProps, State> {
       >
         {this.renderTrack()}
         <View style={styles.touchArea} onTouchEnd={this.handleTrackPress}/>
-        {useRange && this.renderMinThumb()}
+        <View style={[!this.isDefaultThumbActive() ? {zIndex: 1}: {zIndex: 0}, {top: '-50%'}]}>
+          {useRange && this.renderMinThumb()}
+        </View>
         {this.renderThumb()}
       </View>
     );


### PR DESCRIPTION
## Description
Fixes range slider to allow initial min and max thumb positions. The prior implementation always sets the initial thumb positions to the track min and max values which is typically not the same as the values selected by the user. This change allows the range slider to be reconstructed from values set in a previous session.

## Changelog
Fix range slider to allow initial min and max thumb positions to be set on component mount.
