### PR TITLE
Tests/incubator dialog support headless tests

### DIFF
--- a/src/incubator/Dialog/index.tsx
+++ b/src/incubator/Dialog/index.tsx
@@ -17,6 +17,7 @@ import {
   PanGestureHandlerEventPayload
 } from 'react-native-gesture-handler';
 import {Spacings, Colors, BorderRadiuses} from '../../style';
+import {useDidUpdate} from '../../hooks';
 import {asBaseComponent} from '../../commons/new';
 import View from '../../components/view';
 import Modal from '../../components/modal';
@@ -108,7 +109,7 @@ const Dialog = (props: DialogProps, ref: ForwardedRef<DialogImperativeMethods>) 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visible, wasMeasured]);
 
-  useEffect(() => {
+  useDidUpdate(() => {
     if (wasMeasured) {
       if (modalVisibility) {
         open();

--- a/src/incubator/hooks/useHiddenLocation.ts
+++ b/src/incubator/hooks/useHiddenLocation.ts
@@ -10,13 +10,16 @@ export interface HiddenLocation extends HiddenLocationRecord {
   wasMeasured: boolean;
 }
 
+// Adding this for headless tests that are not triggering onLayout
+const wasMeasuredDefaultValue = global?.describe !== undefined ?? false;
+
 export default function useHiddenLocation<T extends View>() {
   const getHiddenLocation = ({
     x = 0,
     y = 0,
     width = Constants.screenWidth,
     height = Constants.windowHeight,
-    wasMeasured = false
+    wasMeasured = wasMeasuredDefaultValue
   }): HiddenLocation => {
     return {
       up: -y - height,
@@ -30,7 +33,7 @@ export default function useHiddenLocation<T extends View>() {
   const [hiddenLocation, setHiddenLocation] = useState<HiddenLocation>(getHiddenLocation({}));
   const ref = useRef<T>();
   const layoutData = useRef<LayoutRectangle>();
-  const wasMeasured = useRef(false);
+  const wasMeasured = useRef(wasMeasuredDefaultValue);
 
   const measure = useCallback(() => {
     if (ref.current && layoutData.current && layoutData.current.width > 0 && layoutData.current.height > 0) {


### PR DESCRIPTION
## Description
Change `useEffect` to `useDidUpdate`:  this is done in case the user has something like `onDismiss={() => this.toggleVisibility()}` (`VisualPickerScreen`) and if `wasMeasured` is true from the start (tests and future proofing).

Setting `wasMeasured` to `true` in testing env, this is done because headless tests do not trigger `onLayout` which means the `ActionSheet` cannot be closed via item click.

## Changelog
Incubator.Dialog - support headless tests