### PR TITLE
Incubator.TextField - should float with defaultValue

### DIFF
--- a/src/incubator/TextField/FloatingPlaceholder.tsx
+++ b/src/incubator/TextField/FloatingPlaceholder.tsx
@@ -28,10 +28,8 @@ const FloatingPlaceholder = ({
     left: 0
   });
 
-  const shouldFloat = useMemo(() => {
-    return (floatOnFocus && context.isFocused) || context.hasValue || !isEmpty(defaultValue);
-  }, [floatOnFocus, context.isFocused, context.hasValue, defaultValue]);
-
+  const useDefaultValue = !isEmpty(defaultValue) && context.value === undefined; // To consider a user that has deleted the defaultValue (and then the placeholder should un-float)
+  const shouldFloat = (floatOnFocus && context.isFocused) || context.hasValue || useDefaultValue;
   const animation = useRef(new Animated.Value(Number(shouldFloat))).current;
   const hidePlaceholder = !context.isValid && validationMessagePosition === ValidationMessagePosition.TOP;
 

--- a/src/incubator/TextField/FloatingPlaceholder.tsx
+++ b/src/incubator/TextField/FloatingPlaceholder.tsx
@@ -1,9 +1,8 @@
-import {isEmpty} from 'lodash';
 import React, {useContext, useRef, useCallback, useState, useMemo} from 'react';
 import {Animated, LayoutChangeEvent, StyleSheet, Platform} from 'react-native';
 import {useDidUpdate} from 'hooks';
 import {FloatingPlaceholderProps, ValidationMessagePosition} from './types';
-import {getColorByState} from './Presenter';
+import {getColorByState, shouldPlaceholderFloat} from './Presenter';
 import {Colors} from '../../style';
 import {Constants} from '../../commons/new';
 import View from '../../components/view';
@@ -12,24 +11,22 @@ import FieldContext from './FieldContext';
 
 const FLOATING_PLACEHOLDER_SCALE = 0.875;
 
-const FloatingPlaceholder = ({
-  placeholder,
-  floatingPlaceholderColor = Colors.$textNeutralLight,
-  floatingPlaceholderStyle,
-  floatOnFocus,
-  validationMessagePosition,
-  extraOffset = 0,
-  defaultValue,
-  testID
-}: FloatingPlaceholderProps) => {
+const FloatingPlaceholder = (props: FloatingPlaceholderProps) => {
+  const {
+    placeholder,
+    floatingPlaceholderColor = Colors.$textNeutralLight,
+    floatingPlaceholderStyle,
+    validationMessagePosition,
+    extraOffset = 0,
+    testID
+  } = props;
   const context = useContext(FieldContext);
   const [placeholderOffset, setPlaceholderOffset] = useState({
     top: 0,
     left: 0
   });
 
-  const useDefaultValue = !isEmpty(defaultValue) && context.value === undefined; // To consider a user that has deleted the defaultValue (and then the placeholder should un-float when losing focus)
-  const shouldFloat = (floatOnFocus && context.isFocused) || context.hasValue || useDefaultValue;
+  const shouldFloat = shouldPlaceholderFloat(props, context.isFocused, context.hasValue, context.value);
   const animation = useRef(new Animated.Value(Number(shouldFloat))).current;
   const hidePlaceholder = !context.isValid && validationMessagePosition === ValidationMessagePosition.TOP;
 

--- a/src/incubator/TextField/FloatingPlaceholder.tsx
+++ b/src/incubator/TextField/FloatingPlaceholder.tsx
@@ -28,7 +28,7 @@ const FloatingPlaceholder = ({
     left: 0
   });
 
-  const useDefaultValue = !isEmpty(defaultValue) && context.value === undefined; // To consider a user that has deleted the defaultValue (and then the placeholder should un-float)
+  const useDefaultValue = !isEmpty(defaultValue) && context.value === undefined; // To consider a user that has deleted the defaultValue (and then the placeholder should un-float when losing focus)
   const shouldFloat = (floatOnFocus && context.isFocused) || context.hasValue || useDefaultValue;
   const animation = useRef(new Animated.Value(Number(shouldFloat))).current;
   const hidePlaceholder = !context.isValid && validationMessagePosition === ValidationMessagePosition.TOP;

--- a/src/incubator/TextField/FloatingPlaceholder.tsx
+++ b/src/incubator/TextField/FloatingPlaceholder.tsx
@@ -1,3 +1,4 @@
+import {isEmpty} from 'lodash';
 import React, {useContext, useRef, useCallback, useState, useMemo} from 'react';
 import {Animated, LayoutChangeEvent, StyleSheet, Platform} from 'react-native';
 import {useDidUpdate} from 'hooks';
@@ -18,6 +19,7 @@ const FloatingPlaceholder = ({
   floatOnFocus,
   validationMessagePosition,
   extraOffset = 0,
+  defaultValue,
   testID
 }: FloatingPlaceholderProps) => {
   const context = useContext(FieldContext);
@@ -25,17 +27,21 @@ const FloatingPlaceholder = ({
     top: 0,
     left: 0
   });
-  const animation = useRef(new Animated.Value(Number((floatOnFocus && context.isFocused) || context.hasValue))).current;
+
+  const shouldFloat = useMemo(() => {
+    return (floatOnFocus && context.isFocused) || context.hasValue || !isEmpty(defaultValue);
+  }, [floatOnFocus, context.isFocused, context.hasValue, defaultValue]);
+
+  const animation = useRef(new Animated.Value(Number(shouldFloat))).current;
   const hidePlaceholder = !context.isValid && validationMessagePosition === ValidationMessagePosition.TOP;
 
   useDidUpdate(() => {
-    const toValue = floatOnFocus ? context.isFocused || context.hasValue : context.hasValue;
     Animated.timing(animation, {
-      toValue: Number(toValue),
+      toValue: Number(shouldFloat),
       duration: 200,
       useNativeDriver: true
     }).start();
-  }, [floatOnFocus, context.isFocused, context.hasValue]);
+  }, [shouldFloat]);
 
   const animatedStyle = useMemo(() => {
     return {

--- a/src/incubator/TextField/Presenter.ts
+++ b/src/incubator/TextField/Presenter.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import {Colors} from './../../style';
-import {ColorType, Validator, FieldContextType} from './types';
+import {ColorType, Validator, FieldContextType, FloatingPlaceholderProps} from './types';
 // TODO: Fix this import after moving all TextField types to a single file after we move to the new docs
 import {TextFieldProps} from './index';
 import formValidators from './validators';
@@ -74,4 +74,12 @@ export function shouldHidePlaceholder({floatingPlaceholder, hint, floatOnFocus}:
   } else {
     return false;
   }
+}
+
+export function shouldPlaceholderFloat({defaultValue, floatOnFocus}: FloatingPlaceholderProps,
+  isFocused: boolean,
+  hasValue: boolean,
+  value?: string) {
+  const useDefaultValue = !_.isEmpty(defaultValue) && value === undefined; // To consider a user that has deleted the defaultValue (and then the placeholder should un-float when losing focus)
+  return (floatOnFocus && isFocused) || hasValue || useDefaultValue;
 }

--- a/src/incubator/TextField/index.tsx
+++ b/src/incubator/TextField/index.tsx
@@ -125,6 +125,7 @@ const TextField = (props: InternalTextFieldProps) => {
           <View flexG /* flex row */>
             {floatingPlaceholder && (
               <FloatingPlaceholder
+                defaultValue={others.defaultValue}
                 placeholder={placeholder}
                 floatingPlaceholderStyle={_floatingPlaceholderStyle}
                 floatingPlaceholderColor={floatingPlaceholderColor}

--- a/src/incubator/TextField/types.ts
+++ b/src/incubator/TextField/types.ts
@@ -86,6 +86,7 @@ export interface FloatingPlaceholderProps {
   floatOnFocus?: boolean;
   validationMessagePosition?: ValidationMessagePosition;
   extraOffset?: number;
+  defaultValue?: TextInputProps['defaultValue'];
   testID: string;
 }
 
@@ -142,7 +143,7 @@ export interface InputProps
   /**
    * Use react-native-gesture-handler instead of react-native for the base TextInput
    */
-   useGestureHandlerInput?: boolean;
+  useGestureHandlerInput?: boolean;
 }
 
 export type TextFieldProps = MarginModifiers &


### PR DESCRIPTION
## Description
Incubator.TextField - FloatingPlaceholder should float with defaultValue
Adding `shouldFloat` and fixing its logic

WOAUILIB-3123

Handling edge cases, using the below `PlaygroundScreen`:
1. Switching between `TextField`s should:
    a. float\un-float if both are empty
    b. float\un-float on an empty one and remain un-floated on one with a `value` \ `defaultValue`
2. Changing `defaultValue` should affect the floating status
3. Deleting the `defaultValue` (to an empty `value`) should un-float

```
import React, {Component} from 'react';
import {View, Text, Card, Incubator, Button} from 'react-native-ui-lib';

export default class PlaygroundScreen extends Component {
  state = {
    defaultValue: 'initial value'
  };
  render() {
    return (
      <View bg-grey80 flex padding-20>
        <View marginT-20>
          <Incubator.TextField
            migrate
            marginH-s5
            placeholder={'placeholder'}
            defaultValue={this.state.defaultValue}
            floatingPlaceholder
            floatOnFocus
          />
          <Incubator.TextField migrate marginH-s5 placeholder={'placeholder'} floatingPlaceholder floatOnFocus/>
        </View>
        <Card height={100} center padding-20>
          <Text text50>Playground Screen</Text>
        </Card>
        <View flex center>
          <Button
            marginV-20
            label="Button"
            onPress={() => {
              this.setState({defaultValue: undefined});
            }}
          />
        </View>
      </View>
    );
  }
}
```


## Changelog
Incubator.TextField - FloatingPlaceholder should float with defaultValue