### PR TITLE
Fixed TabBar scroll when there is selected index

### DIFF
--- a/src/components/tabController/TabBar.tsx
+++ b/src/components/tabController/TabBar.tsx
@@ -165,13 +165,7 @@ const TabBar = (props: Props) => {
   const tabBar = useRef<typeof FadedScrollView>();
   const [key, setKey] = useState<orientations>(Constants.orientation);
   const context = useContext(TabBarContext);
-  const {
-    items: contextItems,
-    currentPage,
-    targetPage,
-    initialIndex,
-    containerWidth: contextContainerWidth
-  } = context;
+  const {items: contextItems, currentPage, targetPage, containerWidth: contextContainerWidth} = context;
   const containerWidth: number = useMemo(() => {
     return propsContainerWidth || contextContainerWidth;
   }, [propsContainerWidth, contextContainerWidth]);
@@ -194,7 +188,7 @@ const TabBar = (props: Props) => {
     // @ts-expect-error TODO: typing bug
     scrollViewRef: tabBar,
     itemsCount,
-    selectedIndex: initialIndex,
+    selectedIndex: currentPage.value,
     containerWidth,
     offsetType: centerSelected ? useScrollToItem.offsetType.CENTER : useScrollToItem.offsetType.DYNAMIC
   });


### PR DESCRIPTION
## Description
TabBar selectedIndex changed to the currentPage instead of initialIndex.
When the items sent to the TabController change the selectedIndex will stay on the current page.

## Changelog
TabBar stays on the selected index when items change.

## Additional info
