### PR TITLE
Fix how we handle style in our Svg image component for web

### DIFF
--- a/src/components/svgImage/index.web.tsx
+++ b/src/components/svgImage/index.web.tsx
@@ -18,16 +18,18 @@ function SvgImage(props: SvgImageProps) {
   const [svgStyleCss, setSvgStyleCss] = useState<string>(EMPTY_STYLE);
   const [postCssStyleCalled, setPostCssStyleCalled] = useState(false);
 
+  const styleObj = JSON.parse(JSON.stringify(style));
+
   const createStyleSvgCss = async (PostCssPackage: {postcss: any; cssjs: any}) => {
     setPostCssStyleCalled(true);
     const {postcss, cssjs} = PostCssPackage;
     postcss()
-      .process(style, {parser: cssjs})
+      .process(styleObj, {parser: cssjs})
       .then((style: {css: any}) => setSvgStyleCss(`{${style.css}}`));
   };
 
   if (isSvgUri(data)) {
-    return <img {...others} src={data.uri} style={style}/>;
+    return <img {...others} src={data.uri} style={styleObj}/>;
   } else if (isBase64ImageContent(data)) {
     if (tintColor) {
       return (
@@ -40,7 +42,7 @@ function SvgImage(props: SvgImageProps) {
         />
       );
     }
-    return <img {...others} src={data} style={style}/>;
+    return <img {...others} src={data} style={styleObj}/>;
   } else if (data) {
     const PostCssPackage = require('../../optionalDependencies').PostCssPackage;
     if (PostCssPackage) {

--- a/src/components/svgImage/index.web.tsx
+++ b/src/components/svgImage/index.web.tsx
@@ -14,10 +14,7 @@ export interface SvgImageProps {
 }
 
 function SvgImage(props: SvgImageProps) {
-  const {data, style, tintColor, ...others} = props;
-
-  const styleObj = Object.assign({}, ...(style || []));
-
+  const {data, style = {}, tintColor, ...others} = props;
   const [svgStyleCss, setSvgStyleCss] = useState<string>(EMPTY_STYLE);
   const [postCssStyleCalled, setPostCssStyleCalled] = useState(false);
 
@@ -25,12 +22,12 @@ function SvgImage(props: SvgImageProps) {
     setPostCssStyleCalled(true);
     const {postcss, cssjs} = PostCssPackage;
     postcss()
-      .process(styleObj, {parser: cssjs})
+      .process(style, {parser: cssjs})
       .then((style: {css: any}) => setSvgStyleCss(`{${style.css}}`));
   };
 
   if (isSvgUri(data)) {
-    return <img {...others} src={data.uri} style={styleObj}/>;
+    return <img {...others} src={data.uri} style={style}/>;
   } else if (isBase64ImageContent(data)) {
     if (tintColor) {
       return (
@@ -43,7 +40,7 @@ function SvgImage(props: SvgImageProps) {
         />
       );
     }
-    return <img {...others} src={data} style={styleObj}/>;
+    return <img {...others} src={data} style={style}/>;
   } else if (data) {
     const PostCssPackage = require('../../optionalDependencies').PostCssPackage;
     if (PostCssPackage) {


### PR DESCRIPTION
## Description
Fix how we handle style in our Svg image component for web
There was a potential issue with how we merge the incoming style prop that can be either an object or an array 

## Changelog
SvgImage (web) - fix issue with style being passed as object

## Additional info
<!--
If applicable, add additional info such as link to the bug being fixed by this PR etc
-->
