### PR TITLE
Fix crash on Android following RN71 (flex shadow node)

### DIFF
--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -103,7 +103,20 @@ class Text extends PureComponent<PropsTypes> {
   }
 
   render() {
-    const {modifiers, style, center, uppercase, underline, children, forwardedRef, ...others} = this.props;
+    const {
+      // (!) extract flex prop to avoid passing them on Android
+      /* eslint-disable */
+      flex,
+      /* eslint-enable */
+      modifiers,
+      style,
+      center,
+      uppercase,
+      underline,
+      children,
+      forwardedRef,
+      ...others
+    } = this.props;
     const color = this.props.color || modifiers.color;
     const {margins, typography, backgroundColor, flexStyle} = modifiers;
     const textStyle = [
@@ -153,7 +166,6 @@ const styles = StyleSheet.create({
 });
 
 export {Text}; // For tests
-
 
 const modifiersOptions = {
   color: true,

--- a/src/incubator/TextField/Input.tsx
+++ b/src/incubator/TextField/Input.tsx
@@ -14,6 +14,11 @@ const DEFAULT_INPUT_COLOR: ColorType = {
 };
 
 const Input = ({
+  // (!) extract flex prop to avoid passing them on Android
+  /* eslint-disable */
+  // @ts-ignore (does not exist on props)
+  flex,
+  /* eslint-enable */
   style,
   hint,
   color = DEFAULT_INPUT_COLOR,


### PR DESCRIPTION
## Description
Fix crash on Android following RN71 (flex shadow node)
This currently breaks at least one screen (NumberInputScreen)

## Changelog
⚠️ Fix crash on Android following RN71 (flex shadow node)