### PR TITLE
Fix missing useCustomTheme type in Picker

### DIFF
--- a/src/components/picker/types.tsx
+++ b/src/components/picker/types.tsx
@@ -48,7 +48,7 @@ export interface PickerSearchStyle {
 
 // TODO: need to extend TextField props (and not just TextInputProps)
 export type PickerBaseProps = Omit<TextFieldProps, 'value' | 'onChange'> &
-  Omit<NewTextFieldProps, 'value' | 'onChange'> & {
+  Omit<NewTextFieldProps, 'value' | 'onChange'> & ThemeComponent & {
     /* ...TextField.propTypes, */
     /**
      * Temporary prop required for migration to Picker's new API


### PR DESCRIPTION
## Description
Fix missing useCustomTheme type in Picker after Picker refactor (removing asBaseComponent)

## Changelog
N/A