### PR TITLE
Add migration to TextField errorMessage and fix validationMessagePosition type

### DIFF
--- a/src/components/textField/TextFieldMigrator.tsx
+++ b/src/components/textField/TextFieldMigrator.tsx
@@ -17,7 +17,8 @@ const propsMigrationMap: Dictionary<string> = {
   titleStyle: 'labelStyle',
   /* CHAR COUNTER */
   showCharacterCounter: 'showCharCounter',
-  transformer: 'formatter'
+  transformer: 'formatter',
+  errorMessage: 'validationMessage'
 };
 
 const specialMigrationMap: Dictionary<string> = {

--- a/src/incubator/TextField/index.tsx
+++ b/src/incubator/TextField/index.tsx
@@ -213,7 +213,13 @@ const TextField = (props: InternalTextFieldProps) => {
 TextField.displayName = 'Incubator.TextField';
 TextField.validationMessagePositions = ValidationMessagePosition;
 
-export {TextFieldProps, FieldContextType, StaticMembers as TextFieldStaticMembers, TextFieldMethods};
+export {
+  TextFieldProps,
+  FieldContextType,
+  StaticMembers as TextFieldStaticMembers,
+  TextFieldMethods,
+  ValidationMessagePosition as TextFieldValidationMessagePosition
+};
 export default asBaseComponent<TextFieldProps, StaticMembers>(forwardRef(TextField as any), {
   modifiersOptions: {
     margins: true,

--- a/src/incubator/TextField/types.ts
+++ b/src/incubator/TextField/types.ts
@@ -26,6 +26,8 @@ export enum ValidationMessagePosition {
   BOTTOM = 'bottom'
 }
 
+type ValidationMessagePositionType = `${ValidationMessagePosition}` | ValidationMessagePosition;
+
 export type Validator = Function | keyof typeof formValidators;
 
 export interface FieldStateProps extends InputProps {
@@ -63,7 +65,7 @@ export interface LabelProps {
    * Pass extra props to the label Text element
    */
   labelProps?: TextProps;
-  validationMessagePosition?: ValidationMessagePosition;
+  validationMessagePosition?: ValidationMessagePositionType;
   floatingPlaceholder?: boolean;
   testID?: string;
 }
@@ -85,7 +87,7 @@ export interface FloatingPlaceholderProps {
    * Should placeholder float on focus or when start typing
    */
   floatOnFocus?: boolean;
-  validationMessagePosition?: ValidationMessagePosition;
+  validationMessagePosition?: ValidationMessagePositionType;
   extraOffset?: number;
   defaultValue?: TextInputProps['defaultValue'];
   testID: string;
@@ -205,7 +207,7 @@ export type TextFieldProps = MarginModifiers &
     /**
      * The position of the validation message (top/bottom)
      */
-    validationMessagePosition?: ValidationMessagePosition;
+    validationMessagePosition?: ValidationMessagePositionType;
     /**
      * Internal style for the field container
      */

--- a/src/incubator/index.ts
+++ b/src/incubator/index.ts
@@ -1,7 +1,7 @@
 // export {default as Calendar} from './Calendar';
 export {default as ExpandableOverlay} from './expandableOverlay';
 // @ts-ignore
-export {default as TextField, TextFieldProps, FieldContextType, TextFieldMethods} from './TextField';
+export {default as TextField, TextFieldProps, FieldContextType, TextFieldMethods, TextFieldValidationMessagePosition} from './TextField';
 export {default as Toast, ToastProps, ToastPresets} from './toast';
 export {default as TouchableOpacity, TouchableOpacityProps} from './TouchableOpacity';
 export {default as PanView, PanViewProps, PanViewDirections, PanViewDismissThreshold} from './panView';

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import * as Incubator from './incubator';
 export {
   TextFieldProps,
   TextFieldMethods,
+  TextFieldValidationMessagePosition,
   FieldContextType,
   ToastProps,
   ToastPresets,


### PR DESCRIPTION
## Description
Fix migration of TextField errorMessage prop
Fix validationMessagePosition type to support literal strings

## Changelog
Add migration to TextField errorMessage and fix validationMessagePosition type