### PR TITLE
Fix dummyPlaceholder style

### DIFF
--- a/src/incubator/TextField/index.tsx
+++ b/src/incubator/TextField/index.tsx
@@ -109,6 +109,9 @@ const TextField = (props: InternalTextFieldProps) => {
   const inputStyle = useMemo(() => {
     return [typographyStyle, colorStyle, others.style, centered && styles.centeredInput];
   }, [typographyStyle, colorStyle, others.style, centered]);
+  const dummyPlaceholderStyle = useMemo(() => {
+    return [inputStyle, styles.dummyPlaceholder];
+  }, [inputStyle]);
 
   return (
     <FieldContext.Provider value={context}>
@@ -140,7 +143,7 @@ const TextField = (props: InternalTextFieldProps) => {
             <View flex={!centered && !inline}>
               {/* Note: Render dummy placeholder for Android center issues */}
               {Constants.isAndroid && (centered || inline) && (
-                <Text marginR-s1 style={styles.dummyPlaceholder}>
+                <Text marginR-s1 style={dummyPlaceholderStyle}>
                   {placeholder}
                 </Text>
               )}


### PR DESCRIPTION
## Description
After looking at `MainInput` size issue we've discussed, I think the dummy placeholder should have the `inputStyle` for the typography.
Technically it can be `[typographyStyle, others.style, styles.dummyPlaceholder]` but I think that will be less clear.

## Changelog
Fix dummyPlaceholder style