### PR TITLE
SortableList SortableGridList - add initialData

### DIFF
--- a/demo/src/screens/componentScreens/SortableGridListScreen.tsx
+++ b/demo/src/screens/componentScreens/SortableGridListScreen.tsx
@@ -100,7 +100,7 @@ class SortableGridListScreen extends Component {
         </View>
         <View flex>
           <SortableGridList
-            data={items}
+            initialData={items}
             renderItem={this.renderItem}
             // numColumns={2}
             maxItemWidth={140}

--- a/demo/src/screens/componentScreens/SortableListScreen.tsx
+++ b/demo/src/screens/componentScreens/SortableListScreen.tsx
@@ -111,7 +111,7 @@ const SortableListScreen = () => {
       </View>
       <View flex useSafeArea>
         <SortableList
-          data={items}
+          initialData={items}
           renderItem={renderItem}
           keyExtractor={keyExtractor}
           onOrderChange={onOrderChange}

--- a/src/components/sortableGridList/index.tsx
+++ b/src/components/sortableGridList/index.tsx
@@ -19,7 +19,13 @@ function SortableGridList<T = any>(props: SortableGridListProps<T>) {
   const {renderItem, onOrderChange, ...others} = props;
 
   const {itemContainerStyle, numberOfColumns, listContentStyle} = useGridLayout(props);
-  const {numColumns = DEFAULT_NUM_COLUMNS, itemSpacing = DEFAULT_ITEM_SPACINGS, data} = others;
+  const {
+    numColumns = DEFAULT_NUM_COLUMNS,
+    itemSpacing = DEFAULT_ITEM_SPACINGS,
+    initialData,
+    data: deprecatedData
+  } = others;
+  const data = initialData ?? deprecatedData;
   const itemsOrder = useSharedValue<ItemsOrder>(generateItemsOrder(data));
 
   useDidUpdate(() => {

--- a/src/components/sortableGridList/sortableGridList.api.json
+++ b/src/components/sortableGridList/sortableGridList.api.json
@@ -6,7 +6,7 @@
   "extends": ["lists/GridList"],
   "example": "https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/SortableGridListScreen.tsx",
   "props": [
-    {"name": "data", "type": "any[] & {id: string}", "description": "Data of items with an id prop as unique identifier"},
+    {"name": "initialData", "type": "any[] & {id: string}", "description": "Initial data of items with an id prop as unique identifier"},
     {"name": "renderItem", "type": "FlatListProps['renderItem']", "description": "Custom render item callback"},
     {
       "name": "onOrderChange",

--- a/src/components/sortableGridList/types.ts
+++ b/src/components/sortableGridList/types.ts
@@ -8,7 +8,8 @@ export type ItemsOrder = string[];
 export type ItemProps<T> = T & {id: string};
 
 export interface SortableGridListProps<T = any> extends GridListBaseProps, ScrollViewProps {
-  data: FlatListProps<ItemProps<T>>['data'];
+  initialData?: FlatListProps<ItemProps<T>>['data'];
+  data?: FlatListProps<ItemProps<T>>['data'];
   renderItem: FlatListProps<ItemProps<T>>['renderItem'];
   onOrderChange?: (newData: ItemProps<T>[], newOrder: ItemsOrder) => void;
   extraData?: any;

--- a/src/components/sortableList/SortableList.api.json
+++ b/src/components/sortableList/SortableList.api.json
@@ -7,14 +7,14 @@
   "example": "https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/SortableListScreen.tsx",
   "props": [
     {
-      "name": "data",
+      "name": "initialData",
       "type": "ItemT[] (ItemT extends {id: string})",
-      "description": "The data of the list, with an id prop as unique identifier.",
+      "description": "The initial data of the list, with an id prop as unique identifier.",
       "required": true
     },
     {
       "name": "onOrderChange",
-      "type": "(data: ItemT[]) => void",
+      "type": "(newData: ItemT[]) => void",
       "description": "A callback to get the new order (or swapped items).",
       "required": true
     },

--- a/src/components/sortableList/index.tsx
+++ b/src/components/sortableList/index.tsx
@@ -22,7 +22,8 @@ function generateLockedIds<ItemT extends SortableListItemProps>(data: SortableLi
 
 const SortableList = <ItemT extends SortableListItemProps>(props: SortableListProps<ItemT>) => {
   const themeProps = useThemeProps(props, 'SortableList');
-  const {data, onOrderChange, enableHaptic, scale, ...others} = themeProps;
+  const {initialData, data: deprecatedData, onOrderChange, enableHaptic, scale, ...others} = themeProps;
+  const data = initialData ?? deprecatedData;
 
   const itemsOrder = useSharedValue<string[]>(generateItemsOrder(data));
   const lockedIds = useSharedValue<Dictionary<boolean>>(generateLockedIds(data));

--- a/src/components/sortableList/types.ts
+++ b/src/components/sortableList/types.ts
@@ -13,9 +13,13 @@ export interface SortableListProps<ItemT extends SortableListItemProps>
   extends Omit<FlatListProps<ItemT>, 'extraData' | 'data'>,
     Pick<SortableListContextType<ItemT>, 'scale'> {
   /**
+   * The initial data of the list, do not update the data.
+   */
+  initialData?: Data<ItemT>;
+  /**
    * The data of the list, do not update the data.
    */
-  data: Data<ItemT>;
+  data?: Data<ItemT>;
   /**
    * A callback to get the new order (or swapped items).
    */


### PR DESCRIPTION
## Description
SortableList SortableGridList - add initialData
* `initialData` is taken over `data`
* Unfortunately I had to make `data` optional (not in the API), otherwise the typescript would be too complex.

WOAUILIB-3120

## Changelog
SortableList SortableGridList - add initialData