### PR TITLE
Add key prop to Wheel Picker Item

### DIFF
--- a/src/incubator/WheelPicker/Item.tsx
+++ b/src/incubator/WheelPicker/Item.tsx
@@ -34,7 +34,6 @@ interface InternalProps extends ItemProps {
 
 const WheelPickerItem = memo(({
   index,
-  key,
   label,
   fakeLabel,
   fakeLabelStyle,
@@ -69,7 +68,7 @@ const WheelPickerItem = memo(({
     <AnimatedTouchableOpacity
       activeOpacity={1}
       style={containerStyle}
-      key={key ?? index}
+      key={index}
       centerV
       centerH={align ? align === WheelPickerAlign.CENTER : centerH}
       right={align ? align === WheelPickerAlign.RIGHT : !centerH}

--- a/src/incubator/WheelPicker/Item.tsx
+++ b/src/incubator/WheelPicker/Item.tsx
@@ -13,6 +13,7 @@ const AnimatedText = Animated.createAnimatedComponent(Text);
 export interface ItemProps {
   label: string;
   value: string | number;
+  key?: string;
   align?: WheelPickerAlign;
 }
 
@@ -33,6 +34,7 @@ interface InternalProps extends ItemProps {
 
 const WheelPickerItem = memo(({
   index,
+  key,
   label,
   fakeLabel,
   fakeLabelStyle,
@@ -67,7 +69,7 @@ const WheelPickerItem = memo(({
     <AnimatedTouchableOpacity
       activeOpacity={1}
       style={containerStyle}
-      key={index}
+      key={key ?? index}
       centerV
       centerH={align ? align === WheelPickerAlign.CENTER : centerH}
       right={align ? align === WheelPickerAlign.RIGHT : !centerH}

--- a/src/incubator/WheelPicker/index.tsx
+++ b/src/incubator/WheelPicker/index.tsx
@@ -125,7 +125,7 @@ const WheelPicker = ({
   const prevInitialValue = useRef(initialValue);
   const prevIndex = useRef(currentIndex);
   const [flatListWidth, setFlatListWidth] = useState(0);
-  const keyExtractor = useCallback((item: ItemProps, index: number) => `${item}.${index}`, []);
+  const keyExtractor = useCallback((item: ItemProps, index: number) => item.key ?? `${item}.${index}`, []);
 
   useEffect(() => {
     // This effect making sure to reset index if initialValue has changed


### PR DESCRIPTION
## Description
* When trying to replace all items of `SectionsWheelPicker` it calculates row differences wrongly because index is used as a key

## Changelog
* Added key prop to wheel picker item
