### PR TITLE
V7 date time picker

### DIFF
--- a/src/components/dateTimePicker/index.tsx
+++ b/src/components/dateTimePicker/index.tsx
@@ -137,7 +137,7 @@ function DateTimePicker(props: DateTimePickerPropsInternal) {
     // @ts-expect-error
     useCustomTheme,
     testID,
-    migrateTextField,
+    migrateTextField = true,
     ...others
   } = props;
 


### PR DESCRIPTION
## Description
Enable text field migration by default in DateTimePicker

## Changelog
Enable text field migration by default in DateTimePicker