### PR TITLE
Slider - adding 'migrate' prop to allow using Incubator.Silder

### DIFF
--- a/demo/src/screens/componentScreens/SliderScreen.tsx
+++ b/demo/src/screens/componentScreens/SliderScreen.tsx
@@ -115,6 +115,7 @@ export default class SliderScreen extends Component<SliderScreenProps, SliderScr
             // @ts-expect-error
             ref={this.slider}
             onReset={this.onSliderReset}
+            migrate
           />
           <Text bodySmall $textNeutral style={styles.text} numberOfLines={1}>
             ${sliderValue}
@@ -137,6 +138,7 @@ export default class SliderScreen extends Component<SliderScreenProps, SliderScr
           minimumTrackTintColor={Colors.red30}
           thumbTintColor={Colors.red50}
           containerStyle={styles.slider}
+          migrate
         />
         <Slider
           minimumValue={-300}
@@ -145,6 +147,7 @@ export default class SliderScreen extends Component<SliderScreenProps, SliderScr
           minimumTrackTintColor={Colors.red30}
           thumbTintColor={Colors.red50}
           containerStyle={styles.slider}
+          migrate
         />
       </Fragment>
     );
@@ -156,8 +159,14 @@ export default class SliderScreen extends Component<SliderScreenProps, SliderScr
         <Text $textDefault text70BO marginT-20>
           Disabled
         </Text>
-        <Slider minimumValue={100} maximumValue={200} value={120} containerStyle={styles.slider} disabled/>
+        <Slider minimumValue={100} maximumValue={200} value={120} containerStyle={styles.slider} disabled migrate/>
+      </Fragment>
+    );
+  }
 
+  renderCustomSlider() {
+    return (
+      <>
         <Text $textDefault text70BO marginT-15>
           Custom with Steps
         </Text>
@@ -173,8 +182,9 @@ export default class SliderScreen extends Component<SliderScreenProps, SliderScr
           thumbTintColor={Colors.violet70}
           minimumTrackTintColor={Colors.violet40}
           maximumTrackTintColor={Colors.violet70}
+          migrate
         />
-      </Fragment>
+      </>
     );
   }
 
@@ -205,6 +215,7 @@ export default class SliderScreen extends Component<SliderScreenProps, SliderScr
           // @ts-expect-error
           ref={this.rangeSlider}
           onReset={this.onRangeSliderReset}
+          migrate
         />
       </Fragment>
     );
@@ -237,6 +248,7 @@ export default class SliderScreen extends Component<SliderScreenProps, SliderScr
           disableRTL={forceLTR}
           initialMinimumValue={25}
           initialMaximumValue={80}
+          migrate
         />
       </Fragment>
     );
@@ -260,6 +272,7 @@ export default class SliderScreen extends Component<SliderScreenProps, SliderScr
             onValueChange={this.onGradientValueChange}
             // @ts-expect-error
             ref={this.gradientSlider}
+            migrate
           />
           <View style={styles.box}>
             <View style={{flex: 1, backgroundColor: color, opacity: alpha}}/>
@@ -274,6 +287,7 @@ export default class SliderScreen extends Component<SliderScreenProps, SliderScr
             color={COLOR}
             containerStyle={styles.gradientSliderContainer}
             onValueChange={this.onGradientValueChange}
+            migrate
           />
           <View style={styles.box}>
             <View style={{flex: 1, backgroundColor: color}}/>
@@ -297,6 +311,7 @@ export default class SliderScreen extends Component<SliderScreenProps, SliderScr
           containerStyle={styles.group}
           showLabels
           // onValueChange={this.onGroupValueChange}
+          migrate
         />
       </Fragment>
     );
@@ -317,6 +332,7 @@ export default class SliderScreen extends Component<SliderScreenProps, SliderScr
           {this.renderDefaultSliderExample()}
           {this.renderNegativeSliderExample()}
           {this.renderDisabledSliderExample()}
+          {this.renderCustomSlider()}
           {this.renderRangeSliderExample()}
           {this.renderRangeSliderWithValuesExample()}
           {this.renderGradientSlidersExample()}

--- a/demo/src/screens/componentScreens/SliderScreen.tsx
+++ b/demo/src/screens/componentScreens/SliderScreen.tsx
@@ -115,7 +115,6 @@ export default class SliderScreen extends Component<SliderScreenProps, SliderScr
             // @ts-expect-error
             ref={this.slider}
             onReset={this.onSliderReset}
-            migrate
           />
           <Text bodySmall $textNeutral style={styles.text} numberOfLines={1}>
             ${sliderValue}
@@ -138,7 +137,6 @@ export default class SliderScreen extends Component<SliderScreenProps, SliderScr
           minimumTrackTintColor={Colors.red30}
           thumbTintColor={Colors.red50}
           containerStyle={styles.slider}
-          migrate
         />
         <Slider
           minimumValue={-300}
@@ -147,7 +145,6 @@ export default class SliderScreen extends Component<SliderScreenProps, SliderScr
           minimumTrackTintColor={Colors.red30}
           thumbTintColor={Colors.red50}
           containerStyle={styles.slider}
-          migrate
         />
       </Fragment>
     );
@@ -159,7 +156,7 @@ export default class SliderScreen extends Component<SliderScreenProps, SliderScr
         <Text $textDefault text70BO marginT-20>
           Disabled
         </Text>
-        <Slider minimumValue={100} maximumValue={200} value={120} containerStyle={styles.slider} disabled migrate/>
+        <Slider minimumValue={100} maximumValue={200} value={120} containerStyle={styles.slider} disabled/>
       </Fragment>
     );
   }
@@ -182,7 +179,6 @@ export default class SliderScreen extends Component<SliderScreenProps, SliderScr
           thumbTintColor={Colors.violet70}
           minimumTrackTintColor={Colors.violet40}
           maximumTrackTintColor={Colors.violet70}
-          migrate
         />
       </>
     );
@@ -215,7 +211,6 @@ export default class SliderScreen extends Component<SliderScreenProps, SliderScr
           // @ts-expect-error
           ref={this.rangeSlider}
           onReset={this.onRangeSliderReset}
-          migrate
         />
       </Fragment>
     );
@@ -248,7 +243,6 @@ export default class SliderScreen extends Component<SliderScreenProps, SliderScr
           disableRTL={forceLTR}
           initialMinimumValue={25}
           initialMaximumValue={80}
-          migrate
         />
       </Fragment>
     );
@@ -272,7 +266,6 @@ export default class SliderScreen extends Component<SliderScreenProps, SliderScr
             onValueChange={this.onGradientValueChange}
             // @ts-expect-error
             ref={this.gradientSlider}
-            migrate
           />
           <View style={styles.box}>
             <View style={{flex: 1, backgroundColor: color, opacity: alpha}}/>
@@ -287,7 +280,6 @@ export default class SliderScreen extends Component<SliderScreenProps, SliderScr
             color={COLOR}
             containerStyle={styles.gradientSliderContainer}
             onValueChange={this.onGradientValueChange}
-            migrate
           />
           <View style={styles.box}>
             <View style={{flex: 1, backgroundColor: color}}/>
@@ -311,7 +303,6 @@ export default class SliderScreen extends Component<SliderScreenProps, SliderScr
           containerStyle={styles.group}
           showLabels
           // onValueChange={this.onGroupValueChange}
-          migrate
         />
       </Fragment>
     );

--- a/demo/src/screens/incubatorScreens/IncubatorSliderScreen.tsx
+++ b/demo/src/screens/incubatorScreens/IncubatorSliderScreen.tsx
@@ -194,7 +194,7 @@ const IncubatorSliderScreen = () => {
 
   const renderGradientSlidersExample = () => {
     return (
-      <>
+      <View marginH-20>
         <Text margin-10 text70BL $textDefault>
           Gradient Sliders
         </Text>
@@ -229,7 +229,7 @@ const IncubatorSliderScreen = () => {
             <View style={{flex: 1, backgroundColor: color}}/>
           </View>
         </View>
-      </>
+      </View>
     );
   };
 

--- a/demo/src/screens/incubatorScreens/IncubatorSliderScreen.tsx
+++ b/demo/src/screens/incubatorScreens/IncubatorSliderScreen.tsx
@@ -1,6 +1,6 @@
 import React, {useState, useRef, useCallback} from 'react';
 import {StyleSheet, ScrollView} from 'react-native';
-import {Constants, Colors, View, Text, Button, Incubator} from 'react-native-ui-lib'; //eslint-disable-line
+import {Constants, Colors, View, Text, Button, Incubator, GradientSlider, ColorSliderGroup} from 'react-native-ui-lib'; //eslint-disable-line
 import {renderBooleanOption} from '../ExampleScreenPresenter';
 
 const VALUE = 20;
@@ -9,6 +9,7 @@ const MIN = 0;
 const MAX = Constants.screenWidth - 40; // horizontal margins 20
 const INITIAL_MIN = 30;
 const INITIAL_MAX = 270;
+const COLOR = Colors.blue30;
 
 const IncubatorSliderScreen = () => {
   const [disableRTL, setDisableRTL] = useState<boolean>(false);
@@ -18,6 +19,9 @@ const IncubatorSliderScreen = () => {
   const [negativeSliderValue, setNegativeSliderValue] = useState(NEGATIVE_VALUE);
   const [sliderMinValue, setSliderMinValue] = useState(INITIAL_MIN);
   const [sliderMaxValue, setSliderMaxValue] = useState(INITIAL_MAX);
+
+  const [color, setColor] = useState(COLOR);
+  const [alpha, setAlpha] = useState(1);
 
   const slider = useRef<typeof Incubator.Slider>();
   const customSlider = useRef<typeof Incubator.Slider>();
@@ -47,6 +51,15 @@ const IncubatorSliderScreen = () => {
     setSliderMaxValue(value.max);
     setSliderMinValue(value.min);
   }, []);
+
+  const onGradientValueChange = useCallback((value: string, alpha: number) => {
+    setColor(value);
+    setAlpha(alpha);
+  }, []);
+
+  const onGroupValueChange = (value: string) => {
+    console.warn('onGroupValueChange: ', value);
+  };
 
   const renderValuesBox = (min: number, max?: number) => {
     if (max !== undefined) {
@@ -179,6 +192,65 @@ const IncubatorSliderScreen = () => {
     );
   };
 
+  const renderGradientSlidersExample = () => {
+    return (
+      <>
+        <Text margin-10 text70BL $textDefault>
+          Gradient Sliders
+        </Text>
+        <View row centerV>
+          <Text text90 $textNeutral>
+            DEFAULT
+          </Text>
+          <GradientSlider
+            color={color}
+            containerStyle={styles.gradientSliderContainer}
+            onValueChange={onGradientValueChange}
+            // @ts-expect-error
+            ref={this.gradientSlider}
+            migrate
+          />
+          <View style={styles.box}>
+            <View style={{flex: 1, backgroundColor: color, opacity: alpha}}/>
+          </View>
+        </View>
+        <View row centerV>
+          <Text text90 $textNeutral>
+            HUE
+          </Text>
+          <GradientSlider
+            type={GradientSlider.types.HUE}
+            color={COLOR}
+            containerStyle={styles.gradientSliderContainer}
+            onValueChange={onGradientValueChange}
+            migrate
+          />
+          <View style={styles.box}>
+            <View style={{flex: 1, backgroundColor: color}}/>
+          </View>
+        </View>
+      </>
+    );
+  };
+
+  const renderColorSliderGroupExample = () => {
+    return (
+      <>
+        <Text margin-10 text70BL $textDefault>
+          Color Slider Group
+        </Text>
+        <ColorSliderGroup
+          initialColor={color}
+          sliderContainerStyle={styles.slider}
+          containerStyle={styles.group}
+          showLabels
+          // onValueChange={onGroupValueChange}
+          migrate
+        />
+      </>
+    );
+  };
+
   return (
     <ScrollView showsVerticalScrollIndicator={false} style={{backgroundColor: Colors.$backgroundDefault}}>
       <View row spread margin-20>
@@ -196,6 +268,8 @@ const IncubatorSliderScreen = () => {
       {renderCustomSliderExample()}
       {renderNegativeSliderExample()}
       {renderRangeSliderExample()}
+      {renderGradientSlidersExample()}
+      {renderColorSliderGroupExample()}
     </ScrollView>
   );
 };
@@ -221,5 +295,26 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.red30,
     borderWidth: 2,
     borderColor: Colors.red70
+  },
+  gradientSliderContainer: {
+    flex: 1, // NOTE: to place a slider in a row layout you must set flex in its 'containerStyle'!!!
+    marginHorizontal: 20,
+    marginVertical: 10
+  },
+  box: {
+    width: 20,
+    height: 20,
+    borderRadius: 4,
+    borderWidth: 1,
+    borderColor: Colors.$outlineDefault
+  },
+  slider: {
+    marginVertical: 6
+  },
+  group: {
+    backgroundColor: Colors.$backgroundNeutralMedium,
+    padding: 20,
+    margin: 20,
+    borderRadius: 6
   }
 });

--- a/demo/src/screens/incubatorScreens/IncubatorSliderScreen.tsx
+++ b/demo/src/screens/incubatorScreens/IncubatorSliderScreen.tsx
@@ -58,7 +58,7 @@ const IncubatorSliderScreen = () => {
   }, []);
 
   const onGroupValueChange = (value: string) => {
-    console.warn('onGroupValueChange: ', value);
+    console.log('onGroupValueChange: ', value);
   };
 
   const renderValuesBox = (min: number, max?: number) => {
@@ -244,7 +244,7 @@ const IncubatorSliderScreen = () => {
           sliderContainerStyle={styles.slider}
           containerStyle={styles.group}
           showLabels
-          // onValueChange={onGroupValueChange}
+          onValueChange={onGroupValueChange}
           migrate
         />
       </>

--- a/src/components/slider/ColorSliderGroup.tsx
+++ b/src/components/slider/ColorSliderGroup.tsx
@@ -42,6 +42,9 @@ export type ColorSliderGroupProps = {
    * If true the component will have accessibility features enabled
    */
   accessible?: boolean;
+  /** Whether to use the new Slider implementation using Reanimated
+   */
+  migrate?: boolean;
 };
 
 interface ColorSliderGroupState {
@@ -79,7 +82,7 @@ class ColorSliderGroup extends PureComponent<ColorSliderGroupProps, ColorSliderG
   };
 
   renderSlider = (type: GradientSliderTypes) => {
-    const {sliderContainerStyle, showLabels, labelsStyle, accessible, labels} = this.props;
+    const {sliderContainerStyle, showLabels, labelsStyle, accessible, labels, migrate} = this.props;
 
     return (
       <>
@@ -93,6 +96,7 @@ class ColorSliderGroup extends PureComponent<ColorSliderGroupProps, ColorSliderG
           type={type}
           containerStyle={sliderContainerStyle}
           accessible={accessible}
+          migrate={migrate}
         />
       </>
     );

--- a/src/components/slider/ColorSliderGroup.tsx
+++ b/src/components/slider/ColorSliderGroup.tsx
@@ -42,7 +42,8 @@ export type ColorSliderGroupProps = {
    * If true the component will have accessibility features enabled
    */
   accessible?: boolean;
-  /** Whether to use the new Slider implementation using Reanimated
+  /** 
+   * Whether to use the new Slider implementation using Reanimated
    */
   migrate?: boolean;
 };

--- a/src/components/slider/GradientSlider.tsx
+++ b/src/components/slider/GradientSlider.tsx
@@ -225,6 +225,7 @@ class GradientSlider extends Component<Props, GradientSliderState> {
     return (
       <SliderComponent
         {...others}
+        //@ts-expect-error
         ref={forwardedRef}
         onReset={this.reset}
         renderTrack={renderTrack}

--- a/src/components/slider/GradientSlider.tsx
+++ b/src/components/slider/GradientSlider.tsx
@@ -5,6 +5,7 @@ import {StyleProp, ViewStyle} from 'react-native';
 import {Colors} from '../../style';
 import {asBaseComponent, forwardRef, ForwardRefInjectedProps} from '../../commons/new';
 import Slider, {SliderProps} from './index';
+import {Slider as NewSlider} from '../../incubator';
 import {SliderContextProps} from './context/SliderContext';
 import asSliderGroupChild from './context/asSliderGroupChild';
 import Gradient from '../gradient';
@@ -47,6 +48,9 @@ export type GradientSliderProps = Omit<SliderProps, 'onValueChange'> & {
    * If true the Slider will be disabled and will appear in disabled color
    */
   disabled?: boolean;
+  /** Whether to use the new Slider implementation using Reanimated
+   */
+  migrate?: boolean;
 };
 
 type GradientSliderComponentProps = {
@@ -216,8 +220,10 @@ class GradientSlider extends Component<Props, GradientSliderState> {
         break;
     }
 
+    const SliderComponent = this.props.migrate ? NewSlider : Slider;
+
     return (
-      <Slider
+      <SliderComponent
         {...others}
         ref={forwardedRef}
         onReset={this.reset}

--- a/src/components/slider/GradientSlider.tsx
+++ b/src/components/slider/GradientSlider.tsx
@@ -48,9 +48,6 @@ export type GradientSliderProps = Omit<SliderProps, 'onValueChange'> & {
    * If true the Slider will be disabled and will appear in disabled color
    */
   disabled?: boolean;
-  /** Whether to use the new Slider implementation using Reanimated
-   */
-  migrate?: boolean;
 };
 
 type GradientSliderComponentProps = {

--- a/src/components/slider/GradientSlider.tsx
+++ b/src/components/slider/GradientSlider.tsx
@@ -185,7 +185,7 @@ class GradientSlider extends Component<Props, GradientSliderState> {
   };
 
   render() {
-    const {type, containerStyle, disabled, accessible, forwardedRef, ...others} = this.props;
+    const {type, containerStyle, disabled, accessible, forwardedRef, migrate, ...others} = this.props;
     const initialColor = this.state.initialColor;
     const color = this.getColor();
     const thumbTintColor = Colors.getHexString(color);
@@ -217,7 +217,7 @@ class GradientSlider extends Component<Props, GradientSliderState> {
         break;
     }
 
-    const SliderComponent = this.props.migrate ? NewSlider : Slider;
+    const SliderComponent = migrate ? NewSlider : Slider;
 
     return (
       <SliderComponent

--- a/src/components/slider/context/SliderGroup.tsx
+++ b/src/components/slider/context/SliderGroup.tsx
@@ -41,7 +41,9 @@ export default class SliderGroup extends Component<SliderGroupProps, SliderGroup
   render() {
     return (
       <View {...this.props}>
-        <SliderContext.Provider value={this.getContextProviderValue()}>{this.props.children}</SliderContext.Provider>
+        <SliderContext.Provider value={this.getContextProviderValue()}>
+          {this.props.children}
+        </SliderContext.Provider>
       </View>
     );
   }

--- a/src/components/slider/index.tsx
+++ b/src/components/slider/index.tsx
@@ -16,6 +16,7 @@ import {
 } from 'react-native';
 import {Constants} from '../../commons/new';
 import {Colors} from '../../style';
+import IncubatorSlider from '../../incubator/Slider';
 import View from '../view';
 import Thumb, {ThumbProps} from './Thumb';
 import {extractAccessibilityProps} from '../../commons/modifiers';
@@ -120,6 +121,9 @@ export type SliderProps = Omit<ThumbProps, 'ref'> & {
    * The slider's test identifier
    */
   testID?: string;
+  /** Whether to use the new Slider implementation using Reanimated
+   */
+  migrate?: boolean;
 } & typeof defaultProps;
 
 interface State {
@@ -739,7 +743,11 @@ export default class Slider extends PureComponent<SliderProps, State> {
   }
 
   render() {
-    const {containerStyle, testID} = this.props;
+    const {containerStyle, testID, migrate} = this.props;
+
+    if (migrate) {
+      return <IncubatorSlider {...this.props}/>;
+    }
     
     return (
       <View

--- a/src/components/slider/index.tsx
+++ b/src/components/slider/index.tsx
@@ -121,7 +121,8 @@ export type SliderProps = Omit<ThumbProps, 'ref'> & {
    * The slider's test identifier
    */
   testID?: string;
-  /** Whether to use the new Slider implementation using Reanimated
+  /** 
+   * Whether to use the new Slider implementation using Reanimated
    */
   migrate?: boolean;
 } & typeof defaultProps;

--- a/src/components/slider/slider.api.json
+++ b/src/components/slider/slider.api.json
@@ -83,7 +83,8 @@
       "type": "boolean",
       "description": "If true the component will have accessibility features enabled"
     },
-    {"name": "testID", "type": "string", "description": "The component test id"}
+    {"name": "testID", "type": "string", "description": "The component test id"},
+    {"name": "migrate", "type": "boolean", "description": "Temporary prop required for migration to the Slider's new implementation"}
   ],
   "snippet": [
     "<Slider",

--- a/src/incubator/Slider/index.tsx
+++ b/src/incubator/Slider/index.tsx
@@ -148,8 +148,8 @@ const Slider = React.memo((props: Props) => {
   useAnimatedReaction(() => {
     return Math.round(defaultThumbOffset.value);
   },
-  (offset, _prevOffset) => {
-    if (offset !== _prevOffset) {
+  (offset, prevOffset) => {
+    if (offset !== prevOffset) {
       const value = getValueForOffset(offset, trackSize.value.width, minimumValue, maximumValue, stepXValue.value);
       if (useRange) {
         const maxValue = getValueForOffset(rangeThumbOffset.value,

--- a/src/incubator/Slider/index.tsx
+++ b/src/incubator/Slider/index.tsx
@@ -95,11 +95,17 @@ const Slider = React.memo((props: Props) => {
   const end = useSharedValue(0);
   const defaultThumbOffset = useSharedValue(0);
   const rangeThumbOffset = useSharedValue(0);
-
-  const defaultThumbStyle: StyleProp<ViewStyle> = useMemo(() => [
-    styles.thumb, {backgroundColor: disabled ? Colors.$backgroundDisabled : thumbTintColor}
+  
+  const thumbBackground: StyleProp<ViewStyle> = useMemo(() => [
+    {backgroundColor: disabled ? Colors.$backgroundDisabled : thumbTintColor}
   ], [disabled, thumbTintColor]);
-  const _thumbStyle = useSharedValue(StyleUtils.unpackStyle(thumbStyle || defaultThumbStyle, {flatten: true}));
+  const defaultThumbStyle: StyleProp<ViewStyle> = useMemo(() => [
+    styles.thumb, thumbBackground
+  ], [thumbBackground]);
+  const customThumbStyle: StyleProp<ViewStyle> = useMemo(() => [
+    thumbStyle, thumbBackground
+  ], [thumbStyle, thumbBackground]); 
+  const _thumbStyle = useSharedValue(StyleUtils.unpackStyle(customThumbStyle || defaultThumbStyle, {flatten: true}));
   const _activeThumbStyle = useSharedValue(StyleUtils.unpackStyle(activeThumbStyle, {flatten: true}));
 
   useEffect(() => {

--- a/src/incubator/Slider/index.tsx
+++ b/src/incubator/Slider/index.tsx
@@ -143,16 +143,18 @@ const Slider = React.memo((props: Props) => {
     return Math.round(defaultThumbOffset.value);
   },
   (offset, _prevOffset) => {
-    const value = getValueForOffset(offset, trackSize.value.width, minimumValue, maximumValue, stepXValue.value);
-    if (useRange) {
-      const maxValue = getValueForOffset(rangeThumbOffset.value,
-        trackSize.value.width,
-        minimumValue,
-        maximumValue,
-        stepXValue.value);
-      runOnJS(onRangeChangeThrottled)(value, maxValue);
-    } else {
-      runOnJS(onValueChangeThrottled)(value);
+    if (offset !== _prevOffset) {
+      const value = getValueForOffset(offset, trackSize.value.width, minimumValue, maximumValue, stepXValue.value);
+      if (useRange) {
+        const maxValue = getValueForOffset(rangeThumbOffset.value,
+          trackSize.value.width,
+          minimumValue,
+          maximumValue,
+          stepXValue.value);
+        runOnJS(onRangeChangeThrottled)(value, maxValue);
+      } else {
+        runOnJS(onValueChangeThrottled)(value);
+      }
     }
   });
 


### PR DESCRIPTION
## Description
Slider, GradientSlider, ColorSliderGroup - adding 'migrate' prop to allow using Incubator Silder instead of the old implementation.
Included: a fix for 'thumbTintColor' in the Incubator Slider to match old implementation.

## Changelog
Slider, GradientSlider, ColorSliderGroup - adding 'migrate' prop to allow using Incubator Silder instead of the old implementation. NO breaking changes.
