### PR TITLE
Fetch stars count from repo

### DIFF
--- a/docuilib/package.json
+++ b/docuilib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uilib-docs",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",

--- a/docuilib/package.json
+++ b/docuilib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uilib-docs",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",

--- a/docuilib/src/components/MainSection.tsx
+++ b/docuilib/src/components/MainSection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
@@ -6,9 +6,26 @@ import styles from './MainSection.module.scss';
 import mainCover from '@site/static/img/mainCover.jpg';
 import GoldStarSvg from '@site/static/img/goldStar.svg';
 
+const STARS_COUNT_KEY = 'starsCount';
+
 export default () => {
   const {siteConfig} = useDocusaurusContext();
   const {expoSnackLink, docsMainEntry} = siteConfig.customFields;
+  const [starsCount, setStarsCount] = useState(localStorage.getItem(STARS_COUNT_KEY) ?? siteConfig.customFields.stars);
+
+  useEffect(() => {
+    fetchStarsCount();
+  }, []);
+
+  const fetchStarsCount = async () => {
+    const response = await fetch('https://api.github.com/repos/wix/react-native-ui-lib');
+    const data = await response.json();
+    const _starsCount = (data.stargazers_count / 1000).toFixed(1);
+
+
+    localStorage.setItem(STARS_COUNT_KEY, _starsCount.toString());
+    setStarsCount(_starsCount);
+  };
 
   return (
     <div className={styles.main}>
@@ -19,7 +36,7 @@ export default () => {
         </p>
         <div className={styles.gitStars}>
           <GoldStarSvg width={16} height={16} style={{margin: 4}}/>
-          <span>{siteConfig.customFields.stars}k</span>
+          <span>{starsCount}k</span>
         </div>
 
         <div className={styles.buttons}>

--- a/docuilib/src/pages/index.tsx
+++ b/docuilib/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Layout from '@theme/Layout';
+import BrowserOnly from '@docusaurus/BrowserOnly';
 // import clsx from 'clsx';
 // import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 // import HomepageFeatures from '../components/HomepageFeatures';
@@ -15,16 +16,17 @@ export default function Home(): JSX.Element {
   // const {siteConfig} = useDocusaurusContext();
   return (
     <>
-      <StandWithUkraine />
+      <StandWithUkraine/>
       <Layout
         /* title={`Hello from ${siteConfig.title}`} */ description="Description will go into a meta tag in <head />"
       >
         <main>
-          <MainSection />
-          <ComponentsSection />
-          <FeaturesSection />
-          <CodeSection />
-          <LibrariesSection />
+          {/* Note: BrowserOnly allows using `localStorage` in MainSection, otherwise docusaurus build fail */}
+          <BrowserOnly>{() => <MainSection/>}</BrowserOnly>
+          <ComponentsSection/>
+          <FeaturesSection/>
+          <CodeSection/>
+          <LibrariesSection/>
         </main>
       </Layout>
     </>


### PR DESCRIPTION
## Description
We set our stars count in our docs manually (through the docs config)
I changed it to fetch stars count from repo info

## Changelog
Docs - get stars count from github repo info