### PR TITLE
fix: TextField package exports TextFieldMigrator

### DIFF
--- a/scripts/buildPackages.js
+++ b/scripts/buildPackages.js
@@ -15,6 +15,10 @@ const packages = [
     content: `module.exports = require('./src/commons/Constants').default;\n`
   },
   {
+    filename: 'textField.js',
+    content: `module.exports = require('./src/components/textField/TextFieldMigrator').default;\n`
+  },
+  {
     filename: 'core.js',
     components: ['View', 'Text', 'Image', 'TouchableOpacity', 'Button'],
     styleComponents: [

--- a/scripts/buildPackages/buildComponentsPackages.js
+++ b/scripts/buildPackages/buildComponentsPackages.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const _ = require('lodash');
+
+/* Write all components as separate packages */
+const path = './src/components';
+fs.readdir(path, (err, files) => {
+  if (!err) {
+    files
+      .filter((f) => f !== 'index.js')
+      .forEach((file) => {
+        fs.writeFileSync(`${file}.js`,
+          `module.exports = require('${path}/${file}').default;\n`);
+        const componentName = _.upperFirst(file);
+        fs.writeFileSync(`${file}.d.ts`,
+          `import {${componentName}} from './src';\nexport default ${componentName};\n`);
+      });
+  }
+});

--- a/scripts/buildPackages/buildCustomPackages.js
+++ b/scripts/buildPackages/buildCustomPackages.js
@@ -88,19 +88,3 @@ packages.forEach((package) => {
     fs.writeFileSync(filename, typings);
   }
 });
-
-/* Write all components as separate packages */
-const path = './src/components';
-fs.readdir(path, (err, files) => {
-  if (!err) {
-    files
-      .filter((f) => f !== 'index.js')
-      .forEach((file) => {
-        fs.writeFileSync(`${file}.js`,
-          `module.exports = require('${path}/${file}').default;\n`);
-        const componentName = _.upperFirst(file);
-        fs.writeFileSync(`${file}.d.ts`,
-          `import {${componentName}} from './src';\nexport default ${componentName};\n`);
-      });
-  }
-});

--- a/scripts/buildPackages/index.js
+++ b/scripts/buildPackages/index.js
@@ -1,0 +1,6 @@
+const childProcess = require('child_process');
+
+const path = 'scripts/buildPackages';
+
+childProcess.execSync(`node ${path}/buildComponentsPackages`);
+childProcess.execSync(`node ${path}/buildCustomPackages`);


### PR DESCRIPTION
## Description
TextField package should `TextFieldMigrator` instead of `index.ts`

## Changelog
TextField package exports TextFieldMigrator instead of index
