### PR TITLE
Omit alignment props from passing forward to Text and TextInput components

### DIFF
--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -105,8 +105,17 @@ class Text extends PureComponent<PropsTypes> {
   render() {
     const {
       // (!) extract flex prop to avoid passing them on Android
+      // TODO: extract alignment (top, right, ...) props till we manage to exclude them from typings
       /* eslint-disable */
       flex,
+      // @ts-ignore
+      left,
+      // @ts-ignore
+      top,
+      // @ts-ignore
+      right,
+      // @ts-ignore
+      bottom,
       /* eslint-enable */
       modifiers,
       style,

--- a/src/incubator/TextField/Input.tsx
+++ b/src/incubator/TextField/Input.tsx
@@ -15,9 +15,18 @@ const DEFAULT_INPUT_COLOR: ColorType = {
 
 const Input = ({
   // (!) extract flex prop to avoid passing them on Android
+  // TODO: extract alignment (top, right, ...) props till we manage to exclude them from typings
   /* eslint-disable */
   // @ts-ignore (does not exist on props)
   flex,
+  // @ts-ignore
+  left,
+  // @ts-ignore
+  top,
+  // @ts-ignore
+  right,
+  // @ts-ignore
+  bottom,
   /* eslint-enable */
   style,
   hint,


### PR DESCRIPTION
## Description
Temporarily omit alignment props (top, left, right, bottom) from being passed on to Text and TextInput components. 
This is due an issue with Android crashing when these props are passed. 
The ideal solution is to remove these typings all together, unfortunately because of how we handle modifiers typings, we allow all boolean props

## Changelog
Omit alignment props (top, left, right, bottom) from being passed on to Text and TextInput components to avoid a crash on Android (RN71)
