### PR TITLE
WebDemo app now have ActionSheet example, Modal TouchableWithoutFeedb…

### DIFF
--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -80,7 +80,7 @@ class Modal extends Component<ModalProps> {
   renderTouchableOverlay() {
     const {testID, overlayBackgroundColor, onBackgroundPress, accessibilityLabel = 'Dismiss'} = this.props;
     if (_.isFunction(onBackgroundPress) || !!overlayBackgroundColor) {
-      const isScreenReaderEnabled = Constants.accessibility.isScreenReaderEnabled;
+      const isScreenReaderEnabled = Constants.isWeb ? false : Constants.accessibility.isScreenReaderEnabled;
       const accessibilityProps = isScreenReaderEnabled
         ? {accessible: true, accessibilityLabel, accessibilityRole: 'button'}
         : undefined;

--- a/webDemo/src/App.tsx
+++ b/webDemo/src/App.tsx
@@ -17,6 +17,7 @@ import ProgressBar from 'react-native-ui-lib/ProgressBar';
 import AnimatedImage from 'react-native-ui-lib/AnimatedImage';
 import Avatar from 'react-native-ui-lib/Avatar';
 import Drawer from 'react-native-ui-lib/Drawer';
+import ActionSheet from 'react-native-ui-lib/ActionSheet';
 
 import {
   Colors,
@@ -304,6 +305,37 @@ const itemsToRender: ItemToRender[] = [
   {
     title: 'Picker',
     FC: Picker
+  },
+  {
+    title: 'ActionSheet',
+    FC: () => {
+      const [showCustom, setShowCustom] = useState(false);
+      return (
+        <View>
+          <Button
+            label={'Open ActionSheet'}
+            size={Button.sizes.medium}
+            onPress={() => {
+              setShowCustom(true);
+            }}
+          />
+          <ActionSheet
+            title={'Title'}
+            message={'Message of action sheet'}
+            destructiveButtonIndex={0}
+            useNativeIOS={false}
+            migrateDialog
+            options={[
+              {label: 'option 1', onPress: () => alert('Option 1 selected!')},
+              {label: 'option 2', onPress: () => alert('Option 3 selected!')},
+              {label: 'option 3', onPress: () => alert('Option 3 selected!')}
+            ]}
+            visible={showCustom}
+            onDismiss={() => setShowCustom(false)}
+          />
+        </View>
+      );
+    }
   },
   {
     title: 'Date',


### PR DESCRIPTION
## Description
WebDemo new ActionSheet example.
Modal close on overly background press fixed on the web.

## Changelog
Modal close on background press fixed on the web, isScreenReaderEnabled modified for the web.