### PR TITLE
Incubator.Dialog - allow changing pointerEvents in children

### DIFF
--- a/src/incubator/Dialog/index.tsx
+++ b/src/incubator/Dialog/index.tsx
@@ -163,7 +163,7 @@ const Dialog = (props: DialogProps) => {
   const renderDialog = () => {
     return (
       <PanGestureHandler onGestureEvent={isEmpty(directions) ? undefined : panGestureEvent}>
-        <View reanimated style={style} onLayout={onLayout} ref={setRef} testID={testID}>
+        <View pointerEvents={'box-none'} reanimated style={style} onLayout={onLayout} ref={setRef} testID={testID}>
           {headerProps && <DialogHeader {...headerProps}/>}
           {children}
         </View>


### PR DESCRIPTION
## Description
Incubator.Dialog - allow changing pointerEvents in children
This is for the CustomDialog's `Close` button.

## Changelog
Incubator.Dialog - allow changing pointerEvents in children