### PR TITLE
TextField and Switch/ forward id prop

### DIFF
--- a/src/components/switch/index.tsx
+++ b/src/components/switch/index.tsx
@@ -56,6 +56,7 @@ export type SwitchProps = {
   thumbStyle?: StyleProp<ViewStyle>;
   style?: StyleProp<ViewStyle>;
   testID?: string;
+  id?: string;
 }
 
 /**

--- a/src/components/switch/switch.api.json
+++ b/src/components/switch/switch.api.json
@@ -25,7 +25,8 @@
     {"name": "thumbSize", "type": "number", "description": "The Switch's thumb size (width & height)"},
     {"name": "thumbStyle", "type": "ViewStyle", "description": "The Switch's thumb style"},
     {"name": "style", "type": "ViewStyle", "description": "Custom style"},
-    {"name": "testID", "type": "string", "description": "Component test id"}
+    {"name": "testID", "type": "string", "description": "Component test id"},
+    {"name": "id", "type": "string", "description": "Component id"}
   ],
   "snippet": [
     "<Switch value={false$1} onValueChange={() => console.log('value changed')$2}/>"

--- a/src/incubator/TextField/index.tsx
+++ b/src/incubator/TextField/index.tsx
@@ -46,7 +46,7 @@ const TextField = (props: InternalTextFieldProps) => {
   const {
     modifiers,
     // General
-    containerId,
+    containerProps = {},
     fieldStyle: fieldStyleProp,
     dynamicFieldStyle,
     containerStyle,
@@ -124,7 +124,7 @@ const TextField = (props: InternalTextFieldProps) => {
 
   return (
     <FieldContext.Provider value={context}>
-      <View id={containerId} style={[margins, positionStyle, containerStyle, centeredContainerStyle]}>
+      <View {...containerProps} style={[margins, positionStyle, containerStyle, centeredContainerStyle]}>
         <Label
           label={label}
           labelColor={labelColor}

--- a/src/incubator/TextField/index.tsx
+++ b/src/incubator/TextField/index.tsx
@@ -46,7 +46,7 @@ const TextField = (props: InternalTextFieldProps) => {
   const {
     modifiers,
     // General
-    containerProps = {},
+    containerProps,
     fieldStyle: fieldStyleProp,
     dynamicFieldStyle,
     containerStyle,

--- a/src/incubator/TextField/index.tsx
+++ b/src/incubator/TextField/index.tsx
@@ -46,6 +46,7 @@ const TextField = (props: InternalTextFieldProps) => {
   const {
     modifiers,
     // General
+    containerId,
     fieldStyle: fieldStyleProp,
     dynamicFieldStyle,
     containerStyle,
@@ -123,7 +124,7 @@ const TextField = (props: InternalTextFieldProps) => {
 
   return (
     <FieldContext.Provider value={context}>
-      <View style={[margins, positionStyle, containerStyle, centeredContainerStyle]}>
+      <View id={containerId} style={[margins, positionStyle, containerStyle, centeredContainerStyle]}>
         <Label
           label={label}
           labelColor={labelColor}

--- a/src/incubator/TextField/textField.api.json
+++ b/src/incubator/TextField/textField.api.json
@@ -56,6 +56,7 @@
       "type": "ViewStyle | (context: FieldContextType, props) => ViewStyle",
       "description": "Internal style for the field container to style the field underline, outline and fill color"
     },
+    {"name": "containerProps", "type": "Omit<ViewProps, 'style'>", "description": "Container props of the whole component"},
     {"name": "containerStyle", "type": "ViewStyle", "description": "Container style of the whole component"},
     {
       "name": "preset",

--- a/src/incubator/TextField/types.ts
+++ b/src/incubator/TextField/types.ts
@@ -165,6 +165,10 @@ export type TextFieldProps = MarginModifiers &
   ValidationMessageProps &
   Omit<CharCounterProps, 'maxLength' | 'testID'> & {
     /**
+     * Pass id to the container
+     */
+    containerId?: string;
+    /**
      * Pass to render a leading element
      */
     leadingAccessory?: ReactElement;

--- a/src/incubator/TextField/types.ts
+++ b/src/incubator/TextField/types.ts
@@ -10,6 +10,7 @@ import {
 } from '../../commons/new';
 import {TextProps} from '../../components/text';
 import {PropsWithChildren, ReactElement} from 'react';
+import {ViewProps} from '../../components/view';
 
 export type ColorType =
   | string
@@ -165,9 +166,9 @@ export type TextFieldProps = MarginModifiers &
   ValidationMessageProps &
   Omit<CharCounterProps, 'maxLength' | 'testID'> & {
     /**
-     * Pass id to the container
+     * Pass props to the container
      */
-    containerId?: string;
+    containerProps?: Omit<ViewProps, 'style'>;
     /**
      * Pass to render a leading element
      */

--- a/src/incubator/TextField/types.ts
+++ b/src/incubator/TextField/types.ts
@@ -166,10 +166,6 @@ export type TextFieldProps = MarginModifiers &
   ValidationMessageProps &
   Omit<CharCounterProps, 'maxLength' | 'testID'> & {
     /**
-     * Pass props to the container
-     */
-    containerProps?: Omit<ViewProps, 'style'>;
-    /**
      * Pass to render a leading element
      */
     leadingAccessory?: ReactElement;
@@ -221,6 +217,10 @@ export type TextFieldProps = MarginModifiers &
      * Internal dynamic style callback for the field container
      */
     dynamicFieldStyle?: (context: FieldContextType, props: {preset: TextFieldProps['preset']}) => StyleProp<ViewStyle>;
+    /**
+     * Pass props to the container
+     */
+    containerProps?: Omit<ViewProps, 'style'>;
     /**
      * Container style of the whole component
      */


### PR DESCRIPTION
## Description
we need to be able to pass `id` prop to the TextField container.
currently `id` is typed but passed to the `Input` component, so we declared new prop `containerId` in order to not break anyone.

## Changelog
TextField - add `containerProps` prop
Switch - add `id` prop
