### PR TITLE
Checkbox + RadioButton - fix long labels are stretching outside

### DIFF
--- a/src/components/checkbox/index.tsx
+++ b/src/components/checkbox/index.tsx
@@ -242,7 +242,7 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
     return label ? (
       <View row centerV style={containerStyle}>
         {this.renderCheckbox()}
-        <Text style={[this.styles.checkboxLabel, labelStyle]} {...labelProps} onPress={this.onPress}>
+        <Text flexS style={[this.styles.checkboxLabel, labelStyle]} {...labelProps} onPress={this.onPress}>
           {label}
         </Text>
       </View>
@@ -275,7 +275,7 @@ function createStyles(props: CheckboxProps) {
       justifyContent: 'center'
     },
     checkboxLabel: {
-      marginHorizontal: Spacings.s3,
+      marginLeft: Spacings.s3,
       alignSelf: 'center',
       color: Colors.$textDefault
     }

--- a/src/components/checkbox/index.tsx
+++ b/src/components/checkbox/index.tsx
@@ -240,7 +240,7 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
   render() {
     const {label, labelStyle, containerStyle, labelProps} = this.props;
     return label ? (
-      <View row centerV style={[containerStyle]}>
+      <View row centerV style={containerStyle}>
         {this.renderCheckbox()}
         <Text style={[this.styles.checkboxLabel, labelStyle]} {...labelProps} onPress={this.onPress}>
           {label}
@@ -275,7 +275,7 @@ function createStyles(props: CheckboxProps) {
       justifyContent: 'center'
     },
     checkboxLabel: {
-      marginLeft: Spacings.s3,
+      marginHorizontal: Spacings.s3,
       alignSelf: 'center',
       color: Colors.$textDefault
     }

--- a/src/components/radioButton/index.tsx
+++ b/src/components/radioButton/index.tsx
@@ -230,7 +230,7 @@ class RadioButton extends PureComponent<Props, RadioButtonState> {
     const {label, labelStyle, testID} = this.props;
     return (
       label && (
-        <Text marginL-10={!this.isContentOnLeft} marginR-10 $textDefault style={labelStyle} testID={`${testID}.label`}>
+        <Text flexS marginL-10={!this.isContentOnLeft} marginR-10={this.isContentOnLeft} $textDefault style={labelStyle} testID={`${testID}.label`}>
           {label}
         </Text>
       )

--- a/src/components/radioButton/index.tsx
+++ b/src/components/radioButton/index.tsx
@@ -141,6 +141,7 @@ class RadioButton extends PureComponent<Props, RadioButtonState> {
     const {opacityAnimationValue, scaleAnimationValue} = this.state;
     const animationTime = 150;
     const animationDelay = 60;
+    
     if (selected) {
       Animated.parallel([
         Animated.timing(opacityAnimationValue, {
@@ -229,7 +230,7 @@ class RadioButton extends PureComponent<Props, RadioButtonState> {
     const {label, labelStyle, testID} = this.props;
     return (
       label && (
-        <Text marginL-10={!this.isContentOnLeft} marginR-10={this.isContentOnLeft} $textDefault style={labelStyle} testID={`${testID}.label`}>
+        <Text marginL-10={!this.isContentOnLeft} marginR-10 $textDefault style={labelStyle} testID={`${testID}.label`}>
           {label}
         </Text>
       )


### PR DESCRIPTION
## Description
Checkbox + RadioButton - fix long labels are stretching outside their container

## Changelog
Checkbox + RadioButton - fix long labels are stretching outside their container
