### PR TITLE
Improving date utils

### DIFF
--- a/src/incubator/Calendar/Day.tsx
+++ b/src/incubator/Calendar/Day.tsx
@@ -6,7 +6,7 @@ import {Colors} from 'style';
 import View from '../../components/view';
 import TouchableOpacity from '../../components/touchableOpacity';
 import Text from '../../components/text';
-import {getDayOfDate, isSameDay, isToday} from './helpers/DateUtils';
+import {getDateObject, isSameDay, isToday} from './helpers/DateUtils';
 import {DayProps, UpdateSource} from './types';
 import CalendarContext from './CalendarContext';
 
@@ -26,6 +26,7 @@ const AnimatedText = Reanimated.createAnimatedComponent(Text);
 const Day = (props: DayProps) => {
   const {date, onPress, inactive} = props;
   const {selectedDate, setDate, showExtraDays} = useContext(CalendarContext);
+  const day = !isNull(date) ? getDateObject(date).day : '';
 
   const isSelected = useSharedValue(!isNull(date) ? isSameDay(selectedDate.value, date) : false);
   const isHidden = !showExtraDays && inactive;
@@ -70,7 +71,6 @@ const Day = (props: DayProps) => {
   }, [date, setDate, onPress]);
   
   const renderDay = () => {
-    const day = !isNull(date) ? getDayOfDate(date) : '';
     return (
       <View center>
         <View reanimated style={selectionStyle}/>

--- a/src/incubator/Calendar/Header.tsx
+++ b/src/incubator/Calendar/Header.tsx
@@ -4,7 +4,7 @@ import Reanimated, {useAnimatedProps} from 'react-native-reanimated';
 import {Colors, Typography} from 'style';
 import View from '../../components/view';
 import Button from '../../components/button';
-import {getDateObject, getMonthForIndex, addMonths, getTimestamp} from './helpers/DateUtils';
+import {getDateObject, getMonthForIndex, addMonths} from './helpers/DateUtils';
 import {HeaderProps, DayNamesFormat, UpdateSource} from './types';
 import CalendarContext from './CalendarContext';
 import WeekDaysNames from './WeekDaysNames';
@@ -23,7 +23,7 @@ const Header = (props: HeaderProps) => {
   const getNewDate = useCallback((count: number) => {
     const newDate = addMonths(selectedDate.value, count);
     const dateObject = getDateObject(newDate);
-    return getTimestamp({year: dateObject.year, month: dateObject.month, day: 1});
+    return getDateObject({year: dateObject.year, month: dateObject.month, day: 1}).timestamp;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/incubator/Calendar/__tests__/DateUtils.spec.ts
+++ b/src/incubator/Calendar/__tests__/DateUtils.spec.ts
@@ -48,7 +48,7 @@ describe('Calendar/DateUtils', () => {
         const dayObject = DateUtils.getDateObject(firstDayInTheYear);
         expect(dayObject.day).toBe(28);
         expect(dayObject.month).toBe(11);
-        expect(DateUtils.getDayOfTheWeek(firstDayInTheYear)).toBe(6);
+        expect(dayObject.dayOfTheWeek).toBe(6);
       });
 
       it('2020 When Sunday is first day of the week - should return Sunday Dec 29th', () => {
@@ -56,7 +56,7 @@ describe('Calendar/DateUtils', () => {
         const dayObject = DateUtils.getDateObject(firstDayInTheYear);
         expect(dayObject.day).toBe(29);
         expect(dayObject.month).toBe(11);
-        expect(DateUtils.getDayOfTheWeek(firstDayInTheYear)).toBe(0);
+        expect(dayObject.dayOfTheWeek).toBe(0);
       });
 
       it('2020 When Monday is first day of the week - should return Monday Dec 30th', () => {
@@ -64,7 +64,7 @@ describe('Calendar/DateUtils', () => {
         const dayObject = DateUtils.getDateObject(firstDayInTheYear);
         expect(dayObject.day).toBe(30);
         expect(dayObject.month).toBe(11);
-        expect(DateUtils.getDayOfTheWeek(firstDayInTheYear)).toBe(1);
+        expect(dayObject.dayOfTheWeek).toBe(1);
       });
     });
 
@@ -74,7 +74,7 @@ describe('Calendar/DateUtils', () => {
         const dayObject = DateUtils.getDateObject(firstDayInTheYear);
         expect(dayObject.day).toBe(26);
         expect(dayObject.month).toBe(11);
-        expect(DateUtils.getDayOfTheWeek(firstDayInTheYear)).toBe(6);
+        expect(dayObject.dayOfTheWeek).toBe(6);
       });
 
       it('2021 When Sunday is first day of the week - should return Sunday Dec 27th', () => {
@@ -82,7 +82,7 @@ describe('Calendar/DateUtils', () => {
         const dayObject = DateUtils.getDateObject(firstDayInTheYear);
         expect(dayObject.day).toBe(27);
         expect(dayObject.month).toBe(11);
-        expect(DateUtils.getDayOfTheWeek(firstDayInTheYear)).toBe(0);
+        expect(dayObject.dayOfTheWeek).toBe(0);
       });
 
       it('2021 When Monday is first day of the week - should return Monday Dec 28th', () => {
@@ -90,7 +90,7 @@ describe('Calendar/DateUtils', () => {
         const dayObject = DateUtils.getDateObject(firstDayInTheYear);
         expect(dayObject.day).toBe(28);
         expect(dayObject.month).toBe(11);
-        expect(DateUtils.getDayOfTheWeek(firstDayInTheYear)).toBe(1);
+        expect(dayObject.dayOfTheWeek).toBe(1);
       });
     });
 
@@ -100,7 +100,7 @@ describe('Calendar/DateUtils', () => {
         const dayObject = DateUtils.getDateObject(firstDayInTheYear);
         expect(dayObject.day).toBe(1);
         expect(dayObject.month).toBe(0);
-        expect(DateUtils.getDayOfTheWeek(firstDayInTheYear)).toBe(6);
+        expect(dayObject.dayOfTheWeek).toBe(6);
       });
 
       it('2022 When Sunday is first day of the week - should return Sunday Dec 26th', () => {
@@ -108,7 +108,7 @@ describe('Calendar/DateUtils', () => {
         const dayObject = DateUtils.getDateObject(firstDayInTheYear);
         expect(dayObject.day).toBe(26);
         expect(dayObject.month).toBe(11);
-        expect(DateUtils.getDayOfTheWeek(firstDayInTheYear)).toBe(0);
+        expect(dayObject.dayOfTheWeek).toBe(0);
       });
 
       it('2022 When Monday is first day of the week - should return Monday Dec 27th', () => {
@@ -116,7 +116,7 @@ describe('Calendar/DateUtils', () => {
         const dayObject = DateUtils.getDateObject(firstDayInTheYear);
         expect(dayObject.day).toBe(27);
         expect(dayObject.month).toBe(11);
-        expect(DateUtils.getDayOfTheWeek(firstDayInTheYear)).toBe(1);
+        expect(dayObject.dayOfTheWeek).toBe(1);
       });
     });
 
@@ -126,7 +126,7 @@ describe('Calendar/DateUtils', () => {
         const dayObject = DateUtils.getDateObject(firstDayInTheYear);
         expect(dayObject.day).toBe(31);
         expect(dayObject.month).toBe(11);
-        expect(DateUtils.getDayOfTheWeek(firstDayInTheYear)).toBe(6);
+        expect(dayObject.dayOfTheWeek).toBe(6);
       });
 
       it('2023 When Sunday is first day of the week - should return Sunday Jan 1st', () => {
@@ -134,7 +134,7 @@ describe('Calendar/DateUtils', () => {
         const dayObject = DateUtils.getDateObject(firstDayInTheYear);
         expect(dayObject.day).toBe(1);
         expect(dayObject.month).toBe(0);
-        expect(DateUtils.getDayOfTheWeek(firstDayInTheYear)).toBe(0);
+        expect(dayObject.dayOfTheWeek).toBe(0);
       });
 
       it('2023 When Monday is first day of the week - should return Monday Dec 26th', () => {
@@ -142,7 +142,7 @@ describe('Calendar/DateUtils', () => {
         const dayObject = DateUtils.getDateObject(firstDayInTheYear);
         expect(dayObject.day).toBe(26);
         expect(dayObject.month).toBe(11);
-        expect(DateUtils.getDayOfTheWeek(firstDayInTheYear)).toBe(1);
+        expect(dayObject.dayOfTheWeek).toBe(1);
       });
     });
   });
@@ -186,25 +186,6 @@ describe('Calendar/DateUtils', () => {
       expect(lastDayObject.year).toBe(2023);
     });
   });
-
-  describe('getDayOfDate', () => {
-    it('should return the day number from the date timestamp', () => {
-      const day = DateUtils.getDayOfDate(new Date(2022, 11, 26).getTime());
-      expect(day).toBe(26);
-    });
-  });
-
-  describe('getDayOfTheWeek', () => {
-    it('should return the day of week (Sunday = 0) from the date timestamp', () => {
-      const day = DateUtils.getDayOfTheWeek(new Date(2023, 1, 5).getTime());
-      expect(day).toBe(0);
-    });
-    it('should return the day of week (Friday = 5) from the date timestamp', () => {
-      const day = DateUtils.getDayOfTheWeek(new Date(2023, 1, 3).getTime());
-      expect(day).toBe(5);
-    });
-  });
-
 
   describe('addMonths', () => {
     it('should return the date timestamp for the next (1) months in the next (1) years', () => {

--- a/src/incubator/Calendar/helpers/DateUtils.ts
+++ b/src/incubator/Calendar/helpers/DateUtils.ts
@@ -1,10 +1,21 @@
 import _ from 'lodash';
 import getWeek from 'date-fns/getWeek';
-import {FirstDayOfWeek, DayNamesFormat, DateObjectWithOptionalDay, DateObject} from '../types';
+import {FirstDayOfWeek, DayNamesFormat, DateObjectWithOptionalDay, DateObjectWithDate, DateObject} from '../types';
 
 export const HOUR_IN_MS = 60 * 60 * 1000;
 const DAY_IN_MS = 24 * HOUR_IN_MS;
 const WEEK_IN_MS = 7 * DAY_IN_MS;
+
+function getNumberOfWeeksInMonth(year: number, month: number, firstDayOfWeek: FirstDayOfWeek) {
+  const numberOfDaysInMonth = new Date(year, month + 1, 0).getDate();
+  const dayOfTheWeek = new Date(year, month, 1).getDay();
+  
+  // Modify day in the week based on the first day of the week
+  const fixedDayOfTheWeek = (7 - (firstDayOfWeek - dayOfTheWeek)) % 7;
+  const numberOfWeeks = Math.ceil((numberOfDaysInMonth + fixedDayOfTheWeek) / 7);
+  
+  return numberOfWeeks;
+}
 
 export function getWeekNumbersOfMonth(year: number, month: number, firstDayOfWeek: FirstDayOfWeek) {
   if (month < 0 || month > 11) {
@@ -14,24 +25,15 @@ export function getWeekNumbersOfMonth(year: number, month: number, firstDayOfWee
   const firstDayOfMonth = new Date(year, month, 1);
   const firstWeekNumber = getWeek(firstDayOfMonth, {weekStartsOn: firstDayOfWeek});
   const numberOfWeeks = getNumberOfWeeksInMonth(year, month, firstDayOfWeek);
+  
   const weekNumbers: number[] = [];
   _.times(numberOfWeeks, i => weekNumbers.push(i + firstWeekNumber));
-
+  
   return weekNumbers;
 }
 
-export function getNumberOfWeeksInMonth(year: number, month: number, firstDayOfWeek: FirstDayOfWeek) {
-  const numberOfDaysInMonth = new Date(year, month + 1, 0).getDate();
-  const dayOfTheWeek = new Date(year, month, 1).getDay();
-  // Modify day in the week based on the first day of the week
-  const fixedDayOfTheWeek = (7 - (firstDayOfWeek - dayOfTheWeek)) % 7;
-  const numberOfWeeks = Math.ceil((numberOfDaysInMonth + fixedDayOfTheWeek) / 7);
-  return numberOfWeeks;
-}
-
-function getFirstDayInTheWeek(date: number, firstDayOfWeek: FirstDayOfWeek) {
-  const dayOfTheWeek = new Date(date).getDay();
-  let result = date - DAY_IN_MS * ((dayOfTheWeek - firstDayOfWeek) % 7);
+function getFirstDayInTheWeek(date: DateObject, firstDayOfWeek: FirstDayOfWeek) {
+  let result = date.timestamp - DAY_IN_MS * ((date.dayOfTheWeek - firstDayOfWeek) % 7);
   const dayInMonth = getDateObject(result).day;
 
   if (dayInMonth > 1 && dayInMonth <= 7) {
@@ -41,8 +43,8 @@ function getFirstDayInTheWeek(date: number, firstDayOfWeek: FirstDayOfWeek) {
 }
 
 function getFirstDayInTheYear(year: number, firstDayOfWeek: FirstDayOfWeek) {
-  const dayInFirstWeekOfYear = new Date(year, 0, 1);
-  return getFirstDayInTheWeek(dayInFirstWeekOfYear.getTime(), firstDayOfWeek);
+  const dayInFirstWeekOfYear = getDateObject({year, month: 0, day: 1});
+  return getFirstDayInTheWeek(dayInFirstWeekOfYear, firstDayOfWeek);
 }
 
 // TODO: Fix to use Default behavior for week number
@@ -57,30 +59,21 @@ export function getDaysOfWeekNumber(year: number, weekNumber: number, firstDayOf
   return result;
 }
 
-export function getDayOfDate(date: number) {
-  return new Date(date).getDate();
-}
-
-export function getDayOfTheWeek(date: number) {
-  return new Date(date).getDay();
-}
-
 /* Worklets */
 
-export function getDateObject(date: number) {
+export function getDateObject(date: number | DateObjectWithDate) {
   'worklet';
-  const d = new Date(date);
+  const isNumberType = typeof date === 'number';
+  const d = isNumberType ? new Date(date) : new Date(date.year, date.month, date.day);
 
   return {
     day: d.getDate(),
     month: d.getMonth(),
-    year: d.getFullYear()
+    year: d.getFullYear(),
+    dayOfTheWeek: d.getDay(),
+    timestamp: isNumberType ? date : d.getTime(),
+    date: d
   };
-}
-
-export function getTimestamp(date: DateObject) {
-  'worklet';
-  return new Date(date.year, date.month, date.day).getTime();
 }
 
 export function addMonths(date: number, count: number) {
@@ -89,8 +82,9 @@ export function addMonths(date: number, count: number) {
     return date;
   }
 
-  const month = getDateObject(date).month;
-  return new Date(date).setMonth(month + count);
+  const d = new Date(date);
+  const month = d.getMonth();
+  return d.setMonth(month + count);
 }
 
 export function addYears(date: number, count: number) {
@@ -99,8 +93,9 @@ export function addYears(date: number, count: number) {
     return date;
   }
 
-  const year = getDateObject(date).year;
-  return new Date(date).setFullYear(year + count);
+  const d = new Date(date);
+  const year = d.getFullYear();
+  return d.setFullYear(year + count);
 }
 
 export function getMonthForIndex(index: number) {

--- a/src/incubator/Calendar/index.tsx
+++ b/src/incubator/Calendar/index.tsx
@@ -4,7 +4,7 @@ import {FlashListPackage} from 'optionalDeps';
 import {Constants} from '../../commons/new';
 import {generateMonthItems} from './helpers/CalendarProcessor';
 import {addHeaders} from './helpers/DataProcessor';
-import {isSameMonth, getTimestamp, addYears, getDateObject} from './helpers/DateUtils';
+import {isSameMonth, addYears, getDateObject} from './helpers/DateUtils';
 import {CalendarContextProps, CalendarProps, FirstDayOfWeek, UpdateSource, DateObjectWithOptionalDay} from './types';
 import CalendarContext from './CalendarContext';
 import CalendarItem from './CalendarItem';
@@ -74,6 +74,7 @@ function Calendar(props: PropsWithChildren<CalendarProps>) {
   }, [initialDate]);
 
   useDidUpdate(() => {
+    console.log('Update items');
     const index = getItemIndex(current.value);
     scrollToIndex(index);
   }, [items, getItemIndex]);
@@ -136,7 +137,7 @@ function Calendar(props: PropsWithChildren<CalendarProps>) {
     const index = getItemIndex(selected);
     
     if (shouldAddPages(index)) {
-      console.log('Add new pages');
+      console.log('Add new pages: ', index, items.length);
       runOnJS(addPages)(index);
     } else if (lastUpdateSource.value !== UpdateSource.MONTH_SCROLL) {
       if (previous && !isSameMonth(selected, previous)) {
@@ -151,7 +152,7 @@ function Calendar(props: PropsWithChildren<CalendarProps>) {
     const item = viewableItems?.[0]?.item;
     if (item && scrolledByUser.value) {
       if (!isSameMonth(item, current.value)) {
-        const newDate = getTimestamp({year: item.year, month: item.month, day: 1});
+        const newDate = getDateObject({year: item.year, month: item.month, day: 1}).timestamp;
         setDate(newDate, UpdateSource.MONTH_SCROLL);
       }
     }

--- a/src/incubator/Calendar/types.ts
+++ b/src/incubator/Calendar/types.ts
@@ -6,6 +6,15 @@ export interface DateObject {
   month: number;
   year: number;
   day: number;
+  dayOfTheWeek: number;
+  timestamp: number;
+  date: Date;
+}
+
+export interface DateObjectWithDate {
+  month: number;
+  year: number;
+  day: number;
 }
 
 export interface DateObjectWithOptionalDay {


### PR DESCRIPTION
## Description
- Remove 'getDayOfTheWeek' by adding 'dayOfTheWeek' to the DateObject.
- Removing 'getDayOfDate' in favor of getDateObject().day.
- Removing 'getTimestamp' by adding 'timestamp' to the DateObject.
- 'addMonth' and 'addYears' refactor to create only one new Date object.
- 'getDateObject' support DateObjectWithDate to create a dateObject when passing year, month, and day params.
- Change 'getFirstDayInTheWeek' date param to be dateObject to avoid creating a new Date object only to extract the timestamp and back to Date.
- 'getNumberOfWeeksInMonth' removing export as it's not used outside yet.

## Changelog
Calendar - improve date utils

## Additional info
<!--
If applicable, add additional info such as link to the bug being fixed by this PR etc
-->
