### PR TITLE
fix typo

### DIFF
--- a/src/incubator/TextField/textField.api.json
+++ b/src/incubator/TextField/textField.api.json
@@ -96,7 +96,7 @@
   ],
   "snippet": [
     "<TextField",
-    "  placeholder={'Placeholder$1}",
+    "  placeholder={'Placeholder'$1}",
     "  floatingPlaceholder",
     "  onChangeText={() => console.log('changed')$2}",
     "  enableErrors",


### PR DESCRIPTION
## Fix Typo in docs
https://github.com/wix/react-native-ui-lib/blob/684a39f5f59f19ba0c2050eb04aabb11a3933f83/src/incubator/TextField/textField.api.json#L99
```js
placeholder={'Placeholder'$1}
```
