### PR TITLE
Fix short text when wrapped with a centered container

### DIFF
--- a/src/incubator/TextField/CharCounter.tsx
+++ b/src/incubator/TextField/CharCounter.tsx
@@ -20,7 +20,7 @@ const CharCounter = ({maxLength, charCounterStyle, testID}: CharCounterProps) =>
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
+    flexGrow: 1,
     textAlign: 'right'
   }
 });


### PR DESCRIPTION
## Description
Incubator.TextField - fix short text when wrapped with a centered container

Code example:
```
import _ from 'lodash';
import React, {Component} from 'react';
import {StyleSheet} from 'react-native';
import {View, Text, Card, TextField, Button} from 'react-native-ui-lib'; //eslint-disable-line

export default class PlaygroundScreen extends Component {
  render() {
    return (
      <View bg-grey80 padding-20 center>
        <TextField
          migrate
          marginT-16
          placeholder="Enter confirmation code"
          floatingPlaceholder={false}
          showCharacterCounter
          centered
          validate={'number'}
          validationMessage={'Blaaa blaa bla'}
          validateOnChange
          maxLength={6}
        />
      </View>
    );
  }
}

const styles = StyleSheet.create({
  container: {}
});

```

## Changelog
Incubator.TextField - fix short text when wrapped with a centered container
