### PR TITLE
Set default value to Toast zIndex prop

### DIFF
--- a/src/incubator/toast/index.tsx
+++ b/src/incubator/toast/index.tsx
@@ -1,5 +1,12 @@
 import React, {PropsWithChildren, useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import {ActivityIndicator, StyleSheet, findNodeHandle, AccessibilityInfo, ViewStyle, LayoutChangeEvent} from 'react-native';
+import {
+  ActivityIndicator,
+  StyleSheet,
+  findNodeHandle,
+  AccessibilityInfo,
+  ViewStyle,
+  LayoutChangeEvent
+} from 'react-native';
 import _ from 'lodash';
 import {Constants, asBaseComponent} from '../../commons/new';
 import {useDidUpdate} from '../../hooks';
@@ -23,7 +30,7 @@ const Toast = (props: PropsWithChildren<ToastProps>) => {
     icon,
     iconColor,
     preset,
-    zIndex,
+    zIndex = Constants.isAndroid ? 100 : undefined,
     elevation,
     style,
     containerStyle,


### PR DESCRIPTION
## Description
Set default value to Toast zIndex prop.
This is the solution to the floating button that opens the Toast message, the Toast gets rendered beneath the button in Android. 
Ticket: 3100.

## Changelog
Set default value to Toast zIndex prop.