### PR TITLE
Fix typing issue for standalone components

### DIFF
--- a/scripts/buildPackages.js
+++ b/scripts/buildPackages.js
@@ -71,7 +71,7 @@ packages.forEach((package) => {
     });
     content += '};\n';
     typings += '}';
-    typings = `import ${typings} from './generatedTypes';\nexport ${typings};\n`;
+    typings = `import ${typings} from './src';\nexport ${typings};\n`;
   }
 
   fs.writeFileSync(package.filename, content);
@@ -92,7 +92,7 @@ fs.readdir(path, (err, files) => {
           `module.exports = require('${path}/${file}').default;\n`);
         const componentName = _.upperFirst(file);
         fs.writeFileSync(`${file}.d.ts`,
-          `import {${componentName}} from './generatedTypes';\nexport default ${componentName};\n`);
+          `import {${componentName}} from './src';\nexport default ${componentName};\n`);
       });
   }
 });


### PR DESCRIPTION
## Description
Typescript `.d.ts` files are no longer generated in the `generatedTypes` directory, but are generated alongside the source files since #1927 was merged.
This resulted in standalone components not being typed properly as the types it is attempting to import no longer exists.
This PR changes the import directory for the generated `.d.ts` files for standalone components to `./src` to fix this issue.

Tested the changes by running `yarn build` and ensuring the generated `.d.ts` files for standalone components now actually resolve correctly.


## Changelog
Fix typing issue for standalone components