### PR TITLE
Lock RNN to 7.29.0 to fix Android build

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "react-native-gesture-handler": "2.5.0",
     "react-native-haptic-feedback": "^1.11.0",
     "react-native-linear-gradient": "2.5.6",
-    "react-native-navigation": "^7.19.1",
+    "react-native-navigation": "7.29.0",
     "react-native-reanimated": "2.8.0",
     "react-native-shimmer-placeholder": "^2.0.6",
     "react-native-svg": "^12.1.0",


### PR DESCRIPTION
## Description
Lock RNN to 7.29.0 to fix Android build

## Changelog
Lock RNN to 7.29.0 to fix Android build