### PR TITLE
Feat/sortable list separators

### DIFF
--- a/src/components/sortableList/SortableListItem.tsx
+++ b/src/components/sortableList/SortableListItem.tsx
@@ -44,6 +44,7 @@ const SortableListItem = (props: Props) => {
   const {getTranslationByIndexChange, getItemIndexById, getIndexByPosition, getIdByItemIndex} = usePresenter();
   const id: string = data[index].id;
   const locked: boolean = data[index].locked;
+  const separator: boolean = data[index].separator;
   const initialIndex = useSharedValue<number>(map(data, 'id').indexOf(id));
   const currIndex = useSharedValue(initialIndex.value);
   const translateY = useSharedValue<number>(0);
@@ -78,7 +79,7 @@ const SortableListItem = (props: Props) => {
 
   const dragOnLongPressGesture = Gesture.Pan()
     .activateAfterLongPress(250)
-    .enabled(!locked)
+    .enabled(!locked && !separator)
     .onStart(() => {
       isDragging.value = true;
       translateY.value = getTranslationByIndexChange(currIndex.value, initialIndex.value, itemHeight.value);

--- a/src/components/sortableList/types.ts
+++ b/src/components/sortableList/types.ts
@@ -4,6 +4,7 @@ import {SortableListContextType} from './SortableListContext';
 export interface SortableListItemProps {
   id: string;
   locked?: boolean;
+  separator?: boolean;
 }
 
 // Internal


### PR DESCRIPTION
## Description
A common usage of sortable lists is to let the users move items between two or more lists. Usually, such lists are indicated by separator elements. An example of the intended functionality can be found [here](https://ionic-lzraml.stackblitz.io/). This was made using Ionic which also has a sortable list implementation and the example's source can be found [here](https://stackblitz.com/edit/ionic-lzraml?file=src/app/example.component.html).

If I'm not missing out on something, doing this with RNUILib is impossible until now.

Only 3 lines need to change to support something like this. The above example can be reproduced with this data array passed to SortableList:
```
const data: SortableListItemProps[] = [
    {
      id: 'list1',
      separator: true
    },
    {
      id: 'item1'
    },
    {
      id: 'item2'
    },
    {
      id: 'item3'
    },
    {
      id: 'list2',
      separator: true
    },
    {
      id: 'item4'
    },
    {
      id: 'item5'
    }
  ];
```
Almost always, the first separator must be locked at the top. With this implementation, both locked and separator fields can be set to true to provide this functionality.

## Changelog
Add `separator?: boolean` in `SortableListItemProps`
