### PR TITLE
Fix/ New DialogHeader conditions

### DIFF
--- a/src/incubator/Dialog/DialogHeader.tsx
+++ b/src/incubator/Dialog/DialogHeader.tsx
@@ -38,12 +38,12 @@ const DialogHeader = (props: DialogHeaderProps = {}) => {
     if (!isEmpty(title) || !isEmpty(subtitle)) {
       return (
         <Container onPress={onPress} center flex>
-          {title && (
+          {!isEmpty(title) && (
             <Text $textDefault {...titleProps} marginB-s3 style={titleStyle}>
               {title}
             </Text>
           )}
-          {subtitle && (
+          {!isEmpty(subtitle) && (
             <Text $textDefault {...subtitleProps} marginB-s3 style={subtitleStyle}>
               {subtitle}
             </Text>


### PR DESCRIPTION
## Description
There's an error when passing both the `title` and `subtitle` and one of them is an empty string
to reproduce, change the `headerProps` in the `incubatorDialogScreen` to `{title: 'Title (swipe here)', subtitle: ''};`



## Changelog
Fix new DialogHeader titles