### PR TITLE
Fix: Paths on migrating guide: text input and wheel picker

### DIFF
--- a/docs/getting-started/v7.md
+++ b/docs/getting-started/v7.md
@@ -118,7 +118,7 @@ Props migration:
 - `onToggleExpandableModal` 'prop is deprecated
 - `topBarProps` prop is deprecated
 
-Check full (and new) API: https://wix.github.io/react-native-ui-lib/docs/components/incubator/TextField
+Check full (and new) API: https://wix.github.io/react-native-ui-lib/docs/components/form/TextField
 
 ### WheelPicker
 The WheelPicker component has a new implementation. 
@@ -127,4 +127,4 @@ The component is now uncontrolled and have some prop changes:
 `onValueChange` prop renamed `onChange`.
 Also, `children` can now be passed to the `items` prop (not mandatory).
 
-Check full (and new) API: https://wix.github.io/react-native-ui-lib/docs/components/incubator/WheelPicker
+Check full (and new) API: https://wix.github.io/react-native-ui-lib/docs/components/form/WheelPicker


### PR DESCRIPTION
## Description
Both TextField and Wheelpicker have wrong links on docs, this PR fixes it

## Changelog
Fixed Paths on migrating guide: TextField and WheelPicker
