### PR TITLE
fix wheelpicker in android

### DIFF
--- a/src/components/WheelPicker/index.tsx
+++ b/src/components/WheelPicker/index.tsx
@@ -147,15 +147,13 @@ const WheelPicker = ({
   const [flatListWidth, setFlatListWidth] = useState(0);
   const keyExtractor = useCallback((item: ItemProps, index: number) => `${item}.${index}`, []);
   const itemsLength = useMemo(() => items.length, [items]);
-  const androidFlatListProps = useMemo(() => itemsLength > 20 && Constants.isAndroid, [itemsLength]);
   const bigDataFlatListProps = useMemo(() => {
-    if (androidFlatListProps) {
+    if (Constants.isAndroid) {
       return {
-        initialNumToRender: itemsLength,
         maxToRenderPerBatch: itemsLength
       };
     }
-  }, [androidFlatListProps, itemsLength]);
+  }, [itemsLength]);
 
   useEffect(() => {
     // This effect making sure to reset index if initialValue has changed
@@ -329,7 +327,7 @@ const WheelPicker = ({
   }, []);
 
   return (
-    <View testID={testID} bg-$backgroundDefault style={[style, androidFlatListProps && styles.androidBigData]}>
+    <View testID={testID} bg-$backgroundDefault style={style}>
       <View row centerH>
         <View flexG>
           <AnimatedFlatList
@@ -384,8 +382,5 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: 0,
     bottom: 0
-  },
-  androidBigData: {
-    flex: 0
   }
 });

--- a/src/components/WheelPicker/index.tsx
+++ b/src/components/WheelPicker/index.tsx
@@ -330,8 +330,8 @@ const WheelPicker = ({
       <View row centerH>
         <View flexG>
           <AnimatedFlatList
-            {...flatListProps}
             {...androidFlatListProps}
+            {...flatListProps}
             testID={`${testID}.list`}
             listKey={`${testID}.flatList`}
             height={height}

--- a/src/components/WheelPicker/index.tsx
+++ b/src/components/WheelPicker/index.tsx
@@ -146,14 +146,13 @@ const WheelPicker = ({
   const prevIndex = useRef(currentIndex);
   const [flatListWidth, setFlatListWidth] = useState(0);
   const keyExtractor = useCallback((item: ItemProps, index: number) => `${item}.${index}`, []);
-  const itemsLength = useMemo(() => items.length, [items]);
-  const bigDataFlatListProps = useMemo(() => {
+  const androidFlatListProps = useMemo(() => {
     if (Constants.isAndroid) {
       return {
-        maxToRenderPerBatch: itemsLength
+        maxToRenderPerBatch: items.length
       };
     }
-  }, [itemsLength]);
+  }, [items]);
 
   useEffect(() => {
     // This effect making sure to reset index if initialValue has changed
@@ -332,7 +331,7 @@ const WheelPicker = ({
         <View flexG>
           <AnimatedFlatList
             {...flatListProps}
-            {...bigDataFlatListProps}
+            {...androidFlatListProps}
             testID={`${testID}.list`}
             listKey={`${testID}.flatList`}
             height={height}

--- a/src/components/WheelPicker/index.tsx
+++ b/src/components/WheelPicker/index.tsx
@@ -146,6 +146,16 @@ const WheelPicker = ({
   const prevIndex = useRef(currentIndex);
   const [flatListWidth, setFlatListWidth] = useState(0);
   const keyExtractor = useCallback((item: ItemProps, index: number) => `${item}.${index}`, []);
+  const itemsLength = useMemo(() => items.length, [items]);
+  const androidFlatListProps = useMemo(() => itemsLength > 20 && Constants.isAndroid, [itemsLength]);
+  const bigDataFlatListProps = useMemo(() => {
+    if (androidFlatListProps) {
+      return {
+        initialNumToRender: itemsLength,
+        maxToRenderPerBatch: itemsLength
+      };
+    }
+  }, [androidFlatListProps, itemsLength]);
 
   useEffect(() => {
     // This effect making sure to reset index if initialValue has changed
@@ -319,11 +329,12 @@ const WheelPicker = ({
   }, []);
 
   return (
-    <View testID={testID} bg-$backgroundDefault style={style}>
+    <View testID={testID} bg-$backgroundDefault style={[style, androidFlatListProps && styles.androidBigData]}>
       <View row centerH>
         <View flexG>
           <AnimatedFlatList
             {...flatListProps}
+            {...bigDataFlatListProps}
             testID={`${testID}.list`}
             listKey={`${testID}.flatList`}
             height={height}
@@ -373,5 +384,8 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: 0,
     bottom: 0
+  },
+  androidBigData: {
+    flex: 0
   }
 });

--- a/src/components/WheelPicker/wheelPicker.api.json
+++ b/src/components/WheelPicker/wheelPicker.api.json
@@ -2,7 +2,7 @@
   "name": "WheelPicker",
   "category": "form",
   "description": "A customizable WheelPicker component",
-  "note": "When using Android by default the FlatList will have 'maxToRenderPerBatch' prop set to items.<br/>length to solve FlatList bug on Android, you can override it by passing your own 'flatListProps' with 'maxToRenderPerBatch' prop.<br/>See the RN FlatList issue for more info: https://github.com/facebook/react-native/issues/15990",
+  "note": "When using Android by default the FlatList will have <code>maxToRenderPerBatch</code> prop set to <code>items.length</code> to solve FlatList bug on Android, you can override it by passing your own 'flatListProps' with 'maxToRenderPerBatch' prop.<br/>See the RN FlatList issue for more info: https://github.com/facebook/react-native/issues/15990",
   "example": "https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/WheelPickerScreen.tsx",
   "images": [],
   "props": [

--- a/src/components/WheelPicker/wheelPicker.api.json
+++ b/src/components/WheelPicker/wheelPicker.api.json
@@ -33,7 +33,12 @@
       "default": "center"
     },
     {"name": "separatorsStyle", "type": "ViewStyle", "description": "Extra style for the separators"},
-    {"name": "testID", "type": "string", "description": "test identifier"}
+    {"name": "testID", "type": "string", "description": "test identifier"},
+    {
+      "name": "flatListProps",
+      "type": "FlatListProps",
+      "description": "Props to be sent to the FlatList. When using Android by default the FlatList will have 'maxToRenderPerBatch' prop set to items.length to solve FlatList bug on Android, you can override it by passing your own 'flatListProps' with 'maxToRenderPerBatch' prop"
+    }
   ],
   "snippet": [
     "<WheelPicker",

--- a/src/components/WheelPicker/wheelPicker.api.json
+++ b/src/components/WheelPicker/wheelPicker.api.json
@@ -2,7 +2,7 @@
   "name": "WheelPicker",
   "category": "form",
   "description": "A customizable WheelPicker component",
-  "note": "When using Android by default the FlatList will have 'maxToRenderPerBatch' prop set to items.length to solve FlatList bug on Android, you can override it by passing your own 'flatListProps' with 'maxToRenderPerBatch' prop. See the RN FlatList issue for more info: https://github.com/facebook/react-native/issues/15990",
+  "note": "When using Android by default the FlatList will have 'maxToRenderPerBatch' prop set to items.<br/>length to solve FlatList bug on Android, you can override it by passing your own 'flatListProps' with 'maxToRenderPerBatch' prop.<br/>See the RN FlatList issue for more info: https://github.com/facebook/react-native/issues/15990",
   "example": "https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/WheelPickerScreen.tsx",
   "images": [],
   "props": [

--- a/src/components/WheelPicker/wheelPicker.api.json
+++ b/src/components/WheelPicker/wheelPicker.api.json
@@ -2,6 +2,7 @@
   "name": "WheelPicker",
   "category": "form",
   "description": "A customizable WheelPicker component",
+  "note": "When using Android by default the FlatList will have 'maxToRenderPerBatch' prop set to items.length to solve FlatList bug on Android, you can override it by passing your own 'flatListProps' with 'maxToRenderPerBatch' prop. See the RN FlatList issue for more info: https://github.com/facebook/react-native/issues/15990",
   "example": "https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/WheelPickerScreen.tsx",
   "images": [],
   "props": [
@@ -37,7 +38,7 @@
     {
       "name": "flatListProps",
       "type": "FlatListProps",
-      "description": "Props to be sent to the FlatList. When using Android by default the FlatList will have 'maxToRenderPerBatch' prop set to items.length to solve FlatList bug on Android, you can override it by passing your own 'flatListProps' with 'maxToRenderPerBatch' prop"
+      "description": "Props to be sent to the FlatList."
     }
   ],
   "snippet": [

--- a/src/components/WheelPicker/wheelPicker.api.json
+++ b/src/components/WheelPicker/wheelPicker.api.json
@@ -2,7 +2,7 @@
   "name": "WheelPicker",
   "category": "form",
   "description": "A customizable WheelPicker component",
-  "note": "When using Android by default the FlatList will have <code>maxToRenderPerBatch</code> prop set to <code>items.length</code> to solve FlatList bug on Android, you can override it by passing your own 'flatListProps' with 'maxToRenderPerBatch' prop.<br/>See the RN FlatList issue for more info: https://github.com/facebook/react-native/issues/15990",
+  "note": "When using Android by default the FlatList will have <code>maxToRenderPerBatch</code> prop set to <code>items.length</code> to solve FlatList bug on Android, you can override it by passing your own <code>flatListProps</code> with <code>maxToRenderPerBatch</code> prop.<br/>See the RN FlatList issue for more info: https://github.com/facebook/react-native/issues/15990",
   "example": "https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/WheelPickerScreen.tsx",
   "images": [],
   "props": [


### PR DESCRIPTION
## Description
WheelPicker missing data in Android bug fix, passing `maxToRenderPerBatch` to the `FlatList` when using Android.

## Changelog
WheelPicker missing data in Android bug fix, passing `maxToRenderPerBatch` to the `FlatList` when using Android.
Solve [RN FlastList issue](https://github.com/facebook/react-native/issues/15990).
`WOAUILIB-3440`
