### PR TITLE
Fix/Chip - typo in src/components/chip/index.ts

### DIFF
--- a/src/components/chip/index.tsx
+++ b/src/components/chip/index.tsx
@@ -257,7 +257,7 @@ const Chip = ({
           }
           if (rightElement && leftElement) {
             return {
-              marginHorizontally: 2
+              marginHorizontal: 2
             };
           }
           if (iconSource || leftElement) {


### PR DESCRIPTION
## Description
Changed `marginHorizontally` to `marginHorizontal` to fix warning: 

> Failed %s type: %s%s, prop, Invalid props.style key `marginHorizontally` supplied to `Text`

## Changelog
Fixed margin for Chip component when both leftElement and rightElement are provided.
