### PR TITLE
feat: extended styling options for segments

### DIFF
--- a/src/components/segmentedControl/index.tsx
+++ b/src/components/segmentedControl/index.tsx
@@ -68,6 +68,10 @@ export type SegmentedControlProps = {
    */
   iconOnRight?: boolean;
   /**
+   * Should segments fill parent's height
+   */
+  fillParentY?: boolean;
+  /**
    * Trailing throttle time of changing index in ms.
    */
   throttleTime?: number;
@@ -97,6 +101,7 @@ const SegmentedControl = (props: SegmentedControlProps) => {
     inactiveColor = Colors.$textNeutralHeavy,
     outlineColor = activeColor,
     outlineWidth = BORDER_WIDTH,
+    fillParentY,
     throttleTime = 0,
     testID
   } = props;
@@ -164,6 +169,7 @@ const SegmentedControl = (props: SegmentedControlProps) => {
           selectedIndex={animatedSelectedIndex}
           activeColor={activeColor}
           inactiveColor={inactiveColor}
+          fillContainerY={fillParentY}
           {...segments?.[index]}
           testID={testID}
         />

--- a/src/components/segmentedControl/segment.tsx
+++ b/src/components/segmentedControl/segment.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useMemo} from 'react';
-import {LayoutChangeEvent, ImageSourcePropType, ImageStyle, StyleProp} from 'react-native';
+import {LayoutChangeEvent, ImageSourcePropType, ImageStyle, StyleProp, ViewStyle} from 'react-native';
 import Reanimated, {useAnimatedStyle} from 'react-native-reanimated';
 import {Spacings, Typography} from '../../style';
 import {asBaseComponent} from '../../commons/new';
@@ -22,6 +22,14 @@ export type SegmentedControlItemProps = {
    * Should the icon be on right of the label
    */
   iconOnRight?: boolean;
+  /**
+   * Should segment fill container vertically
+   */
+  fillContainerY?: boolean;
+  /**
+   * Additional styling for the segment
+   */
+  style?: StyleProp<ViewStyle>;
 };
 
 export type SegmentProps = SegmentedControlItemProps & {
@@ -67,6 +75,8 @@ const Segment = React.memo((props: SegmentProps) => {
     inactiveColor,
     index,
     iconOnRight,
+    fillContainerY,
+    style,
     testID
   } = props;
 
@@ -80,7 +90,7 @@ const Segment = React.memo((props: SegmentProps) => {
     return {tintColor};
   });
 
-  const segmentStyle = useMemo(() => ({paddingHorizontal: Spacings.s3, paddingVertical: Spacings.s2}), []);
+  const segmentStyle = useMemo(() => [{paddingHorizontal: Spacings.s3, paddingVertical: Spacings.s2, ...(fillContainerY && {height: '100%'})}, style], [fillContainerY, style]);
 
   const renderIcon = useCallback(() => {
     return iconSource && <Reanimated.Image source={iconSource} style={[animatedIconStyle, iconStyle]}/>;

--- a/src/components/segmentedControl/segmentedControl.api.json
+++ b/src/components/segmentedControl/segmentedControl.api.json
@@ -17,6 +17,7 @@
     {"name": "iconOnRight", "type": "boolean", "description": "Should the icon be on right of the label"},
     {"name": "throttleTime", "type": "number", "description": "Trailing throttle time of changing index in ms."},
     {"name": "containerStyle", "type": "ViewStyle", "description": "Additional spacing styles for the container"},
+    {"name": "fillParentY", "type": "boolean", "description": "Should segments fill parent's height"},
     {"name": "style", "type": "ViewStyle", "description": "Custom style to inner container"},
     {"name": "testID", "type": "string", "description": "Component test id"}
   ],


### PR DESCRIPTION
## Description

- Added option to pass _styling_ directly to the _Segment_ component.
- Added setting for adjusting _Segment_'s height to parent's.

For providing users more control over _SegmentedControl's_ (_Segment_) styling.

<img src="https://user-images.githubusercontent.com/37552166/218509253-89cbbb94-06ef-45e4-881b-d7ee3b2ec0fa.png" width="35%" alt="Simulator Screen Shot – iPhone 14 Pro">


## Changelog
- Added option to provide _styling_ directly to the Segment component via SegmentedControlItemProps.
- Added setting for adjusting to parent's height (e.g., segment's height to 100%) via SegmentedControlItemProps.
