### PR TITLE
Fix/ Avatar renderRibbon

### DIFF
--- a/src/components/avatar/index.tsx
+++ b/src/components/avatar/index.tsx
@@ -330,7 +330,7 @@ const Avatar = forwardRef<any, AvatarProps>((props: AvatarProps, ref: React.Forw
   };
 
   const renderRibbon = () => {
-    if (ribbonLabel) {
+    if (!customRibbon && ribbonLabel) {
       return (
         <View style={_ribbonStyle}>
           <Text numberOfLines={1} text100 $textDefaultLight style={ribbonLabelStyle}>


### PR DESCRIPTION
## Description
Avatar - don't render ribbon when there's a custom ribbon
(the bug is visible on the private's avatar screen, on master, and on production) 

## Changelog
Avatar - don't render ribbon when there's a custom ribbon
