### PR TITLE
WheelPicker - Android - fix missing values when initialValue is sent

### DIFF
--- a/src/components/WheelPicker/index.tsx
+++ b/src/components/WheelPicker/index.tsx
@@ -351,7 +351,7 @@ const WheelPicker = ({
             decelerationRate={Constants.isAndroid ? 0.98 : 'normal'}
             renderItem={renderItem}
             getItemLayout={getItemLayout}
-            initialScrollIndex={currentIndex}
+            initialScrollIndex={Constants.isIOS ? currentIndex : undefined}
             onContentSizeChange={updateFlatListWidth}
             /* This fixes an issue with RTL when centering flatlist content using alignSelf */
             centerContent={align === 'center' && Constants.isRTL}


### PR DESCRIPTION
## Description
WheelPicker - Android - fix missing values when initialValue is sent
We think that this was broken again in RN71

## Changelog
WheelPicker - Android - fix missing values when initialValue is sent

## Additional info
None
