### PR TITLE
Do not pass flex to RN views (new flex shadow prop)

### DIFF
--- a/src/commons/asBaseComponent.tsx
+++ b/src/commons/asBaseComponent.tsx
@@ -66,7 +66,7 @@ function asBaseComponent<PROPS, STATICS = {}>(WrappedComponent: React.ComponentT
       const {forwardedRef, ...others} = themeProps;
       return (
         (this.state.error && UIComponent.defaultProps?.renderError) || (
-          <WrappedComponent {...others} modifiers={modifiers} ref={forwardedRef}/>
+          <WrappedComponent {...others} modifiers={modifiers} ref={forwardedRef} flex={undefined}/>
         )
       );
     }


### PR DESCRIPTION
## Description
Do not pass flex to RN views (new flex shadow prop)
This currently breaks at least one screen (`NumberInputScreen`).

## Changelog
⚠️ Do not pass flex to RN views (new flex shadow prop)