### PR TITLE
Incubator.TextField - handle long validationMessage with char count

### DIFF
--- a/src/incubator/TextField/ValidationMessage.tsx
+++ b/src/incubator/TextField/ValidationMessage.tsx
@@ -33,6 +33,7 @@ const ValidationMessage = ({
 
 const styles = StyleSheet.create({
   validationMessage: {
+    flexShrink: 1,
     minHeight: 20
   }
 });


### PR DESCRIPTION
## Description
Incubator.TextField - handle long validationMessage with char count
Use the following example to reproduce:
```
<TextField
  placeholder={'bla'}
  migrate
  showCharCounter
  maxLength={100}
  validateOnStart
  validate={['required']}
  validationMessage={['Really long validation message with character counter nearby it']}
/>
```

WOAUILIB-3387

## Changelog
Incubator.TextField - handle long validationMessage with char count
