### PR TITLE
Avoiding showing validation message element when error is not triggered

### DIFF
--- a/src/incubator/TextField/ValidationMessage.tsx
+++ b/src/incubator/TextField/ValidationMessage.tsx
@@ -24,11 +24,11 @@ const ValidationMessage = ({
   const relevantValidationMessage = getRelevantValidationMessage(validationMessage, context.failingValidatorIndex);
   const showValidationMessage = !context.isValid || (!validate && !!validationMessage);
 
-  return (
+  return showValidationMessage ? (
     <Text testID={testID} $textDangerLight style={style}>
-      {showValidationMessage ? relevantValidationMessage : ''}
+      {relevantValidationMessage}
     </Text>
-  );
+  ) : <></>;
 };
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
An issue occurred when I tried to style the `TextField` validation message. Adding a background color and some padding to the message resulted in a colored element always shown whether there's a validation message or not. This is because you can style the validation message element but it's just the string inside which will be hidden when there is no message to show. This PR should fix it.
