### PR TITLE
set default themeVariant in DateTimePicker

### DIFF
--- a/src/components/dateTimePicker/index.tsx
+++ b/src/components/dateTimePicker/index.tsx
@@ -130,7 +130,7 @@ function DateTimePicker(props: DateTimePickerPropsInternal) {
     is24Hour,
     minuteInterval,
     timeZoneOffsetInMinutes,
-    themeVariant,
+    themeVariant = Colors.getScheme(),
     onChange,
     dialogProps,
     headerStyle,


### PR DESCRIPTION
## Description
DateTimePicker - add default `themeVariant` for dark mode support
to check that toggle between dark mode and light mode without changing the scheme in the `Config.ts` file 

## Changelog
DateTimePicker - add default `themeVariant` for dark mode support
