### PR TITLE
Fix initial animation state of TextField floating placeholder

### DIFF
--- a/src/incubator/TextField/FloatingPlaceholder.tsx
+++ b/src/incubator/TextField/FloatingPlaceholder.tsx
@@ -1,5 +1,6 @@
-import React, {useContext, useEffect, useRef, useCallback, useState, useMemo} from 'react';
+import React, {useContext, useRef, useCallback, useState, useMemo} from 'react';
 import {Animated, LayoutChangeEvent, StyleSheet, Platform} from 'react-native';
+import {useDidUpdate} from 'hooks';
 import {FloatingPlaceholderProps, ValidationMessagePosition} from './types';
 import {getColorByState} from './Presenter';
 import {Colors} from '../../style';
@@ -24,10 +25,10 @@ const FloatingPlaceholder = ({
     top: 0,
     left: 0
   });
-  const animation = useRef(new Animated.Value(Number(context.isFocused))).current;
+  const animation = useRef(new Animated.Value(Number((floatOnFocus && context.isFocused) || context.hasValue))).current;
   const hidePlaceholder = !context.isValid && validationMessagePosition === ValidationMessagePosition.TOP;
 
-  useEffect(() => {
+  useDidUpdate(() => {
     const toValue = floatOnFocus ? context.isFocused || context.hasValue : context.hasValue;
     Animated.timing(animation, {
       toValue: Number(toValue),


### PR DESCRIPTION
## Description
Fix initial animation state of TextField floating placeholder
When passing to TextField a value and enabling `floatingPlaceholder` you will see a bug where the placeholder animate on mount. 
This PR fix this issue by initializing the floating placeholder correctly. 

WOAUILIB-2905

## Changelog
Fix initial animation state of TextField floating placeholder