### PR TITLE
Remove flex from TextField validation message in centered mode

### DIFF
--- a/src/incubator/TextField/index.tsx
+++ b/src/incubator/TextField/index.tsx
@@ -224,7 +224,6 @@ const styles = StyleSheet.create({
     textAlign: 'center'
   },
   centeredValidationMessage: {
-    flexGrow: 1,
     textAlign: 'center'
   },
   dummyPlaceholder: {


### PR DESCRIPTION
## Description
When passing `centered` to TextField it flexes the validation message element and in some layouts it stretches the whole field

## Changelog
Fix flex issue in TextField validation message when passing centered 
