### PR TITLE
Incubator.TextField - fix context menu not showing in centered and empty input

### DIFF
--- a/src/incubator/TextField/index.tsx
+++ b/src/incubator/TextField/index.tsx
@@ -116,7 +116,7 @@ const TextField = (props: InternalTextFieldProps) => {
     return centered ? [validationMessageStyle, styles.centeredValidationMessage] : validationMessageStyle;
   }, [validationMessageStyle, centered]);
   const inputStyle = useMemo(() => {
-    return [typographyStyle, colorStyle, others.style, centered && styles.centeredInput];
+    return [typographyStyle, colorStyle, others.style, fieldState.value && centered && styles.centeredInput];
   }, [typographyStyle, colorStyle, others.style, centered]);
   const dummyPlaceholderStyle = useMemo(() => {
     return [inputStyle, styles.dummyPlaceholder];


### PR DESCRIPTION

## Description
Incubator.TextField - fix iOS - the context menu not showing in a centered and empty input

**iOS only**
Try this with and without the fix
`          <Incubator.TextField centered onChangeText={(text) => this.setState({text})} placeholder={'UILIB text field centered'}/>
`
1) Copy a value from some input (marking it, long press for context menu, press 'copy').
2) Long press on the text field when it is empty to display the context menu (for 'paste' action) - without the fix you'll see only the magnifying glass but the context menu will not show. With the fix, you'll see the context menu with a 'paste' action.

## Changelog
Incubator.TextField - fix iOS - the context menu not showing in a centered and empty input


## Additional info
WOAUILIB-3585
