### PR TITLE
export FlashList with default value

### DIFF
--- a/src/optionalDependencies/FlashListPackage.ts
+++ b/src/optionalDependencies/FlashListPackage.ts
@@ -1,4 +1,4 @@
-let FlashListPackage: any;
+let FlashListPackage = {FlashList: {}};
 try {
   FlashListPackage = require('@shopify/flash-list');
 } catch (error) {}

--- a/src/optionalDependencies/index.web.ts
+++ b/src/optionalDependencies/index.web.ts
@@ -4,4 +4,5 @@ export {default as SvgPackage} from './SvgPackage';
 export {createShimmerPlaceholder} from './ShimmerPackage';
 export {default as LinearGradientPackage} from './LinearGradientPackage';
 export {default as PostCssPackage} from './PostCssPackage';
+export {default as FlashListPackage} from './FlashListPackage';
 


### PR DESCRIPTION
## Description
Export `FlashList` optional dependency from `index.web` as well, plus set FlashList return value with a default object to fix deconstruct javascript error.  

## Changelog
Fix `FlashList`'s javascript error when rendering web components
