### PR TITLE
Fixes broken link :: React Native Gesture Handler

### DIFF
--- a/src/components/drawer/index.tsx
+++ b/src/components/drawer/index.tsx
@@ -133,7 +133,7 @@ interface DrawerProps {
  * @description: Drawer Component
  * @important: If your app works with RNN, your screen must be wrapped
  * with gestureHandlerRootHOC from 'react-native-gesture-handler'. see
- * @importantLink: https://kmagiera.github.io/react-native-gesture-handler/docs/getting-started.html#with-wix-react-native-navigation-https-githubcom-wix-react-native-navigation
+ * @importantLink: https://docs.swmansion.com/react-native-gesture-handler/docs/installation/
  * @gif: https://github.com/wix/react-native-ui-lib/blob/master/demo/showcase/Drawer/Drawer.gif?raw=true
  */
 class Drawer extends PureComponent<DrawerProps> {


### PR DESCRIPTION
## Description
A broken link to [React Native Gesture Handler](https://docs.swmansion.com/react-native-gesture-handler/) is fixed.

## Changelog
Drawer component

---------

Before:

<img width="1390" alt="Screenshot 2023-02-12 at 16 44 42" src="https://user-images.githubusercontent.com/17321286/218321632-3931ee4a-bef4-4ae2-bf6d-632f2f31f7eb.png">


After:

<img width="1211" alt="Screenshot 2023-02-12 at 16 45 28" src="https://user-images.githubusercontent.com/17321286/218321637-57854cbb-937e-4697-84c4-d455652e836f.png">


