### PR TITLE
Fix range slider initial values

### DIFF
--- a/src/components/slider/index.tsx
+++ b/src/components/slider/index.tsx
@@ -1,23 +1,24 @@
-import _ from 'lodash';
-import React, {PureComponent, ReactElement} from 'react';
 import {
-  StyleSheet,
-  PanResponder,
+  AccessibilityActionEvent,
   AccessibilityInfo,
+  AccessibilityRole,
   Animated,
-  StyleProp,
-  ViewStyle,
-  PanResponderGestureState,
   GestureResponderEvent,
   LayoutChangeEvent,
-  AccessibilityActionEvent,
-  AccessibilityRole,
-  View as RNView
+  PanResponder,
+  PanResponderGestureState,
+  View as RNView,
+  StyleProp,
+  StyleSheet,
+  ViewStyle
 } from 'react-native';
-import {Constants} from '../../commons/new';
-import {Colors} from '../../style';
-import View from '../view';
+import React, {PureComponent, ReactElement} from 'react';
 import Thumb, {ThumbProps} from './Thumb';
+
+import {Colors} from '../../style';
+import {Constants} from '../../commons/new';
+import View from '../view';
+import _ from 'lodash';
 import {extractAccessibilityProps} from '../../commons/modifiers';
 
 const TRACK_SIZE = 6;
@@ -37,14 +38,22 @@ export type SliderProps = Omit<ThumbProps, 'ref'> & {
    */
   value?: number;
   /**
-   * Minimum value
+   * Initial minimum value (when using range slider)
    */
+  initialMinimumValue?: number;
+   /**
+    * Initial maximum value (when using range slider)
+    */
+  initialMaximumValue?: number;
+    /**
+    * Track minimum value
+    */
   minimumValue?: number;
-  /**
-   * Maximum value
-   */
+   /**
+    * Track maximum value
+    */
   maximumValue?: number;
-  /**
+   /**
    * Step value of the slider. The value should be between 0 and (maximumValue - minimumValue)
    */
   step?: number;
@@ -127,6 +136,8 @@ type MeasuredVariableName = 'containerSize' | 'trackSize' | 'thumbSize';
 
 const defaultProps = {
   value: 0,
+  initialMinimumValue: 0,
+  initialMaximumValue: 1,
   minimumValue: 0,
   maximumValue: 1,
   step: 0,
@@ -155,8 +166,8 @@ export default class Slider extends PureComponent<SliderProps, State> {
   private _x_min = 0;
   private lastDx = 0;
 
-  private initialValue = this.getRoundedValue(this.props.useRange ? this.props.maximumValue : this.props.value);
-  private minInitialValue = this.getRoundedValue(this.props.minimumValue);
+  private initialValue = this.getRoundedValue(this.props.useRange ? this.props.initialMaximumValue : this.props.value);
+  private minInitialValue = this.getRoundedValue(this.props.initialMinimumValue);
   private lastValue = this.initialValue;
   private lastMinValue = this.minInitialValue;
 


### PR DESCRIPTION
## Description
Fixes range slider to allow initial min and max thumb positions. The prior implementation always sets the initial thumb positions to the track min and max values which is typically not the same as the values selected by the user. This change allows the range slider to be reconstructed from values set in a previous session.

## Changelog
Fix range slider to allow initial min and max thumb positions to be set on component mount.