### PR TITLE
Fix Picker setComponentTheme

### DIFF
--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -311,6 +311,7 @@ Picker.defaultProps = {
   ...TextField.defaultProps,
   mode: PickerModes.SINGLE
 };
+Picker.displayName = 'Picker';
 Picker.modes = PickerModes;
 Picker.fieldTypes = PickerFieldTypes;
 Picker.extractPickerItems = (props: PropsWithChildren<PickerProps>) => {


### PR DESCRIPTION
## Description
Picker - fix setComponentTheme support by adding displayName to the Picker component 
Fixes https://github.com/wix/react-native-ui-lib/issues/2167 

## Changelog
Picker - fix setComponentTheme support