### PR TITLE
Fix react-native-colors error when start the webDemo app

### DIFF
--- a/webDemo/webpack.config.js
+++ b/webDemo/webpack.config.js
@@ -21,6 +21,7 @@ const baseProjectSource = [
   path.resolve(appDirectory, 'node_modules/@react-native-community/picker'),
   path.resolve(appDirectory, 'node_modules/@react-native-community/netinfo'),
   path.resolve(appDirectory, 'node_modules/@react-native-community/datetimepicker'),
+  path.resolve(appDirectory, 'node_modules/react-native-color'),
   path.resolve(appDirectory, 'node_modules/react-native-ui-lib')
 ];
 


### PR DESCRIPTION
## Description
webDemo app error fix.

## Changelog
webDemo app `react-native-colors` error fix by adding the repo path to the `webpack` config file.