### PR TITLE
Toast animation fixed

### DIFF
--- a/demo/src/screens/incubatorScreens/IncubatorToastScreen.tsx
+++ b/demo/src/screens/incubatorScreens/IncubatorToastScreen.tsx
@@ -30,14 +30,25 @@ class ToastsScreen extends Component {
     selectedAction: 'none' as keyof typeof TOAST_ACTIONS,
     hasAttachment: false,
     selectedPreset: '' as Incubator.ToastProps['preset'] & '',
-    isSwipeable: true
+    isSwipeable: true,
+    containerStyle: undefined as Incubator.ToastProps['containerStyle'],
+    renderAbove: false
   };
 
   toggleVisibility = () => {
     // Im using this for storing toast visible since setState is async and takes time to response
     this.showToast = !this.showToast;
     this.setState({
-      visible: this.showToast
+      visible: this.showToast,
+      containerStyle: undefined
+    });
+  };
+
+  toggleVisibilityWithStyle = () => {
+    this.showToast = !this.showToast;
+    this.setState({
+      visible: this.showToast,
+      containerStyle: {marginBottom: 100}
     });
   };
 
@@ -93,8 +104,16 @@ class ToastsScreen extends Component {
   };
 
   renderToast = () => {
-    const {visible, toastPosition, showLoader, isCustomContent, hasAttachment, selectedPreset, isSwipeable} =
-      this.state;
+    const {
+      visible,
+      toastPosition,
+      showLoader,
+      isCustomContent,
+      hasAttachment,
+      selectedPreset,
+      isSwipeable,
+      containerStyle
+    } = this.state;
     const action = this.getAction();
 
     return (
@@ -110,6 +129,7 @@ class ToastsScreen extends Component {
         swipeable={isSwipeable}
         onDismiss={this.toggleVisibility}
         autoDismiss={3500}
+        containerStyle={containerStyle}
         // backgroundColor={Colors.$backgroundSuccessLight}
         // icon={Assets.icons.demo.add}
         // iconColor={Colors.$backgroundSuccessHeavy}
@@ -136,6 +156,7 @@ class ToastsScreen extends Component {
   };
 
   render() {
+    const {renderAbove} = this.state;
     return (
       <View flex padding-page>
         <Text $textDefault h1 marginB-s4>
@@ -153,6 +174,7 @@ class ToastsScreen extends Component {
             {renderBooleanOption.call(this, 'Use custom content', 'isCustomContent')}
             {renderBooleanOption.call(this, 'With an attachment', 'hasAttachment')}
             {renderBooleanOption.call(this, 'Swipeable', 'isSwipeable')}
+            {renderBooleanOption.call(this, 'Above Button', 'renderAbove')}
 
             {renderRadioGroup.call(this,
               'Action',
@@ -174,6 +196,17 @@ class ToastsScreen extends Component {
 
             {this.renderToggleButton()}
           </ScrollView>
+          {renderAbove && (
+            <View centerH bottom marginV-s4>
+              <Button
+                testID={`uilib.showToast`}
+                marginT-10
+                marginB-10
+                label={'Bottom Button'}
+                onPress={this.toggleVisibilityWithStyle}
+              />
+            </View>
+          )}
         </View>
         {this.renderToast()}
       </View>

--- a/src/incubator/toast/helpers/useToastAnimation.ts
+++ b/src/incubator/toast/helpers/useToastAnimation.ts
@@ -20,6 +20,7 @@ export default ({
 }: UseToastAnimationProps) => {
   const toastAnimatedValue = useRef<Animated.Value>(new Animated.Value(0));
   const [isAnimating, setIsAnimating] = useState<boolean>();
+  const duration = toastHeight <= 500 ? 300 : toastHeight * 0.7;
 
   const _onAnimationEnd = () => {
     if (visible) {
@@ -35,7 +36,7 @@ export default ({
   const toggleToast = (show = false, {delay}: {delay?: number} = {}) => {
     Animated.timing(toastAnimatedValue.current, {
       toValue: Number(show),
-      duration: 300,
+      duration,
       delay,
       easing: Easing.bezier(0.215, 0.61, 0.355, 1),
       useNativeDriver: true


### PR DESCRIPTION
## Description
When Toast was rendered all the components beneath the Toast weren't clickable, 

## Changelog
<!--
Add a quick message for our users about this change (include Component name, relevant props and general purpose of the PR)
-->

## Additional info
<!--
If applicable, add additional info such as link to the bug being fixed by this PR etc
-->
