### PR TITLE
getTintColor support options, should reverse on dark prop

### DIFF
--- a/src/style/colors.ts
+++ b/src/style/colors.ts
@@ -12,7 +12,7 @@ import Scheme, {Schemes, SchemeType} from './scheme';
 
 export type DesignToken = {semantic?: [string]; resource_paths?: [string]; toString: Function};
 export type TokensOptions = {primaryColor: string};
-export type GetColorTintOptions = {shouldReverseOnDark?: boolean};
+export type GetColorTintOptions = {avoidReverseOnDark?: boolean};
 
 export class Colors {
   [key: string]: any;
@@ -163,8 +163,7 @@ export class Colors {
     return validColors ? undefined : results[0];
   }
 
-  getColorTint(colorValue: string | OpaqueColorValue, tintKey: string | number, options?: GetColorTintOptions) {
-    const avoidReverseOnDark = !!options?.shouldReverseOnDark;
+  getColorTint(colorValue: string | OpaqueColorValue, tintKey: string | number, options: GetColorTintOptions = {}) {
     if (_.isUndefined(tintKey) || isNaN(tintKey as number) || _.isUndefined(colorValue)) {
       // console.error('"Colors.getColorTint" must accept a color and tintKey params');
       return colorValue;
@@ -181,7 +180,8 @@ export class Colors {
     if (colorKey) {
       const colorKeys = [1, 5, 10, 20, 30, 40, 50, 60, 70, 80];
       const keyIndex = _.indexOf(colorKeys, Number(tintKey));
-      const shouldReverseOnDark = avoidReverseOnDark && this.shouldSupportDarkMode && Scheme.getSchemeType() === 'dark';
+      const shouldReverseOnDark =
+        !options?.avoidReverseOnDark && this.shouldSupportDarkMode && Scheme.getSchemeType() === 'dark';
       const key = shouldReverseOnDark ? colorKeys[colorKeys.length - 1 - keyIndex] : tintKey;
       const requiredColorKey = `${colorKey.slice(0, -2)}${key}`;
       const requiredColor = this[requiredColorKey];

--- a/src/style/colors.ts
+++ b/src/style/colors.ts
@@ -12,7 +12,7 @@ import Scheme, {Schemes, SchemeType} from './scheme';
 
 export type DesignToken = {semantic?: [string]; resource_paths?: [string]; toString: Function};
 export type TokensOptions = {primaryColor: string};
-export type ColorTintOptions = {shouldReverseOnDark: boolean};
+export type GetColorTintOptions = {shouldReverseOnDark?: boolean};
 
 export class Colors {
   [key: string]: any;
@@ -163,9 +163,8 @@ export class Colors {
     return validColors ? undefined : results[0];
   }
 
-  getColorTint(colorValue: string | OpaqueColorValue,
-    tintKey: string | number,
-    options: ColorTintOptions = {shouldReverseOnDark: true}) {
+  getColorTint(colorValue: string | OpaqueColorValue, tintKey: string | number, options?: GetColorTintOptions) {
+    const avoidReverseOnDark = !!options?.shouldReverseOnDark;
     if (_.isUndefined(tintKey) || isNaN(tintKey as number) || _.isUndefined(colorValue)) {
       // console.error('"Colors.getColorTint" must accept a color and tintKey params');
       return colorValue;
@@ -182,8 +181,7 @@ export class Colors {
     if (colorKey) {
       const colorKeys = [1, 5, 10, 20, 30, 40, 50, 60, 70, 80];
       const keyIndex = _.indexOf(colorKeys, Number(tintKey));
-      const shouldReverseOnDark =
-        options.shouldReverseOnDark && this.shouldSupportDarkMode && Scheme.getSchemeType() === 'dark';
+      const shouldReverseOnDark = avoidReverseOnDark && this.shouldSupportDarkMode && Scheme.getSchemeType() === 'dark';
       const key = shouldReverseOnDark ? colorKeys[colorKeys.length - 1 - keyIndex] : tintKey;
       const requiredColorKey = `${colorKey.slice(0, -2)}${key}`;
       const requiredColor = this[requiredColorKey];

--- a/src/style/colors.ts
+++ b/src/style/colors.ts
@@ -12,6 +12,7 @@ import Scheme, {Schemes, SchemeType} from './scheme';
 
 export type DesignToken = {semantic?: [string]; resource_paths?: [string]; toString: Function};
 export type TokensOptions = {primaryColor: string};
+export type ColorTintOptions = {shouldReverseOnDark: boolean};
 
 export class Colors {
   [key: string]: any;
@@ -162,7 +163,9 @@ export class Colors {
     return validColors ? undefined : results[0];
   }
 
-  getColorTint(colorValue: string | OpaqueColorValue, tintKey: string | number) {
+  getColorTint(colorValue: string | OpaqueColorValue,
+    tintKey: string | number,
+    options: ColorTintOptions = {shouldReverseOnDark: true}) {
     if (_.isUndefined(tintKey) || isNaN(tintKey as number) || _.isUndefined(colorValue)) {
       // console.error('"Colors.getColorTint" must accept a color and tintKey params');
       return colorValue;
@@ -179,10 +182,9 @@ export class Colors {
     if (colorKey) {
       const colorKeys = [1, 5, 10, 20, 30, 40, 50, 60, 70, 80];
       const keyIndex = _.indexOf(colorKeys, Number(tintKey));
-      const key =
-        this.shouldSupportDarkMode && Scheme.getSchemeType() === 'dark'
-          ? colorKeys[colorKeys.length - 1 - keyIndex]
-          : tintKey;
+      const shouldReverseOnDark =
+        options.shouldReverseOnDark && this.shouldSupportDarkMode && Scheme.getSchemeType() === 'dark';
+      const key = shouldReverseOnDark ? colorKeys[colorKeys.length - 1 - keyIndex] : tintKey;
       const requiredColorKey = `${colorKey.slice(0, -2)}${key}`;
       const requiredColor = this[requiredColorKey];
 


### PR DESCRIPTION
## Description
getTintColor support options object with should reverse on dark prop.

## Changelog
getTintColor support options object with should reverse on dark prop for the new Loader logic - Theme preset.
