### PR TITLE
revert ExpandableSection, removed useSeparator prop

### DIFF
--- a/src/components/expandableSection/expandableSection.api.json
+++ b/src/components/expandableSection/expandableSection.api.json
@@ -15,8 +15,7 @@
       "name": "onPress",
       "type": "() => void",
       "description": "Called when pressing the header of the ExpandableSection"
-    },
-    {"name": "useSeparator", "type": "boolean", "description": "should use separator when section is expanded"}
+    }
   ],
   "snippet": [
     "<ExpandableSection",

--- a/src/components/expandableSection/index.tsx
+++ b/src/components/expandableSection/index.tsx
@@ -3,7 +3,6 @@ import {LayoutAnimation, StyleSheet} from 'react-native';
 import View from '../view';
 import TouchableOpacity from '../touchableOpacity';
 import {useDidUpdate} from 'hooks';
-import {Dividers} from '../../style';
 
 export type ExpandableSectionProps = {
   /**
@@ -26,10 +25,6 @@ export type ExpandableSectionProps = {
    * action for when pressing the header of the expandableSection
    */
   onPress?: () => void;
-  /**
-   * should use separator when section is expanded
-   */
-  useSeparator?: boolean;
 };
 
 /**
@@ -39,7 +34,7 @@ export type ExpandableSectionProps = {
  */
 
 function ExpandableSection(props: ExpandableSectionProps) {
-  const {expanded, sectionHeader, children, top, useSeparator} = props;
+  const {expanded, sectionHeader, children, top} = props;
 
   /**
    * TODO: move to reanimated LayoutAnimation after updating to version 2.3.0
@@ -62,10 +57,6 @@ function ExpandableSection(props: ExpandableSectionProps) {
     return {expanded};
   }, [expanded]);
 
-  const renderSeparator = () => {
-    return <View marginL-s10 style={styles.separator}/>;
-  };
-
   return (
     <View style={styles.container}>
       {top && expanded && children}
@@ -73,7 +64,6 @@ function ExpandableSection(props: ExpandableSectionProps) {
         {sectionHeader}
       </TouchableOpacity>
       {!top && expanded && children}
-      {expanded && useSeparator && renderSeparator()}
     </View>
   );
 }
@@ -83,6 +73,5 @@ export default ExpandableSection;
 const styles = StyleSheet.create({
   container: {
     overflow: 'hidden'
-  },
-  separator: Dividers.d10
+  }
 });


### PR DESCRIPTION
## Description
ExpandableSection revert, removed useSeparator prop.
The old [PR](https://github.com/wix/react-native-ui-lib/pull/2279/files).

## Changelog
ExpandableSection revert, removed useSeparator prop.