### PR TITLE
Feat/incubator dialog more props and fixes

### DIFF
--- a/demo/src/screens/componentScreens/ActionSheetScreen.tsx
+++ b/demo/src/screens/componentScreens/ActionSheetScreen.tsx
@@ -64,6 +64,7 @@ export default class ActionSheetScreen extends Component {
           cancelButtonIndex={3}
           destructiveButtonIndex={0}
           useNativeIOS={false}
+          migrateDialog
           options={[
             {label: 'option 1', onPress: () => this.pickOption('option 1')},
             {label: 'option 2', onPress: () => this.pickOption('option 2')},
@@ -79,6 +80,7 @@ export default class ActionSheetScreen extends Component {
           message={'Message of action sheet'}
           cancelButtonIndex={3}
           destructiveButtonIndex={0}
+          migrateDialog
           options={[
             {label: 'option 1', onPress: () => this.pickOption('option 1'), iconSource: collectionsIcon},
             {label: 'option 2', onPress: () => this.pickOption('option 2'), iconSource: shareIcon},

--- a/demo/src/screens/componentScreens/ChipScreen.tsx
+++ b/demo/src/screens/componentScreens/ChipScreen.tsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React, {Component} from 'react';
 import {Alert} from 'react-native';
-import {Chip, Colors, Spacings, Text, Typography, View, Dialog, WheelPickerDialog, Image} from 'react-native-ui-lib';
+import {Chip, Colors, Spacings, Text, Typography, View, Incubator, WheelPickerDialog, Image} from 'react-native-ui-lib';
 
 const avatarImage = {
   uri: 'https://randomuser.me/api/portraits/women/24.jpg'
@@ -72,9 +72,9 @@ export default class ChipScreen extends Component {
     const {showDialog} = this.state;
 
     return (
-      <Dialog visible={showDialog} useSafeArea bottom onDismiss={this.closeDialog}>
+      <Incubator.Dialog visible={showDialog} useSafeArea bottom onDismiss={this.closeDialog}>
         {this.renderContent()}
-      </Dialog>
+      </Incubator.Dialog>
     );
   };
 
@@ -90,7 +90,7 @@ export default class ChipScreen extends Component {
   render() {
     return (
       <View style={{padding: 20}}>
-        {this.state.showDialog && this.renderPickerDialog()}
+        {this.renderPickerDialog()}
         <Text marginB-20 text40 $textDefault>
           Chip
         </Text>

--- a/demo/src/screens/componentScreens/PickerScreen.tsx
+++ b/demo/src/screens/componentScreens/PickerScreen.tsx
@@ -1,11 +1,11 @@
 import _ from 'lodash';
 import React, {Component} from 'react';
-import {ScrollView} from 'react-native';
+import {ScrollView} from 'react-native-gesture-handler';
 import {
   View,
   Colors,
   Icon,
-  Dialog,
+  Incubator,
   Text,
   Picker,
   Avatar,
@@ -14,7 +14,6 @@ import {
   Typography,
   PickerProps,
   PickerMethods,
-  DialogProps,
   Button
 } from 'react-native-ui-lib'; //eslint-disable-line
 import contactsData from '../../data/conversations';
@@ -61,20 +60,11 @@ export default class PickerScreen extends Component {
     contact: 0
   };
 
-  dialogHeader: DialogProps['renderPannableHeader'] = props => {
-    const {title} = props;
-    return (
-      <Text margin-15 text60 $textDefault>
-        {title}
-      </Text>
-    );
-  };
-
   renderDialog: PickerProps['renderCustomModal'] = modalProps => {
     const {visible, children, toggleModal, onDone} = modalProps;
 
     return (
-      <Dialog
+      <Incubator.Dialog
         visible={visible}
         onDismiss={() => {
           onDone();
@@ -85,12 +75,11 @@ export default class PickerScreen extends Component {
         bottom
         useSafeArea
         containerStyle={{backgroundColor: Colors.$backgroundDefault}}
-        renderPannableHeader={this.dialogHeader}
-        panDirection={PanningProvider.Directions.DOWN}
-        pannableHeaderProps={{title: 'Custom modal'}}
+        direction={PanningProvider.Directions.DOWN}
+        headerProps={{title: 'Custom modal'}}
       >
         <ScrollView>{children}</ScrollView>
-      </Dialog>
+      </Incubator.Dialog>
     );
   };
 

--- a/demo/src/screens/incubatorScreens/WheelPickerScreen.tsx
+++ b/demo/src/screens/incubatorScreens/WheelPickerScreen.tsx
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import React, {useCallback, useState} from 'react';
-import {View, Text, Incubator, Colors, Typography, Button, Dialog} from 'react-native-ui-lib';
+import {View, Text, Incubator, Colors, Typography, Button} from 'react-native-ui-lib';
 
 const monthItems = _.map([
   'January',
@@ -88,9 +88,15 @@ export default () => {
       <View center marginT-40>
         <Text h3 marginB-20>Days</Text>
         <Button size="small" label={'Pick Days'} onPress={onPickDaysPress}/>
-        <Dialog width={'90%'} height={260} bottom visible={showDialog} onDismiss={onDialogDismissed}>
+        <Incubator.Dialog
+          width={'90%'}
+          bottom
+          visible={showDialog}
+          onDismiss={onDialogDismissed}
+          headerProps={{showKnob: false, showDivider: false}}
+        >
           <Incubator.WheelPicker initialValue={5} label={'Days'} items={dayItems}/>
-        </Dialog>
+        </Incubator.Dialog>
       </View>
     </View>
   );

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -16,7 +16,11 @@ jest.mock('react-native-reanimated', () => {
   return reactNativeReanimated;
 });
 global.__reanimatedWorkletInit = jest.fn();
-jest.mock('react-native-gesture-handler', () => {});
+jest.mock('react-native-gesture-handler',
+  () => ({
+    FlatList: require('react-native').FlatList
+  }),
+  {virtual: true});
 jest.mock('@react-native-picker/picker', () => ({Picker: {Item: {}}}));
 jest.mock('react-native', () => {
   const reactNative = jest.requireActual('react-native');

--- a/src/components/actionSheet/index.tsx
+++ b/src/components/actionSheet/index.tsx
@@ -82,6 +82,7 @@ type ActionSheetProps = {
    */
   renderAction?: (option: ButtonProps, index: number, onOptionPress: ActionSheetOnOptionPress) => JSX.Element;
   /**
+   * @deprecated
    * Called once the modal has been dismissed completely
    */
   onModalDismissed?: DialogProps['onDialogDismissed'];

--- a/src/components/actionSheet/index.tsx
+++ b/src/components/actionSheet/index.tsx
@@ -11,11 +11,17 @@ import Image from '../image';
 //@ts-ignore
 import ListItem from '../listItem';
 import PanningProvider from '../panningViews/panningProvider';
+import {Dialog as IncubatorDialog, DialogProps as IncubatorDialogProps} from '../../incubator';
+import {LogService} from '../../services';
 
 const VERTICAL_PADDING = 8;
 type ActionSheetOnOptionPress = (index: number) => void;
 
 type ActionSheetProps = {
+  /**
+   * Migrate to the Incubator.Dialog component
+   */
+  migrateDialog?: boolean;
   /**
    * Whether to show the action sheet or not
    */
@@ -89,7 +95,7 @@ type ActionSheetProps = {
   dialogProps?: Omit<
     DialogProps,
     'useSafeArea' | 'testID' | 'containerStyle' | 'visible' | 'onDismiss' | 'onDialogDismissed'
-  >;
+  > | IncubatorDialogProps;
   /**
    * testID for e2e tests
    */
@@ -213,7 +219,7 @@ class ActionSheet extends Component<ActionSheetProps> {
     );
   }
 
-  render() {
+  renderOldDialog() {
     const {useNativeIOS, visible, onDismiss, dialogStyle, onModalDismissed, testID, useSafeArea, dialogProps} =
       this.props;
 
@@ -239,6 +245,41 @@ class ActionSheet extends Component<ActionSheetProps> {
       </Dialog>
     );
   }
+
+  renderNewDialog() {
+    const {visible, onDismiss, dialogStyle, onModalDismissed, testID, useSafeArea, dialogProps} = this.props;
+
+    if (onModalDismissed) {
+      LogService.deprecationWarn({component: 'ActionSheet', oldProp: 'onModalDismissed', newProp: 'onDismiss'});
+    }
+
+    return (
+      // @ts-expect-error height might be null here
+      <IncubatorDialog
+        bottom
+        centerH
+        width="100%"
+        direction={PanningProvider.Directions.DOWN}
+        {...dialogProps}
+        useSafeArea={useSafeArea}
+        testID={testID}
+        containerStyle={[styles.incubatorDialog, dialogStyle]}
+        visible={visible}
+        onDismiss={onDismiss}
+      >
+        {this.renderSheet()}
+      </IncubatorDialog>
+    );
+  }
+
+  render() {
+    const {migrateDialog} = this.props;
+    if (migrateDialog) {
+      return this.renderNewDialog();
+    } else {
+      return this.renderOldDialog();
+    }
+  }
 }
 
 export default asBaseComponent<ActionSheetProps>(ActionSheet);
@@ -249,6 +290,10 @@ const styles = StyleSheet.create({
   },
   dialog: {
     backgroundColor: Colors.white
+  },
+  incubatorDialog: {
+    backgroundColor: Colors.white,
+    marginBottom: 0
   },
   listWithTitle: {
     paddingBottom: VERTICAL_PADDING

--- a/src/incubator/Dialog/DialogHeader.tsx
+++ b/src/incubator/Dialog/DialogHeader.tsx
@@ -84,7 +84,7 @@ const DialogHeader = (props: DialogHeaderProps = {}) => {
 
   const containerStyle = useMemo(() => [style, outerContainerStyle], [style, outerContainerStyle]);
 
-  if (!isEmpty(props)) {
+  if (knob || content || bottomAccessory || divider) {
     return (
       <View {...others} style={containerStyle}>
         {knob}

--- a/src/incubator/Dialog/DialogHeader.tsx
+++ b/src/incubator/Dialog/DialogHeader.tsx
@@ -4,6 +4,7 @@ import {StyleSheet} from 'react-native';
 import {asBaseComponent} from '../../commons/new';
 import {Spacings, Colors, BorderRadiuses, Dividers} from 'style';
 import View from '../../components/view';
+import TouchableOpacity from '../../components/touchableOpacity';
 import Text from '../../components/text';
 import {DialogHeaderProps} from './types';
 
@@ -18,6 +19,13 @@ const DialogHeader = (props: DialogHeaderProps = {}) => {
     renderContent,
     showKnob = true,
     showDivider = true,
+    leadingAccessory,
+    trailingAccessory,
+    innerContainerStyle,
+    onPress,
+    bottomAccessory,
+    outerContainerStyle,
+    style,
     ...others
   } = props;
 
@@ -32,9 +40,10 @@ const DialogHeader = (props: DialogHeaderProps = {}) => {
       return renderContent(props);
     }
 
+    const Container = onPress ? TouchableOpacity : View;
     if (!isEmpty(title) || !isEmpty(subtitle)) {
       return (
-        <View marginH-s5 marginV-s1>
+        <Container onPress={onPress} center flex>
           {title && (
             <Text $textDefault {...titleProps} marginB-s3 style={titleStyle}>
               {title}
@@ -45,7 +54,7 @@ const DialogHeader = (props: DialogHeaderProps = {}) => {
               {subtitle}
             </Text>
           )}
-        </View>
+        </Container>
       );
     }
 
@@ -53,17 +62,34 @@ const DialogHeader = (props: DialogHeaderProps = {}) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [renderContent, title, titleStyle, titleProps, subtitle, subtitleStyle, subtitleProps]);
 
+  const content = useMemo(() => {
+    if (headerContent || leadingAccessory || trailingAccessory) {
+      return (
+        <View marginH-s5 marginV-s1 style={innerContainerStyle} row spread>
+          {leadingAccessory}
+          {headerContent}
+          {trailingAccessory}
+        </View>
+      );
+    }
+
+    return null;
+  }, [headerContent, leadingAccessory, trailingAccessory, innerContainerStyle]);
+
   const divider = useMemo(() => {
     if (showDivider) {
       return <View style={Dividers.d10}/>;
     }
   }, [showDivider]);
 
+  const containerStyle = useMemo(() => [style, outerContainerStyle], [style, outerContainerStyle]);
+
   if (!isEmpty(props)) {
     return (
-      <View {...others}>
+      <View {...others} style={containerStyle}>
         {knob}
-        {headerContent}
+        {content}
+        {bottomAccessory}
         {divider}
       </View>
     );
@@ -71,6 +97,8 @@ const DialogHeader = (props: DialogHeaderProps = {}) => {
 
   return null;
 };
+
+DialogHeader.displayName = 'Incubator.Dialog.Header';
 
 export default asBaseComponent<DialogHeaderProps>(DialogHeader);
 

--- a/src/incubator/Dialog/DialogHeader.tsx
+++ b/src/incubator/Dialog/DialogHeader.tsx
@@ -21,10 +21,9 @@ const DialogHeader = (props: DialogHeaderProps = {}) => {
     showDivider = true,
     leadingAccessory,
     trailingAccessory,
-    innerContainerStyle,
+    contentContainerStyle,
     onPress,
     bottomAccessory,
-    outerContainerStyle,
     style,
     ...others
   } = props;
@@ -65,7 +64,7 @@ const DialogHeader = (props: DialogHeaderProps = {}) => {
   const content = useMemo(() => {
     if (headerContent || leadingAccessory || trailingAccessory) {
       return (
-        <View marginH-s5 marginV-s1 style={innerContainerStyle} row spread>
+        <View marginH-s5 marginV-s1 style={contentContainerStyle} row spread>
           {leadingAccessory}
           {headerContent}
           {trailingAccessory}
@@ -74,7 +73,7 @@ const DialogHeader = (props: DialogHeaderProps = {}) => {
     }
 
     return null;
-  }, [headerContent, leadingAccessory, trailingAccessory, innerContainerStyle]);
+  }, [headerContent, leadingAccessory, trailingAccessory, contentContainerStyle]);
 
   const divider = useMemo(() => {
     if (showDivider) {
@@ -82,11 +81,9 @@ const DialogHeader = (props: DialogHeaderProps = {}) => {
     }
   }, [showDivider]);
 
-  const containerStyle = useMemo(() => [style, outerContainerStyle], [style, outerContainerStyle]);
-
   if (knob || content || bottomAccessory || divider) {
     return (
-      <View {...others} style={containerStyle}>
+      <View {...others} style={style}>
         {knob}
         {content}
         {bottomAccessory}

--- a/src/incubator/Dialog/dialogHeader.api.json
+++ b/src/incubator/Dialog/dialogHeader.api.json
@@ -1,0 +1,42 @@
+{
+  "name": "Dialog.Header",
+  "category": "incubator",
+  "description": "Component for displaying the header of a popup dialog",
+  "props": [
+    {"name": "title", "type": "string", "description": "Title"},
+    {"name": "titleStyle", "type": "StyleProp<TextStyle>", "description": "Title text style"},
+    {"name": "titleProps", "type": "TextProps", "description": "Title extra props"},
+    {"name": "subtitle", "type": "string", "description": "Subtitle"},
+    {"name": "subtitleStyle", "type": "StyleProp<TextStyle>", "description": "Subtitle text style"},
+    {"name": "subtitleProps", "type": "TextProps", "description": "Subtitle extra props"},
+    {
+      "name": "renderContent",
+      "type": "(props: DialogHeaderProps) => React.ReactElement",
+      "description": "Replace the header's default content (Dialog.Text)"
+    },
+    {"name": "showKnob", "type": "boolean", "description": "Show the header's knob (default is true)"},
+    {"name": "showDivider", "type": "boolean", "description": "Show the header's divider (default is true)"},
+    {"name": "leadingAccessory", "type": "ReactElement", "description": "Pass to render a leading element"},
+    {"name": "trailingAccessory", "type": "ReactElement", "description": "Pass to render a trailing element"},
+    {
+      "name": "innerContainerStyle",
+      "type": "ViewProps['style']",
+      "description": "Style for the leading + content + trailing components (without the bottomAccessory)"
+    },
+    {
+      "name": "onPress",
+      "type": "() => void",
+      "description": "onPress callback for the inner content"
+    },
+    {
+      "name": "bottomAccessory",
+      "type": "ReactElement",
+      "description": "Pass to render a bottom element below the input"
+    },
+    {
+      "name": "outerContainerStyle",
+      "type": "ViewProps['style']",
+      "description": "Style for the whole header's container"
+    }
+  ]
+}

--- a/src/incubator/Dialog/dialogHeader.api.json
+++ b/src/incubator/Dialog/dialogHeader.api.json
@@ -14,12 +14,12 @@
       "type": "(props: DialogHeaderProps) => React.ReactElement",
       "description": "Replace the header's default content (Dialog.Text)"
     },
-    {"name": "showKnob", "type": "boolean", "description": "Show the header's knob (default is true)"},
-    {"name": "showDivider", "type": "boolean", "description": "Show the header's divider (default is true)"},
+    {"name": "showKnob", "type": "boolean", "description": "Show the header's knob", "default": "true"},
+    {"name": "showDivider", "type": "boolean", "description": "Show the header's divider", "default": "true"},
     {"name": "leadingAccessory", "type": "ReactElement", "description": "Pass to render a leading element"},
     {"name": "trailingAccessory", "type": "ReactElement", "description": "Pass to render a trailing element"},
     {
-      "name": "innerContainerStyle",
+      "name": "contentContainerStyle",
       "type": "ViewProps['style']",
       "description": "Style for the leading + content + trailing components (without the bottomAccessory)"
     },
@@ -32,11 +32,6 @@
       "name": "bottomAccessory",
       "type": "ReactElement",
       "description": "Pass to render a bottom element below the input"
-    },
-    {
-      "name": "outerContainerStyle",
-      "type": "ViewProps['style']",
-      "description": "Style for the whole header's container"
     }
   ]
 }

--- a/src/incubator/Dialog/index.tsx
+++ b/src/incubator/Dialog/index.tsx
@@ -124,7 +124,7 @@ const Dialog = (props: DialogProps) => {
   }, [propsVisibility]);
 
   const alignmentStyle = useMemo(() => {
-    return {flex: 1, ...extractAlignmentsValues(props)};
+    return {flex: 1, alignItems: 'center', ...extractAlignmentsValues(props)};
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/incubator/Dialog/index.tsx
+++ b/src/incubator/Dialog/index.tsx
@@ -17,11 +17,18 @@ import {DialogProps, DialogDirections, DialogDirectionsEnum, DialogHeaderProps} 
 export {DialogProps, DialogDirections, DialogDirectionsEnum, DialogHeaderProps};
 import useFadeView from './useFadeView';
 
+export interface DialogStatics {
+  directions: typeof DialogDirectionsEnum;
+  Header: typeof DialogHeader;
+}
+
 const Dialog = (props: DialogProps) => {
   const {
     visible: propsVisibility = false,
     headerProps,
     containerStyle,
+    width,
+    height,
     onDismiss,
     direction = DialogDirectionsEnum.DOWN,
     ignoreBackgroundPress,
@@ -139,9 +146,15 @@ const Dialog = (props: DialogProps) => {
   }, []);
 
   const style = useMemo(() => {
-    return [styles.defaultDialogStyle, containerStyle, transitionStyle];
+    return [
+      styles.defaultDialogStyle,
+      containerStyle,
+      transitionStyle,
+      width ? {width} : undefined,
+      height ? {height} : undefined
+    ];
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [containerStyle]);
+  }, [containerStyle, width, height]);
 
   const renderDialog = () => {
     return (
@@ -178,7 +191,7 @@ Dialog.displayName = 'Incubator.Dialog';
 Dialog.directions = DialogDirectionsEnum;
 Dialog.Header = DialogHeader;
 
-export default asBaseComponent<DialogProps>(Dialog);
+export default asBaseComponent<DialogProps, DialogStatics>(Dialog);
 
 const styles = StyleSheet.create({
   defaultDialogStyle: {

--- a/src/incubator/Dialog/index.tsx
+++ b/src/incubator/Dialog/index.tsx
@@ -19,7 +19,7 @@ import useFadeView from './useFadeView';
 
 const Dialog = (props: DialogProps) => {
   const {
-    visible: propsVisibility,
+    visible: propsVisibility = false,
     headerProps,
     containerStyle,
     onDismiss,

--- a/src/incubator/Dialog/types.ts
+++ b/src/incubator/Dialog/types.ts
@@ -1,4 +1,4 @@
-import {PropsWithChildren} from 'react';
+import {PropsWithChildren, ReactElement} from 'react';
 import {StyleProp, TextStyle, ViewStyle} from 'react-native';
 import {AlignmentModifiers} from '../../commons/modifiers';
 import {ModalProps} from '../../components/modal';
@@ -46,6 +46,30 @@ export interface DialogHeaderProps extends ViewProps {
    * Show the header's divider (default is true)
    */
   showDivider?: boolean;
+  /**
+   * Pass to render a leading element
+   */
+  leadingAccessory?: ReactElement;
+  /**
+   * Pass to render a trailing element
+   */
+  trailingAccessory?: ReactElement;
+  /**
+   * Style for the leading + content + trailing components (without the bottomAccessory)
+   */
+  innerContainerStyle?: ViewProps['style']; // TODO: or upperContentContainerStyle
+  /**
+   * onPress callback for the inner content
+   */
+  onPress?: () => void;
+  /**
+   * Pass to render a bottom element below the input
+   */
+  bottomAccessory?: ReactElement;
+  /**
+   * Style for the whole header's container
+   */
+  outerContainerStyle?: ViewProps['style']; // TODO: or containerStyle
 }
 
 export interface _DialogProps extends AlignmentModifiers, Pick<ViewProps, 'useSafeArea'> {
@@ -62,9 +86,18 @@ export interface _DialogProps extends AlignmentModifiers, Pick<ViewProps, 'useSa
    */
   containerStyle?: StyleProp<ViewStyle>;
   /**
+   * The dialog width.
+   */
+  width?: string | number;
+  /**
+   * The dialog height.
+   */
+  height?: string | number;
+
+  /**
    * Callback that is called after the dialog's dismiss (after the animation has ended).
    */
-  onDismiss?: (props?: _DialogProps) => void;
+  onDismiss?: () => void;
   /**
    * The direction from which and to which the dialog is animating \ panning (default down).
    */

--- a/src/incubator/Dialog/types.ts
+++ b/src/incubator/Dialog/types.ts
@@ -57,7 +57,7 @@ export interface DialogHeaderProps extends ViewProps {
   /**
    * Style for the leading + content + trailing components (without the bottomAccessory)
    */
-  innerContainerStyle?: ViewProps['style']; // TODO: or upperContentContainerStyle
+   contentContainerStyle?: ViewProps['style'];
   /**
    * onPress callback for the inner content
    */
@@ -66,10 +66,6 @@ export interface DialogHeaderProps extends ViewProps {
    * Pass to render a bottom element below the input
    */
   bottomAccessory?: ReactElement;
-  /**
-   * Style for the whole header's container
-   */
-  outerContainerStyle?: ViewProps['style']; // TODO: or containerStyle
 }
 
 export interface _DialogProps extends AlignmentModifiers, Pick<ViewProps, 'useSafeArea'> {

--- a/src/incubator/Dialog/useAnimatedTransition.ts
+++ b/src/incubator/Dialog/useAnimatedTransition.ts
@@ -68,7 +68,7 @@ export default function useAnimatedTransition(props: AnimatedTransitionProps) {
   [onInitPosition]);
 
   useEffect(() => {
-    if (!hiddenLocation.wasMeasured && enterFrom) {
+    if (hiddenLocation.wasMeasured && enterFrom) {
       const location = getLocation(enterFrom);
       initPosition(location, enterFrom, animateIn);
     }

--- a/src/incubator/WheelPicker/index.tsx
+++ b/src/incubator/WheelPicker/index.tsx
@@ -1,8 +1,9 @@
 // TODO: Support style customization
 import {isFunction, isUndefined} from 'lodash';
 import React, {useCallback, useRef, useMemo, useEffect, useState} from 'react';
-import {TextStyle, ViewStyle, FlatList, NativeSyntheticEvent, NativeScrollEvent, StyleSheet, ListRenderItemInfo, FlatListProps} from 'react-native';
+import {TextStyle, ViewStyle, NativeSyntheticEvent, NativeScrollEvent, StyleSheet, ListRenderItemInfo, FlatListProps} from 'react-native';
 import Animated, {useSharedValue, useAnimatedScrollHandler} from 'react-native-reanimated';
+import {FlatList} from 'react-native-gesture-handler';
 import {Colors, Spacings} from 'style';
 import {Constants, asBaseComponent} from '../../commons/new';
 import View from '../../components/view';

--- a/src/incubator/hooks/useHiddenLocation.ts
+++ b/src/incubator/hooks/useHiddenLocation.ts
@@ -21,7 +21,7 @@ export default function useHiddenLocation<T extends View>(props: HiddenLocationP
     y = 0,
     width = Constants.screenWidth,
     height = Constants.windowHeight,
-    wasMeasured = true
+    wasMeasured = false
   }): HiddenLocation => {
     return {
       up: -y - height,
@@ -36,9 +36,9 @@ export default function useHiddenLocation<T extends View>(props: HiddenLocationP
 
   const onLayout = useCallback((event: LayoutChangeEvent) => {
     const {width, height} = event.nativeEvent.layout;
-    if (containerRef.current && hiddenLocation.wasMeasured) {
+    if (containerRef.current && !hiddenLocation.wasMeasured) {
       containerRef.current.measureInWindow((x: number, y: number) => {
-        setHiddenLocation(getHiddenLocation({x, y, width, height, wasMeasured: false}));
+        setHiddenLocation(getHiddenLocation({x, y, width, height, wasMeasured: true}));
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/incubator/index.ts
+++ b/src/incubator/index.ts
@@ -7,4 +7,4 @@ export {default as TouchableOpacity, TouchableOpacityProps} from './TouchableOpa
 export {default as WheelPicker, WheelPickerProps, WheelPickerItemProps} from './WheelPicker';
 export {WheelPickerAlign} from './WheelPicker/types';
 export {default as PanView, PanViewProps, PanViewDirections, PanViewDismissThreshold} from './panView';
-export {default as Dialog, DialogProps, DialogHeaderProps} from './Dialog';
+export {default as Dialog, DialogProps, DialogHeaderProps, DialogStatics} from './Dialog';


### PR DESCRIPTION
## Description
You can look at individual commits for simplicity.

Incubator.Dialog - add support for a few things (custom elements, `onPress` on the header + `width` and `height` in the dialog) and a couple of fixes.
Add API for DialogHeader.
Start migration in `ActionSheet` and a couple of screens (and support it on `Incubator.WheelPicker`.

Naming: I am not sure about a couple of styles names (see TODO), suggestions are welcome.

WOAUILIB-2317
WOAUILIB-3072

## Changelog
Incubator.Dialog - add support for a few things, a couple of fixes and start a migration for ActionSheet.
