### PR TITLE
Start deprecation of Picker useNativePicker prop

### DIFF
--- a/demo/src/screens/componentScreens/PickerScreen.tsx
+++ b/demo/src/screens/componentScreens/PickerScreen.tsx
@@ -126,8 +126,8 @@ export default class PickerScreen extends Component {
           <Picker
             title="Wheel Picker"
             placeholder="Pick a Language"
-            // useNativePicker
-            useWheelPicker
+            useNativePicker
+            // useWheelPicker
             value={this.state.nativePickerValue}
             onChange={nativePickerValue => this.setState({nativePickerValue})}
             rightIconSource={dropdown}

--- a/src/components/picker/helpers/usePickerMigrationWarnings.tsx
+++ b/src/components/picker/helpers/usePickerMigrationWarnings.tsx
@@ -3,10 +3,10 @@ import _ from 'lodash';
 import {LogService} from '../../../services';
 import {PickerProps, PickerModes} from '../types';
 
-type UsePickerMigrationWarnings = Pick<PickerProps, 'value' | 'mode'>;
+type UsePickerMigrationWarnings = Pick<PickerProps, 'value' | 'mode' | 'useNativePicker'>;
 
 const usePickerMigrationWarnings = (props: UsePickerMigrationWarnings) => {
-  const {value, mode} = props;
+  const {value, mode, useNativePicker} = props;
   useEffect(() => {
     if (mode === PickerModes.SINGLE && Array.isArray(value)) {
       LogService.warn('Picker in SINGLE mode cannot accept an array for value');
@@ -17,6 +17,10 @@ const usePickerMigrationWarnings = (props: UsePickerMigrationWarnings) => {
 
     if (_.isPlainObject(value)) {
       LogService.warn('UILib Picker will stop supporting passing object as value in the next major version. Please use either string or a number as value');
+    }
+
+    if (useNativePicker) {
+      LogService.warn(`UILib Picker will stop supporting the 'useNativePicker' prop soon, please pass instead the 'useWheelPicker' prop and handle relevant TextField migration if required to`);
     }
   }, []);
 };

--- a/src/components/picker/types.tsx
+++ b/src/components/picker/types.tsx
@@ -147,6 +147,7 @@ export type PickerBaseProps = Omit<TextFieldProps, 'value' | 'onChange'> &
      */
     renderCustomSearch?: (props: PickerItemsListProps) => React.ReactElement;
     /**
+     * @deprecated pass useWheelPicker prop instead
      * Allow to use the native picker solution (different style for iOS and Android)
      */
     useNativePicker?: boolean;


### PR DESCRIPTION
## Description
useNativePicker prop leads to using our old TextField and we want to deprecate it and use `useWheelPicker` prop instead

I also added this deprecation in our v7 sheet

## Changelog
Start deprecation of useNativePicker in favor of useWheelPicker