### PR TITLE
V7_KeyboardAccessoryView - remove 'iOSScrollBehavior' prop

### DIFF
--- a/lib/components/Keyboard/KeyboardInput/KeyboardAccessoryView.tsx
+++ b/lib/components/Keyboard/KeyboardInput/KeyboardAccessoryView.tsx
@@ -9,7 +9,6 @@ import {
   BackHandler,
   LayoutChangeEvent
 } from 'react-native';
-import {LogService} from '../../../../src/services';
 import KeyboardTrackingView, {KeyboardTrackingViewProps} from '../KeyboardTracking/KeyboardTrackingView';
 import CustomKeyboardView from './CustomKeyboardView';
 import KeyboardUtils from './utils/KeyboardUtils';
@@ -63,9 +62,6 @@ export type KeyboardAccessoryViewProps = kbTrackingViewProps & {
  * @gif: https://github.com/wix/react-native-ui-lib/blob/master/demo/showcase/KeyboardAccessoryView/KeyboardAccessoryView.gif?raw=true
  */
 class KeyboardAccessoryView extends Component<KeyboardAccessoryViewProps> {
-  /**
-   * @deprecated Please use KeyboardAccessoryView.scrollBehaviors instead
-   */
   static scrollBehaviors = KeyboardTrackingView.scrollBehaviors;
 
   static defaultProps = {

--- a/lib/components/Keyboard/KeyboardInput/KeyboardAccessoryView.tsx
+++ b/lib/components/Keyboard/KeyboardInput/KeyboardAccessoryView.tsx
@@ -54,12 +54,6 @@ export type KeyboardAccessoryViewProps = kbTrackingViewProps & {
    * Callback that will be called once the keyboard has been closed
    */
   onKeyboardResigned?: () => void;
-  /**
-   * @deprecated
-   * Please use 'scrollBehavior' prop instead
-   * The scrolling behavior (use KeyboardAccessoryView.scrollBehaviors.NONE | SCROLL_TO_BOTTOM_INVERTED_ONLY | FIXED_OFFSET)
-   */
-  iOSScrollBehavior?: number;
   children?: React.ReactChild;
 };
 
@@ -72,7 +66,6 @@ class KeyboardAccessoryView extends Component<KeyboardAccessoryViewProps> {
   /**
    * @deprecated Please use KeyboardAccessoryView.scrollBehaviors instead
    */
-  static iosScrollBehaviors = KeyboardTrackingView.scrollBehaviors; //TODO: remove on V7
   static scrollBehaviors = KeyboardTrackingView.scrollBehaviors;
 
   static defaultProps = {
@@ -99,12 +92,6 @@ class KeyboardAccessoryView extends Component<KeyboardAccessoryViewProps> {
 
     this.registerForKeyboardResignedEvent();
     this.registerAndroidBackHandler();
-
-    if (props.iOSScrollBehavior) {
-      LogService.warn(`The 'Keyboard.KeyboardAccessoryView' component's prop 'iOSScrollBehavior' is deprecated. 
-        Please use 'scrollBehavior' prop instead and pass it 'Keyboard.KeyboardAccessoryView.scrollBehaviors' 
-        ('Keyboard.KeyboardAccessoryView.iosScrollBehaviors' enum is deprecated).`);
-    }
   }
 
   componentWillUnmount() {
@@ -193,14 +180,13 @@ class KeyboardAccessoryView extends Component<KeyboardAccessoryViewProps> {
       onItemSelected,
       onRequestShowKeyboard,
       scrollBehavior,
-      iOSScrollBehavior,
       ...others
     } = this.props;
 
     return (
       <KeyboardTrackingView
         {...others}
-        scrollBehavior={IsIOS ? iOSScrollBehavior || scrollBehavior : undefined}
+        scrollBehavior={scrollBehavior}
         ref={(r: any) => (this.trackingViewRef = r)}
         style={styles.trackingToolbarContainer}
         onLayout={this.onContainerComponentHeightChanged}


### PR DESCRIPTION
## Description
V7_KeyboardAccessoryView - remove 'iOSScrollBehavior' prop and 'iosScrollBehaviors' enum

## Changelog
V7_KeyboardAccessoryView - remove 'iOSScrollBehavior' prop and 'iosScrollBehaviors' enum (use 'scrollBehavior' prop instead and pass it 'Keyboard.KeyboardAccessoryView.scrollBehaviors' )
