### PR TITLE
fix: touchable opacity press handlers typing

### DIFF
--- a/src/components/touchableOpacity/index.tsx
+++ b/src/components/touchableOpacity/index.tsx
@@ -44,9 +44,9 @@ export interface TouchableOpacityProps
   customValue?: any;
   style?: ViewProps['style'];
   onPress?: (props?: TouchableOpacityProps | any) => void;
-  onPressIn?: (props?: TouchableOpacityProps) => void | RNTouchableOpacityProps['onPressIn'];
-  onPressOut?: (props?: TouchableOpacityProps) => void | RNTouchableOpacityProps['onPressOut'];
-  onLongPress?: (props?: TouchableOpacityProps) => void | RNTouchableOpacityProps['onLongPress'];
+  onPressIn?: (props?: TouchableOpacityProps | any) => void | RNTouchableOpacityProps['onPressIn'];
+  onPressOut?: (props?: TouchableOpacityProps | any) => void | RNTouchableOpacityProps['onPressOut'];
+  onLongPress?: (props?: TouchableOpacityProps | any) => void | RNTouchableOpacityProps['onLongPress'];
 }
 
 type Props = BaseComponentInjectedProps & ForwardRefInjectedProps & TouchableOpacityProps;

--- a/webDemo/src/examples/Picker.tsx
+++ b/webDemo/src/examples/Picker.tsx
@@ -23,6 +23,7 @@ const PickerWrapper = () => {
       onChange={setLanguage}
       topBarProps={{title: 'Languages'}}
       showSearch
+      fieldType={Picker.fieldTypes.filter}
       searchPlaceholder={'Search a language'}
       searchStyle={{color: Colors.blue30, placeholderTextColor: Colors.grey50}}
       migrateTextField


### PR DESCRIPTION
## Description
touchable opacity `onLongPress` handler pass also event, and `onPressIn` & `onPressOut` also pass it when no customValue.

## Changelog
fix TouchableOpacity press handlers typing
