### PR TITLE
Feat/ prioritize backgroundColor prop over bg modifiers

### DIFF
--- a/src/components/view/index.tsx
+++ b/src/components/view/index.tsx
@@ -73,10 +73,18 @@ function View(props: ViewProps, ref: any) {
     animated,
     reanimated,
     children,
+    backgroundColor: backgroundColorProps,
     ...others
   } = themeProps;
-  const {backgroundColor, borderRadius, paddings, margins, alignments, flexStyle, positionStyle} = useModifiers(themeProps,
-    modifiersOptions);
+  const {
+    backgroundColor: backgroundColorModifiers,
+    borderRadius,
+    paddings,
+    margins,
+    alignments,
+    flexStyle,
+    positionStyle
+  } = useModifiers(themeProps, modifiersOptions);
   const [ready, setReady] = useState(!renderDelay);
 
   useEffect(() => {
@@ -101,6 +109,7 @@ function View(props: ViewProps, ref: any) {
   }, [useSafeArea, animated, reanimated]);
 
   const _style = useMemo(() => {
+    const backgroundColor = backgroundColorProps || backgroundColorModifiers;
     return [
       backgroundColor && {
         backgroundColor
@@ -115,7 +124,17 @@ function View(props: ViewProps, ref: any) {
       alignments,
       style
     ];
-  }, [backgroundColor, borderRadius, flexStyle, positionStyle, paddings, margins, alignments, style]);
+  }, [
+    backgroundColorProps,
+    backgroundColorModifiers,
+    borderRadius,
+    flexStyle,
+    positionStyle,
+    paddings,
+    margins,
+    alignments,
+    style
+  ]);
 
   if (!ready) {
     return null;


### PR DESCRIPTION
## Description
View - prioritize backgroundColor prop over bg modifiers
This change is required for WOAUILIB-2781:
Assume that the user renders `<View bg-$backgroundPrimaryHeavy/>`  inside a theme context, we calculate the theme color (in the config) and pass it as a background prop from the config, but it's overridden by the `bg-$backgroundPrimaryHeavy` so it won't get the theme color but the blue primary. 

## Changelog
View - prioritize backgroundColor prop over bg modifiers
