### PR TITLE
Remove Card.Section extra (visible) border

### DIFF
--- a/src/components/card/CardSection.tsx
+++ b/src/components/card/CardSection.tsx
@@ -120,6 +120,7 @@ export default asBaseComponent<CardSectionProps>(asCardChild(CardSection));
 
 const styles = StyleSheet.create({
   container: {
+    borderColor: 'transparent',
     overflow: 'hidden'
   }
 });


### PR DESCRIPTION
## Description
This "extra shadow" can be seen in the `CardsScreen` if the following line is removed from `Card.index` (see image below):
```
return this.styles.containerShadow;
```

WOAUILIB-3427

<img width="156" alt="image" src="https://user-images.githubusercontent.com/38354019/229413860-cf85ae82-4a5f-4875-95b3-ee290faef369.png">


## Changelog
Remove Card.Section extra (visible) border
