### PR TITLE
Fix selected card iconColor

### DIFF
--- a/src/components/card/index.tsx
+++ b/src/components/card/index.tsx
@@ -231,8 +231,8 @@ class Card extends PureComponent<PropTypes, State> {
         {!selectionOptions.hideIndicator && (
           <View style={[this.styles.selectedIndicator, {backgroundColor: selectionColor}]}>
             <Icon
-              style={this.styles.selectedIcon}
               source={_.get(selectionOptions, 'icon', DEFAULT_SELECTION_PROPS.icon)}
+              tintColor={_.get(selectionOptions, 'iconColor', DEFAULT_SELECTION_PROPS.iconColor)}
             />
           </View>
         )}
@@ -333,9 +333,6 @@ function createStyles({width, height, borderRadius, selectionOptions}: CardProps
       backgroundColor: selectionOptionsWithDefaults.color,
       alignItems: 'center',
       justifyContent: 'center'
-    },
-    selectedIcon: {
-      tintColor: selectionOptionsWithDefaults.iconColor
     }
   });
 }

--- a/src/components/card/index.tsx
+++ b/src/components/card/index.tsx
@@ -212,7 +212,7 @@ class Card extends PureComponent<PropTypes, State> {
   renderSelection() {
     const {selectionOptions = {}, selected} = this.props;
     const {animatedSelected} = this.state;
-    const selectionColor = _.get(selectionOptions, 'color', DEFAULT_SELECTION_PROPS.color);
+    const selectionColor = selectionOptions?.color || DEFAULT_SELECTION_PROPS.color;
 
     if (_.isUndefined(selected)) {
       return null;
@@ -231,8 +231,8 @@ class Card extends PureComponent<PropTypes, State> {
         {!selectionOptions.hideIndicator && (
           <View style={[this.styles.selectedIndicator, {backgroundColor: selectionColor}]}>
             <Icon
-              source={_.get(selectionOptions, 'icon', DEFAULT_SELECTION_PROPS.icon)}
-              tintColor={_.get(selectionOptions, 'iconColor', DEFAULT_SELECTION_PROPS.iconColor)}
+              source={selectionOptions?.icon || DEFAULT_SELECTION_PROPS.icon}
+              tintColor={selectionOptions?.iconColor || DEFAULT_SELECTION_PROPS.iconColor}
             />
           </View>
         )}


### PR DESCRIPTION
## Description
Fix selected card iconColor (set tintColor to ignore the default coloring of the private Icon config)
to test it you should run private on the `darkMode` branch
WOAUILIB-3064

## Changelog
Fix selected card iconColor