### PR TITLE
Bump SVG package

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "react-native-navigation": "7.30.0",
     "react-native-reanimated": "2.13.0",
     "react-native-shimmer-placeholder": "^2.0.6",
-    "react-native-svg": "^12.1.0",
+    "react-native-svg": "^13.7.0",
     "react-native-svg-transformer": "^0.14.3",
     "react-test-renderer": "^17.0.1",
     "reassure": "^0.4.1",


### PR DESCRIPTION
## Description
Version bump fixes transparent SVG's paths. Currently paths without **fill** property are rendered transparent instead of black (browsers fallbacks to black in this case). In updated version this bug has been fixed with this PR: https://github.com/software-mansion/react-native-svg/pull/1947

![outdated-rnu](https://user-images.githubusercontent.com/44223680/212064528-f220a7dc-e22a-463c-ae1a-a13ea6d4ae6d.jpg)
![updated-rnu](https://user-images.githubusercontent.com/44223680/212064536-4436ce7c-7fb7-4efe-b9bc-55ef87c1a70b.jpg)


## Changelog
Bumped react-native-svg package
