### PR TITLE
Support passing dark threshold for Colors.isDark

### DIFF
--- a/src/style/colors.ts
+++ b/src/style/colors.ts
@@ -273,10 +273,10 @@ export class Colors {
     return _.inRange(hue, 51, 184);
   }
 
-  isDark(colorValue: string | OpaqueColorValue) {
+  isDark(colorValue: string | OpaqueColorValue, darkThreshold = 0.55) {
     const color = colorValue === null ? undefined : colorStringValue(colorValue);
     const lum = tinycolor(color).getLuminance();
-    return lum < 0.55;
+    return lum < darkThreshold;
   }
   isValidHex(string: string) {
     return /(^#[0-9A-F]{6}$)|(^#[0-9A-F]{3}$)/i.test(string);


### PR DESCRIPTION
## Description
We have a use case where we want to check if a color is (very) dark. 
So I add a new argument for Colors.isDark to pass the dark threshold 

## Changelog
Support passing dark threshold to Colors.isDark
