### PR TITLE
iOS - change bundle id and set min deployment to iOS 13.0

### DIFF
--- a/ios/rnuilib.xcodeproj/project.pbxproj
+++ b/ios/rnuilib.xcodeproj/project.pbxproj
@@ -660,6 +660,7 @@
 					"FB_SONARKIT_ENABLED=1",
 				);
 				INFOPLIST_FILE = rnuilib/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.1.16;
 				OTHER_LDFLAGS = (
@@ -684,6 +685,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_FILE = rnuilib/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.1.16;
 				OTHER_LDFLAGS = (

--- a/ios/rnuilib.xcodeproj/project.pbxproj
+++ b/ios/rnuilib.xcodeproj/project.pbxproj
@@ -669,6 +669,7 @@
 					"-lc++",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
+				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = org.reactjs.native.example.wix.rnuilib;
 				PRODUCT_NAME = rnuilib;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -694,6 +695,7 @@
 					"-lc++",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
+				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = org.reactjs.native.example.wix.rnuilib;
 				PRODUCT_NAME = rnuilib;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Description
iOS - set demo's min deployment to iOS 13.0 and change bundle id to allow running on iOS device
Note: It will create a new app on the device the first time you run it, in case you have the old one still installed.

## Changelog
iOS - set demo's min deployment to iOS 13.0 and change bundle id to allow running on iOS device
