### PR TITLE
Incubator.Dialog - do not show empty header

### DIFF
--- a/src/incubator/Dialog/index.tsx
+++ b/src/incubator/Dialog/index.tsx
@@ -164,7 +164,7 @@ const Dialog = (props: DialogProps) => {
     return (
       <PanGestureHandler onGestureEvent={isEmpty(directions) ? undefined : panGestureEvent}>
         <View reanimated style={style} onLayout={onLayout} ref={setRef} testID={testID}>
-          <DialogHeader {...headerProps}/>
+          {headerProps && <DialogHeader {...headerProps}/>}
           {children}
         </View>
       </PanGestureHandler>


### PR DESCRIPTION
## Description
Incubator.Dialog - do not show header if no `headerProps` are sent

## Changelog
Incubator.Dialog - do not show empty header (with only knob and divider)