### PR TITLE
Include TouchableOpacityProps in SwitchProps

### DIFF
--- a/src/components/switch/index.tsx
+++ b/src/components/switch/index.tsx
@@ -2,14 +2,14 @@ import React, {Component} from 'react';
 import {StyleSheet, Animated, Easing, StyleProp, ViewStyle, ColorValue} from 'react-native';
 import {Colors, BorderRadiuses} from '../../style';
 import {Constants, asBaseComponent} from '../../commons/new';
-import TouchableOpacity from '../touchableOpacity';
+import TouchableOpacity, {TouchableOpacityProps} from '../touchableOpacity';
 
 const INNER_PADDING = 2;
 const DEFAULT_WIDTH = 42;
 const DEFAULT_HEIGHT = 24;
 const DEFAULT_THUMB_SIZE = 20;
 
-export type SwitchProps = {
+export type SwitchProps = TouchableOpacityProps & {
   /**
    * The value of the switch. If true the switch will be turned on. Default value is false
    */


### PR DESCRIPTION
## Description
Switch props passed on to TouchableOpacity component but typing wise didn't support TouchableOpacity props

## Changelog
Switch - fix props types to include TouchableOpacity props

## Additional info

