### PR TITLE
Export the Keyboard's component as the documentation describes

### DIFF
--- a/keyboard.d.ts
+++ b/keyboard.d.ts
@@ -1,0 +1,2 @@
+import Keyboard from './lib/components/Keyboard';
+export = Keyboard;

--- a/keyboard.ts
+++ b/keyboard.ts
@@ -1,7 +1,0 @@
-import Keyboard from './lib/components/Keyboard';
-
-export const KeyboardTrackingView = Keyboard.KeyboardTrackingView;
-export const KeyboardAwareInsetsView = Keyboard.KeyboardAwareInsetsView;
-export const KeyboardRegistry = Keyboard.KeyboardRegistry;
-export const KeyboardAccessoryView = Keyboard.KeyboardAccessoryView;
-export const KeyboardUtils = Keyboard.KeyboardUtils;

--- a/keyboard.ts
+++ b/keyboard.ts
@@ -1,0 +1,7 @@
+import Keyboard from './lib/components/Keyboard';
+
+export const KeyboardTrackingView = Keyboard.KeyboardTrackingView;
+export const KeyboardAwareInsetsView = Keyboard.KeyboardAwareInsetsView;
+export const KeyboardRegistry = Keyboard.KeyboardRegistry;
+export const KeyboardAccessoryView = Keyboard.KeyboardAccessoryView;
+export const KeyboardUtils = Keyboard.KeyboardUtils;


### PR DESCRIPTION
## Description
*Enter description to help the reviewer understand what's the change about...*

Working with this library, I noticed that the components from the keyboard aren't imported as the documentation https://wix.github.io/react-native-ui-lib/docs/getting-started/setup#how-does-it-work

To resolve this issue I created a file keyboard.ts and exported each component as const. Now we can import as described
`import { KeyboardAccessoryView } from 'react-native-ui-lib/keyboard';`

Closes https://github.com/wix/react-native-ui-lib/issues/2494

## Changelog
*Add a quick message for our users about this change (include Component name, relevant props and general purpose of the PR)*
