### PR TITLE
feat/enhance text highlight string

### DIFF
--- a/demo/src/screens/componentScreens/TextScreen.tsx
+++ b/demo/src/screens/componentScreens/TextScreen.tsx
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {Animated, ScrollView} from 'react-native';
+import {Alert, Animated, ScrollView} from 'react-native';
 import {View, Text, Colors} from 'react-native-ui-lib';
 
 class TextScreen extends Component {
@@ -84,6 +84,39 @@ class TextScreen extends Component {
             </Text>
             <Text text60R highlightString={['dancing', 'da']} highlightStyle={{color: Colors.green30}}>
               Dancing in The Dark
+            </Text>
+            <Text
+              text60R
+              highlightString={{
+                string: 'Dancing',
+                onPress: () => Alert.alert('Dancing is pressed!'),
+                style: {color: Colors.blue10, backgroundColor: Colors.green50}
+              }}
+              highlightStyle={{color: Colors.green30}}
+            >
+              Dancing in The Dark
+            </Text>
+            <Text
+              text60R
+              highlightString={[
+                {
+                  string: 'Dancing',
+                  onPress: () => Alert.alert('Dancing is pressed!'),
+                  style: {color: Colors.blue10, backgroundColor: Colors.green50}
+                },
+                {
+                  string: 'laugh',
+                  onPress: () => Alert.alert('laugh is pressed!'),
+                  style: {color: Colors.red50, textDecorationLine: 'underline', textDecorationColor: Colors.blue30}
+                },
+                {
+                  string: 'more',
+                  onPress: () => Alert.alert('more is pressed!')
+                }
+              ]}
+              highlightStyle={{color: Colors.green30}}
+            >
+              Dancing in The Dark, laughing drinking and more
             </Text>
           </View>
           {this.renderDivider()}

--- a/src/components/text/__tests__/index.driver.spec.tsx
+++ b/src/components/text/__tests__/index.driver.spec.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import View from '../../view';
-import Text from '../index';
+import Text, {HighlightString} from '../index';
 import {TextDriver} from '../Text.driver';
+import {Colors} from '../../../style';
+import {TextStyle} from 'react-native';
 
 const TEXT_ID = 'text_test_id';
 const TEXT_CONTENT = 'text content';
@@ -34,11 +36,201 @@ describe('Text', () => {
       expect(await textDriver.isPressable()).toBeFalsy();
     });
   });
+
+  describe('highlightString', () => {
+    const HIGHLIGHT_STRING_TEST_ID = 'highlight-string-test-id';
+
+    describe('single highlightString', () => {
+      describe('style', () => {
+        it('should render highlight string with a given style', async () => {
+          const component = WrapperScreenWithText({
+            highlightString: {
+              string: 'content',
+              style: {color: Colors.red30, textDecorationLine: 'underline'},
+              testID: HIGHLIGHT_STRING_TEST_ID
+            }
+          });
+          const textDriver = new TextDriver({component, testID: TEXT_ID});
+          const {style} = await textDriver.getPropsByTestId(HIGHLIGHT_STRING_TEST_ID);
+
+          expect(style).toEqual({color: Colors.red30, textDecorationLine: 'underline'});
+        });
+
+        it('should render highlight string with the general highlightStyle prop style if no specific style given', async () => {
+          const component = WrapperScreenWithText({
+            highlightString: {
+              string: 'content',
+              testID: HIGHLIGHT_STRING_TEST_ID
+            },
+            highlightStyle: {color: Colors.blue50}
+          });
+          const textDriver = new TextDriver({component, testID: TEXT_ID});
+          const {style} = await textDriver.getPropsByTestId(HIGHLIGHT_STRING_TEST_ID);
+
+          expect(style).toEqual([{color: Colors.grey30}, {color: Colors.blue50}]);
+        });
+      });
+
+      describe('onPress', () => {
+        it('should press on highlighted text and run its callback', async () => {
+          const onPressCallback = jest.fn();
+          const component = WrapperScreenWithText({
+            highlightString: {
+              string: 'content',
+              onPress: onPressCallback,
+              testID: HIGHLIGHT_STRING_TEST_ID
+            }
+          });
+
+          const textDriver = new TextDriver({component, testID: HIGHLIGHT_STRING_TEST_ID});
+          await textDriver.press();
+
+          expect(onPressCallback).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not be pressable if onPress prop is not supplied for a highlightString', async () => {
+          const component = WrapperScreenWithText({
+            highlightString: {
+              string: 'content',
+              testID: HIGHLIGHT_STRING_TEST_ID
+            }
+          });
+
+          const textDriver = new TextDriver({component, testID: HIGHLIGHT_STRING_TEST_ID});
+
+          expect(await textDriver.isPressable()).toBeFalsy();
+        });
+      });
+    });
+
+    describe('highlightString array', () => {
+      const LONGER_TEXT_CONTENT = 'a longer text content to test';
+      const HIGHLIGHT_STRING_2_TEST_ID = 'highlight-string-2-test-id';
+
+      describe('style', () => {
+        it('should render multiple highlight strings, each with its given style', async () => {
+          const component = WrapperScreenWithText({
+            text: LONGER_TEXT_CONTENT,
+            highlightString: [
+              {
+                string: 'longer',
+                style: {color: Colors.red30, textDecorationLine: 'underline'},
+                testID: HIGHLIGHT_STRING_TEST_ID
+              },
+              {
+                string: 'test',
+                style: {color: Colors.yellow40, textDecorationLine: 'line-through'},
+                testID: HIGHLIGHT_STRING_2_TEST_ID
+              }
+            ]
+          });
+
+          const textDriver = new TextDriver({component, testID: TEXT_ID});
+          const {style: style1} = await textDriver.getPropsByTestId(HIGHLIGHT_STRING_TEST_ID);
+          const {style: style2} = await textDriver.getPropsByTestId(HIGHLIGHT_STRING_2_TEST_ID);
+
+          expect(style1).toEqual({color: Colors.red30, textDecorationLine: 'underline'});
+          expect(style2).toEqual({color: Colors.yellow40, textDecorationLine: 'line-through'});
+        });
+
+        it('should render highlight string with the general highlightStyle prop style if no specific style given', async () => {
+          const component = WrapperScreenWithText({
+            text: LONGER_TEXT_CONTENT,
+            highlightString: [
+              {
+                string: 'longer',
+                style: {color: Colors.red30, textDecorationLine: 'underline'},
+                testID: HIGHLIGHT_STRING_TEST_ID
+              },
+              {
+                string: 'test',
+                testID: HIGHLIGHT_STRING_2_TEST_ID
+              }
+            ],
+            highlightStyle: {color: Colors.blue50}
+          });
+
+          const textDriver = new TextDriver({component, testID: TEXT_ID});
+
+          const {style} = await textDriver.getPropsByTestId(HIGHLIGHT_STRING_TEST_ID);
+          const {style: style2} = await textDriver.getPropsByTestId(HIGHLIGHT_STRING_2_TEST_ID);
+
+          expect(style).toEqual({color: Colors.red30, textDecorationLine: 'underline'});
+          expect(style2).toEqual([{color: Colors.grey30}, {color: Colors.blue50}]);
+        });
+      });
+
+      describe('onPress', () => {
+        it('should press on highlighted texts and run their respective callbacks', async () => {
+          const onPressCallback1 = jest.fn();
+          const onPressCallback2 = jest.fn();
+          const component = WrapperScreenWithText({
+            text: LONGER_TEXT_CONTENT,
+            highlightString: [
+              {
+                string: 'longer',
+                onPress: onPressCallback1,
+                testID: HIGHLIGHT_STRING_TEST_ID
+              },
+              {
+                string: 'test',
+                onPress: onPressCallback2,
+                testID: HIGHLIGHT_STRING_2_TEST_ID
+              }
+            ]
+          });
+
+          const textDriver1 = new TextDriver({component, testID: HIGHLIGHT_STRING_TEST_ID});
+          await textDriver1.press();
+
+          expect(onPressCallback1).toHaveBeenCalledTimes(1);
+
+          const textDriver2 = new TextDriver({component, testID: HIGHLIGHT_STRING_2_TEST_ID});
+          await textDriver2.press();
+
+          expect(onPressCallback2).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not be pressable if onPress prop is not supplied for a highlightString', async () => {
+          const onPressCallback = jest.fn();
+          const component = WrapperScreenWithText({
+            text: LONGER_TEXT_CONTENT,
+            highlightString: [
+              {
+                string: 'longer',
+                onPress: onPressCallback,
+                testID: HIGHLIGHT_STRING_TEST_ID
+              },
+              {
+                string: 'test',
+                testID: HIGHLIGHT_STRING_2_TEST_ID
+              }
+            ]
+          });
+
+          const textDriver1 = new TextDriver({component, testID: HIGHLIGHT_STRING_TEST_ID});
+          const textDriver2 = new TextDriver({component, testID: HIGHLIGHT_STRING_2_TEST_ID});
+
+          expect(await textDriver1.isPressable()).toBeTruthy();
+          expect(await textDriver2.isPressable()).toBeFalsy();
+        });
+      });
+    });
+  });
 });
 
-function WrapperScreenWithText(textProps: {onPress?: jest.Mock} = {}) {
-  const {onPress} = textProps;
+function WrapperScreenWithText(textProps: {
+  text?: string;
+  onPress?: jest.Mock,
+  highlightString?: HighlightString | HighlightString[],
+  highlightStyle?: TextStyle
+  } = {}) {
+  const {
+    onPress,
+    highlightString,
+    text,
+    highlightStyle} = textProps;
   return (<View>
-    <Text testID={TEXT_ID} onPress={onPress} >{TEXT_CONTENT}</Text>
+    <Text testID={TEXT_ID} onPress={onPress} highlightString={highlightString} highlightStyle={highlightStyle}>{text ?? TEXT_CONTENT}</Text>
   </View>);
 }

--- a/src/components/text/__tests__/index.driver.spec.tsx
+++ b/src/components/text/__tests__/index.driver.spec.tsx
@@ -231,6 +231,13 @@ function WrapperScreenWithText(textProps: {
     text,
     highlightStyle} = textProps;
   return (<View>
-    <Text testID={TEXT_ID} onPress={onPress} highlightString={highlightString} highlightStyle={highlightStyle}>{text ?? TEXT_CONTENT}</Text>
+    <Text
+      testID={TEXT_ID}
+      onPress={onPress}
+      highlightString={highlightString}
+      highlightStyle={highlightStyle}
+    >
+      {text ?? TEXT_CONTENT}
+    </Text>
   </View>);
 }

--- a/src/components/text/__tests__/index.spec.tsx
+++ b/src/components/text/__tests__/index.spec.tsx
@@ -1,0 +1,218 @@
+import React from 'react';
+import View from '../../view';
+import Text, {HighlightString} from '../index';
+import {TextDriver} from '../Text.driver';
+import {Colors} from '../../../style';
+import {TextStyle} from 'react-native';
+
+const TEXT_ID = 'text_test_id';
+const TEXT_CONTENT = 'text content';
+describe('Text', () => {
+  afterEach(() => {
+    TextDriver.clear();
+  });
+
+  describe('highlightString', () => {
+    const HIGHLIGHT_STRING_TEST_ID = 'highlight-string-test-id';
+
+    describe('single highlightString', () => {
+      describe('style', () => {
+        it('should render highlight string with a given style', async () => {
+          const component = WrapperScreenWithText({
+            highlightString: {
+              string: 'content',
+              style: {color: Colors.red30, textDecorationLine: 'underline'},
+              testID: HIGHLIGHT_STRING_TEST_ID
+            }
+          });
+          const textDriver = new TextDriver({component, testID: TEXT_ID});
+          const {style} = await textDriver.getPropsByTestId(HIGHLIGHT_STRING_TEST_ID);
+
+          expect(style).toEqual({color: Colors.red30, textDecorationLine: 'underline'});
+        });
+
+        it('should render highlight string with the general highlightStyle prop style if no specific style given', async () => {
+          const component = WrapperScreenWithText({
+            highlightString: {
+              string: 'content',
+              testID: HIGHLIGHT_STRING_TEST_ID
+            },
+            highlightStyle: {color: Colors.blue50}
+          });
+          const textDriver = new TextDriver({component, testID: TEXT_ID});
+          const {style} = await textDriver.getPropsByTestId(HIGHLIGHT_STRING_TEST_ID);
+
+          expect(style).toEqual([{color: Colors.grey30}, {color: Colors.blue50}]);
+        });
+      });
+
+      describe('onPress', () => {
+        it('should press on highlighted text and run its callback', async () => {
+          const onPressCallback = jest.fn();
+          const component = WrapperScreenWithText({
+            highlightString: {
+              string: 'content',
+              onPress: onPressCallback,
+              testID: HIGHLIGHT_STRING_TEST_ID
+            }
+          });
+
+          const textDriver = new TextDriver({component, testID: HIGHLIGHT_STRING_TEST_ID});
+          await textDriver.press();
+
+          expect(onPressCallback).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not be pressable if onPress prop is not supplied for a highlightString', async () => {
+          const component = WrapperScreenWithText({
+            highlightString: {
+              string: 'content',
+              testID: HIGHLIGHT_STRING_TEST_ID
+            }
+          });
+
+          const textDriver = new TextDriver({component, testID: HIGHLIGHT_STRING_TEST_ID});
+
+          expect(await textDriver.isPressable()).toBeFalsy();
+        });
+      });
+    });
+
+    describe('highlightString array', () => {
+      const LONGER_TEXT_CONTENT = 'a longer text content to test';
+      const HIGHLIGHT_STRING_2_TEST_ID = 'highlight-string-2-test-id';
+
+      describe('style', () => {
+        it('should render multiple highlight strings, each with its given style', async () => {
+          const component = WrapperScreenWithText({
+            text: LONGER_TEXT_CONTENT,
+            highlightString: [
+              {
+                string: 'longer',
+                style: {color: Colors.red30, textDecorationLine: 'underline'},
+                testID: HIGHLIGHT_STRING_TEST_ID
+              },
+              {
+                string: 'test',
+                style: {color: Colors.yellow40, textDecorationLine: 'line-through'},
+                testID: HIGHLIGHT_STRING_2_TEST_ID
+              }
+            ]
+          });
+
+          const textDriver = new TextDriver({component, testID: TEXT_ID});
+          const {style: style1} = await textDriver.getPropsByTestId(HIGHLIGHT_STRING_TEST_ID);
+          const {style: style2} = await textDriver.getPropsByTestId(HIGHLIGHT_STRING_2_TEST_ID);
+
+          expect(style1).toEqual({color: Colors.red30, textDecorationLine: 'underline'});
+          expect(style2).toEqual({color: Colors.yellow40, textDecorationLine: 'line-through'});
+        });
+
+        it('should render highlight string with the general highlightStyle prop style if no specific style given', async () => {
+          const component = WrapperScreenWithText({
+            text: LONGER_TEXT_CONTENT,
+            highlightString: [
+              {
+                string: 'longer',
+                style: {color: Colors.red30, textDecorationLine: 'underline'},
+                testID: HIGHLIGHT_STRING_TEST_ID
+              },
+              {
+                string: 'test',
+                testID: HIGHLIGHT_STRING_2_TEST_ID
+              }
+            ],
+            highlightStyle: {color: Colors.blue50}
+          });
+
+          const textDriver = new TextDriver({component, testID: TEXT_ID});
+
+          const {style} = await textDriver.getPropsByTestId(HIGHLIGHT_STRING_TEST_ID);
+          const {style: style2} = await textDriver.getPropsByTestId(HIGHLIGHT_STRING_2_TEST_ID);
+
+          expect(style).toEqual({color: Colors.red30, textDecorationLine: 'underline'});
+          expect(style2).toEqual([{color: Colors.grey30}, {color: Colors.blue50}]);
+        });
+      });
+
+      describe('onPress', () => {
+        it('should press on highlighted texts and run their respective callbacks', async () => {
+          const onPressCallback1 = jest.fn();
+          const onPressCallback2 = jest.fn();
+          const component = WrapperScreenWithText({
+            text: LONGER_TEXT_CONTENT,
+            highlightString: [
+              {
+                string: 'longer',
+                onPress: onPressCallback1,
+                testID: HIGHLIGHT_STRING_TEST_ID
+              },
+              {
+                string: 'test',
+                onPress: onPressCallback2,
+                testID: HIGHLIGHT_STRING_2_TEST_ID
+              }
+            ]
+          });
+
+          const textDriver1 = new TextDriver({component, testID: HIGHLIGHT_STRING_TEST_ID});
+          await textDriver1.press();
+
+          expect(onPressCallback1).toHaveBeenCalledTimes(1);
+
+          const textDriver2 = new TextDriver({component, testID: HIGHLIGHT_STRING_2_TEST_ID});
+          await textDriver2.press();
+
+          expect(onPressCallback2).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not be pressable if onPress prop is not supplied for a highlightString', async () => {
+          const onPressCallback = jest.fn();
+          const component = WrapperScreenWithText({
+            text: LONGER_TEXT_CONTENT,
+            highlightString: [
+              {
+                string: 'longer',
+                onPress: onPressCallback,
+                testID: HIGHLIGHT_STRING_TEST_ID
+              },
+              {
+                string: 'test',
+                testID: HIGHLIGHT_STRING_2_TEST_ID
+              }
+            ]
+          });
+
+          const textDriver1 = new TextDriver({component, testID: HIGHLIGHT_STRING_TEST_ID});
+          const textDriver2 = new TextDriver({component, testID: HIGHLIGHT_STRING_2_TEST_ID});
+
+          expect(await textDriver1.isPressable()).toBeTruthy();
+          expect(await textDriver2.isPressable()).toBeFalsy();
+        });
+      });
+    });
+  });
+});
+
+function WrapperScreenWithText(textProps: {
+  text?: string;
+  onPress?: jest.Mock,
+  highlightString?: HighlightString | HighlightString[],
+  highlightStyle?: TextStyle
+} = {}) {
+  const {
+    onPress,
+    highlightString,
+    text,
+    highlightStyle} = textProps;
+  return (<View>
+    <Text
+      testID={TEXT_ID}
+      onPress={onPress}
+      highlightString={highlightString}
+      highlightStyle={highlightStyle}
+    >
+      {text ?? TEXT_CONTENT}
+    </Text>
+  </View>);
+}

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -15,6 +15,24 @@ import {RecorderProps} from '../../../typings/recorderTypes';
 import {Colors} from 'style';
 import {TextUtils} from 'utils';
 
+export interface HighlightStringProps {
+  /**
+   * Substring to highlight
+   */
+  string: string;
+  /**
+   * Callback for when a highlight string is pressed
+   */
+  onPress?: () => void;
+  /**
+   * Custom highlight style for this specific highlight string. If not provided, the general @highlightStyle prop style will be used
+   */
+  style?: TextStyle;
+  testID?: string;
+}
+
+export type HighlightString = string | HighlightStringProps;
+
 export type TextProps = RNTextProps &
   TypographyModifiers &
   ColorsModifiers &
@@ -38,9 +56,9 @@ export type TextProps = RNTextProps &
      */
     underline?: boolean;
     /**
-     * Substring to highlight
+     * Substring to highlight. Can be a simple string of a HighlightStringProps object, or an array of the above
      */
-    highlightString?: string | string[];
+    highlightString?: HighlightString | HighlightString[];
     /**
      * Custom highlight style for highlight string
      */
@@ -92,7 +110,9 @@ class Text extends PureComponent<PropsTypes> {
             return (
               <RNText
                 key={index}
-                style={text.shouldHighlight ? [styles.highlight, highlightStyle] : styles.notHighlight}
+                style={text.shouldHighlight ? (text.style ?? [styles.highlight, highlightStyle]) : styles.notHighlight}
+                onPress={text.onPress}
+                testID={text.testID}
               >
                 {text.string}
               </RNText>

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -56,7 +56,7 @@ export type TextProps = RNTextProps &
      */
     underline?: boolean;
     /**
-     * Substring to highlight. Can be a simple string of a HighlightStringProps object, or an array of the above
+     * Substring to highlight. Can be a simple string or a HighlightStringProps object, or an array of the above
      */
     highlightString?: HighlightString | HighlightString[];
     /**

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -21,11 +21,11 @@ export interface HighlightStringProps {
    */
   string: string;
   /**
-   * Callback for when a highlight string is pressed
+   * Callback for when a highlighted substring is pressed
    */
   onPress?: () => void;
   /**
-   * Custom highlight style for this specific highlight string. If not provided, the general @highlightStyle prop style will be used
+   * Custom highlight style for this specific highlighted substring. If not provided, the general `highlightStyle` prop style will be used
    */
   style?: TextStyle;
   testID?: string;

--- a/src/components/text/text.api.json
+++ b/src/components/text/text.api.json
@@ -14,7 +14,7 @@
     {"name": "center", "type": "boolean", "description": "Whether to center the text (using textAlign)"},
     {"name": "uppercase", "type": "boolean", "description": "Whether to change the text to uppercase"},
     {"name": "underline", "type": "boolean", "description": "Whether to add an underline"},
-    {"name": "highlightString", "type": "HighlightString | HighlightString[]", "description": "Substring to highlight. Can be a simple string of a HighlightStringProps object, or an array of the above"},
+    {"name": "highlightString", "type": "HighlightString | HighlightString[]", "description": "Substring to highlight. Can be a simple string or a HighlightStringProps object, or an array of the above"},
     {"name": "highlightStyle", "type": "TextStyle", "description": "Custom highlight style for highlight string"},
     {"name": "recorderTag", "type": "'mask' | 'unmask'", "description": "Recorder Tag"},
     {"name": "animated", "type": "boolean", "description": "Use Animated.Text as a container"}

--- a/src/components/text/text.api.json
+++ b/src/components/text/text.api.json
@@ -14,7 +14,7 @@
     {"name": "center", "type": "boolean", "description": "Whether to center the text (using textAlign)"},
     {"name": "uppercase", "type": "boolean", "description": "Whether to change the text to uppercase"},
     {"name": "underline", "type": "boolean", "description": "Whether to add an underline"},
-    {"name": "highlightString", "type": "string | string[]", "description": "Substring to highlight"},
+    {"name": "highlightString", "type": "HighlightString | HighlightString[]", "description": "Substring to highlight. Can be a simple string of a HighlightStringProps object, or an array of the above"},
     {"name": "highlightStyle", "type": "TextStyle", "description": "Custom highlight style for highlight string"},
     {"name": "recorderTag", "type": "'mask' | 'unmask'", "description": "Recorder Tag"},
     {"name": "animated", "type": "boolean", "description": "Use Animated.Text as a container"}

--- a/src/utils/__tests__/textUtils.spec.js
+++ b/src/utils/__tests__/textUtils.spec.js
@@ -1,164 +1,446 @@
 import {getTextPartsByHighlight, getArrayPartsByHighlight} from '../textUtils';
 
 describe('Text', () => {
+  const mockHighlightStringProps = {
+    onPress: jest.fn(),
+    style: {color: 'red'},
+    testID: 'highlighted-string-test-id'
+  };
+
   describe('getTextPartsByHighlight', () => {
-    it('should return the whole string as a single part when highlight string is undefined', () => {
-      const result = getTextPartsByHighlight('Playground Screen', undefined);
-      expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
-    });
-    it('should return the whole string as a single part when highlight string is empty', () => {
-      const result = getTextPartsByHighlight('Playground Screen', '');
-      expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
-    });
-    it('should return the whole string as a single part when highlight string dont match', () => {
-      const result = getTextPartsByHighlight('Playground Screen', 'aaa');
-      expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
-    });
-    it('should break text to parts according to highlight string', () => {
-      const result = getTextPartsByHighlight('Playground Screen', 'Scr');
-      expect(result).toEqual([
-        {string: 'Playground ', shouldHighlight: false},
-        {string: 'Scr', shouldHighlight: true},
-        {string: 'een', shouldHighlight: false}
-      ]);
+    describe('Simple string', () => {
+      it('should return the whole string as a single part when highlight string is undefined', () => {
+        const result = getTextPartsByHighlight('Playground Screen', undefined);
+        expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
+      });
+      it('should return the whole string as a single part when highlight string is empty', () => {
+        const result = getTextPartsByHighlight('Playground Screen', '');
+        expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
+      });
+      it('should return the whole string as a single part when highlight string dont match', () => {
+        const result = getTextPartsByHighlight('Playground Screen', 'aaa');
+        expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
+      });
+      it('should break text to parts according to highlight string', () => {
+        const result = getTextPartsByHighlight('Playground Screen', 'Scr');
+        expect(result).toEqual([
+          {string: 'Playground ', shouldHighlight: false},
+          {string: 'Scr', shouldHighlight: true},
+          {string: 'een', shouldHighlight: false}
+        ]);
+      });
+
+      it('should handle case when highlight repeats more than once', () => {
+        const result = getTextPartsByHighlight('Dancing in the Dark', 'Da');
+        expect(result).toEqual([
+          {string: 'Da', shouldHighlight: true},
+          {string: 'ncing in the ', shouldHighlight: false},
+          {string: 'Da', shouldHighlight: true},
+          {string: 'rk', shouldHighlight: false}
+        ]);
+      });
+
+      it('should be case-insensitive', () => {
+        const result = getTextPartsByHighlight('Dancing in the Dark', 'da');
+        expect(result).toEqual([
+          {string: 'Da', shouldHighlight: true},
+          {string: 'ncing in the ', shouldHighlight: false},
+          {string: 'Da', shouldHighlight: true},
+          {string: 'rk', shouldHighlight: false}
+        ]);
+      });
+
+      it('Should handle special characters @', () => {
+        const result = getTextPartsByHighlight('@ancing in the @ark', '@a');
+        expect(result).toEqual([
+          {string: '@a', shouldHighlight: true},
+          {string: 'ncing in the ', shouldHighlight: false},
+          {string: '@a', shouldHighlight: true},
+          {string: 'rk', shouldHighlight: false}
+        ]);
+      });
+
+      it('Should handle special characters !', () => {
+        const result = getTextPartsByHighlight('!ancing in the !ark', '!a');
+        expect(result).toEqual([
+          {string: '!a', shouldHighlight: true},
+          {string: 'ncing in the ', shouldHighlight: false},
+          {string: '!a', shouldHighlight: true},
+          {string: 'rk', shouldHighlight: false}
+        ]);
+      });
+
+      it('Should handle special characters starts with @', () => {
+        const result = getTextPartsByHighlight('uilib@wix.com', '@wix');
+        expect(result).toEqual([
+          {string: 'uilib', shouldHighlight: false},
+          {string: '@wix', shouldHighlight: true},
+          {string: '.com', shouldHighlight: false}
+        ]);
+      });
+
+      it('Should handle empty string.', () => {
+        const result = getTextPartsByHighlight('@ancing in the @ark', '');
+        expect(result).toEqual([{string: '@ancing in the @ark', shouldHighlight: false}]);
+      });
+
+      it('Should handle full string.', () => {
+        const result = getTextPartsByHighlight('Dancing in the Dark', 'Dancing in the Dark');
+        expect(result).toEqual([{string: 'Dancing in the Dark', shouldHighlight: true}]);
+      });
+
+      it('Should handle longer string.', () => {
+        const result = getTextPartsByHighlight('Dancing in the Dark', 'Dancing in the Darker');
+        expect(result).toEqual([{string: 'Dancing in the Dark', shouldHighlight: false}]);
+      });
     });
 
-    it('should handle case when highlight repeats more than once', () => {
-      const result = getTextPartsByHighlight('Dancing in the Dark', 'Da');
-      expect(result).toEqual([
-        {string: 'Da', shouldHighlight: true},
-        {string: 'ncing in the ', shouldHighlight: false},
-        {string: 'Da', shouldHighlight: true},
-        {string: 'rk', shouldHighlight: false}
-      ]);
-    });
+    describe('HighlightStringProps object', () => {
+      it('should return the whole string as a single part when highlight string is empty', () => {
+        const highlightString = {
+          string: '',
+          ...mockHighlightStringProps
+        };
+        const result = getTextPartsByHighlight('Playground Screen', highlightString);
+        expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
+      });
+      it('should return the whole string as a single part when highlight string dont match', () => {
+        const highlightString = {
+          string: 'aaa',
+          onPress: () => {},
+          style: {color: 'red'},
+          testID: 'highlighted-string-1'
+        };
+        const result = getTextPartsByHighlight('Playground Screen', highlightString);
+        expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
+      });
+      it('should break text to parts according to highlight string', () => {
+        const highlightString = {
+          string: 'Scr',
+          ...mockHighlightStringProps
+        };
+        const result = getTextPartsByHighlight('Playground Screen', highlightString);
+        expect(result).toEqual([
+          {string: 'Playground ', shouldHighlight: false},
+          {string: 'Scr', shouldHighlight: true, ...mockHighlightStringProps},
+          {string: 'een', shouldHighlight: false}
+        ]);
+      });
 
-    it('should be case-insensitive', () => {
-      const result = getTextPartsByHighlight('Dancing in the Dark', 'da');
-      expect(result).toEqual([
-        {string: 'Da', shouldHighlight: true},
-        {string: 'ncing in the ', shouldHighlight: false},
-        {string: 'Da', shouldHighlight: true},
-        {string: 'rk', shouldHighlight: false}
-      ]);
-    });
+      it('should handle case when highlight repeats more than once', () => {
+        const highlightString = {
+          string: 'Da',
+          ...mockHighlightStringProps
+        };
+        const result = getTextPartsByHighlight('Dancing in the Dark', highlightString);
+        expect(result).toEqual([
+          {string: 'Da', shouldHighlight: true, ...mockHighlightStringProps},
+          {string: 'ncing in the ', shouldHighlight: false},
+          {string: 'Da', shouldHighlight: true, ...mockHighlightStringProps},
+          {string: 'rk', shouldHighlight: false}
+        ]);
+      });
 
-    it('Should handle special characters @', () => {
-      const result = getTextPartsByHighlight('@ancing in the @ark', '@a');
-      expect(result).toEqual([
-        {string: '@a', shouldHighlight: true},
-        {string: 'ncing in the ', shouldHighlight: false},
-        {string: '@a', shouldHighlight: true},
-        {string: 'rk', shouldHighlight: false}
-      ]);
-    });
+      it('should be case-insensitive', () => {
+        const highlightString = {
+          string: 'da',
+          ...mockHighlightStringProps
+        };
+        const result = getTextPartsByHighlight('Dancing in the Dark', highlightString);
+        expect(result).toEqual([
+          {string: 'Da', shouldHighlight: true, ...mockHighlightStringProps},
+          {string: 'ncing in the ', shouldHighlight: false},
+          {string: 'Da', shouldHighlight: true, ...mockHighlightStringProps},
+          {string: 'rk', shouldHighlight: false}
+        ]);
+      });
 
-    it('Should handle special characters !', () => {
-      const result = getTextPartsByHighlight('!ancing in the !ark', '!a');
-      expect(result).toEqual([
-        {string: '!a', shouldHighlight: true},
-        {string: 'ncing in the ', shouldHighlight: false},
-        {string: '!a', shouldHighlight: true},
-        {string: 'rk', shouldHighlight: false}
-      ]);
-    });
+      it('Should handle special characters @', () => {
+        const highlightString = {
+          string: '@a',
+          ...mockHighlightStringProps
+        };
+        const result = getTextPartsByHighlight('@ancing in the @ark', highlightString);
+        expect(result).toEqual([
+          {string: '@a', shouldHighlight: true, ...mockHighlightStringProps},
+          {string: 'ncing in the ', shouldHighlight: false},
+          {string: '@a', shouldHighlight: true, ...mockHighlightStringProps},
+          {string: 'rk', shouldHighlight: false}
+        ]);
+      });
 
-    it('Should handle special characters starts with @', () => {
-      const result = getTextPartsByHighlight('uilib@wix.com', '@wix');
-      expect(result).toEqual([
-        {string: 'uilib', shouldHighlight: false},
-        {string: '@wix', shouldHighlight: true},
-        {string: '.com', shouldHighlight: false}
-      ]);
-    });
+      it('Should handle special characters !', () => {
+        const highlightString = {
+          string: '!a',
+          ...mockHighlightStringProps
+        };
+        const result = getTextPartsByHighlight('!ancing in the !ark', highlightString);
+        expect(result).toEqual([
+          {string: '!a', shouldHighlight: true, ...mockHighlightStringProps},
+          {string: 'ncing in the ', shouldHighlight: false},
+          {string: '!a', shouldHighlight: true, ...mockHighlightStringProps},
+          {string: 'rk', shouldHighlight: false}
+        ]);
+      });
 
-    it('Should handle empty string.', () => {
-      const result = getTextPartsByHighlight('@ancing in the @ark', '');
-      expect(result).toEqual([{string: '@ancing in the @ark', shouldHighlight: false}]);
-    });
+      it('Should handle special characters starts with @', () => {
+        const highlightString = {
+          string: '@wix',
+          ...mockHighlightStringProps
+        };
+        const result = getTextPartsByHighlight('uilib@wix.com', highlightString);
+        expect(result).toEqual([
+          {string: 'uilib', shouldHighlight: false},
+          {string: '@wix', shouldHighlight: true, ...mockHighlightStringProps},
+          {string: '.com', shouldHighlight: false}
+        ]);
+      });
 
-    it('Should handle full string.', () => {
-      const result = getTextPartsByHighlight('Dancing in the Dark', 'Dancing in the Dark');
-      expect(result).toEqual([{string: 'Dancing in the Dark', shouldHighlight: true}]);
-    });
+      it('Should handle empty string.', () => {
+        const highlightString = {
+          string: '',
+          ...mockHighlightStringProps
+        };
+        const result = getTextPartsByHighlight('@ancing in the @ark', highlightString);
+        expect(result).toEqual([{string: '@ancing in the @ark', shouldHighlight: false}]);
+      });
 
-    it('Should handle longer string.', () => {
-      const result = getTextPartsByHighlight('Dancing in the Dark', 'Dancing in the Darker');
-      expect(result).toEqual([{string: 'Dancing in the Dark', shouldHighlight: false}]);
+      it('Should handle full string.', () => {
+        const highlightString = {
+          string: 'Dancing in the Dark',
+          ...mockHighlightStringProps
+        };
+        const result = getTextPartsByHighlight('Dancing in the Dark', highlightString);
+        expect(result).toEqual([{string: 'Dancing in the Dark', shouldHighlight: true, ...mockHighlightStringProps}]);
+      });
+
+      it('Should handle longer string.', () => {
+        const highlightString = {
+          string: 'Dancing in the Darker',
+          ...mockHighlightStringProps
+        };
+        const result = getTextPartsByHighlight('Dancing in the Dark', highlightString);
+        expect(result).toEqual([{string: 'Dancing in the Dark', shouldHighlight: false}]);
+      });
     });
   });
 
   describe('getArrayPartsByHighlight', () => {
-    it('should return the whole string as a single part when highlight array is empty', () => {
-      const result = getArrayPartsByHighlight('Playground Screen', []);
-      expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
-    });
-    it('should return the whole string as a single part when highlight string is empty', () => {
-      const result = getArrayPartsByHighlight('Playground Screen', ['']);
-      expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
-    });
-    it('should return the whole string as a single part when highlight string dont match', () => {
-      const result = getArrayPartsByHighlight('Playground Screen', ['aaa']);
-      expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
-    });
-    it('should break text to parts according to highlight string', () => {
-      const result = getArrayPartsByHighlight('Playground Screen', ['Scr']);
-      expect(result).toEqual([
-        {string: 'Playground ', shouldHighlight: false},
-        {string: 'Scr', shouldHighlight: true},
-        {string: 'een', shouldHighlight: false}
-      ]);
+    describe('Simple string array', () => {
+      it('should return the whole string as a single part when highlight array is empty', () => {
+        const result = getArrayPartsByHighlight('Playground Screen', []);
+        expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
+      });
+      it('should return the whole string as a single part when highlight string is empty', () => {
+        const result = getArrayPartsByHighlight('Playground Screen', ['']);
+        expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
+      });
+      it('should return the whole string as a single part when highlight string dont match', () => {
+        const result = getArrayPartsByHighlight('Playground Screen', ['aaa']);
+        expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
+      });
+      it('should break text to parts according to highlight string', () => {
+        const result = getArrayPartsByHighlight('Playground Screen', ['Scr']);
+        expect(result).toEqual([
+          {string: 'Playground ', shouldHighlight: false},
+          {string: 'Scr', shouldHighlight: true},
+          {string: 'een', shouldHighlight: false}
+        ]);
+      });
+
+      it('highlight repeats more than once should color the first match', () => {
+        const result = getArrayPartsByHighlight('Dancing in the Dark', ['Da']);
+        expect(result).toEqual([
+          {string: 'Da', shouldHighlight: true},
+          {string: 'ncing in the Dark', shouldHighlight: false}
+        ]);
+      });
+
+      it('should be case-insensitive', () => {
+        const result = getArrayPartsByHighlight('Dancing in the Dark', ['da']);
+        expect(result).toEqual([
+          {string: 'Da', shouldHighlight: true},
+          {string: 'ncing in the Dark', shouldHighlight: false}
+        ]);
+      });
+
+      it('Should handle special characters @', () => {
+        const result = getArrayPartsByHighlight('@ancing in the @ark', ['@a']);
+        expect(result).toEqual([
+          {string: '@a', shouldHighlight: true},
+          {string: 'ncing in the @ark', shouldHighlight: false}
+        ]);
+      });
+
+      it('Should handle special characters !', () => {
+        const result = getArrayPartsByHighlight('!ancing in the !ark', ['!a']);
+        expect(result).toEqual([
+          {string: '!a', shouldHighlight: true},
+          {string: 'ncing in the !ark', shouldHighlight: false}
+        ]);
+      });
+
+      it('Should handle special characters starts with @', () => {
+        const result = getArrayPartsByHighlight('uilib@wix.com', ['@wix']);
+        expect(result).toEqual([
+          {string: 'uilib', shouldHighlight: false},
+          {string: '@wix', shouldHighlight: true},
+          {string: '.com', shouldHighlight: false}
+        ]);
+      });
+
+      it('Should handle full string.', () => {
+        const result = getArrayPartsByHighlight('Dancing in the Dark', ['Dancing in the Dark']);
+        expect(result).toEqual([{string: 'Dancing in the Dark', shouldHighlight: true}]);
+      });
+
+      it('Should handle longer string.', () => {
+        const result = getArrayPartsByHighlight('Dancing in the Dark', ['Dancing in the Darker']);
+        expect(result).toEqual([{string: 'Dancing in the Dark', shouldHighlight: false}]);
+      });
+
+      it('Should handle multiple strings.', () => {
+        const result = getArrayPartsByHighlight('Dancing in the Dark', ['Dancing', 'Dark']);
+        expect(result).toEqual([
+          {string: 'Dancing', shouldHighlight: true},
+          {string: ' in the ', shouldHighlight: false},
+          {string: 'Dark', shouldHighlight: true}
+        ]);
+      });
     });
 
-    it('highlight repeats more than once should color the first match', () => {
-      const result = getArrayPartsByHighlight('Dancing in the Dark', ['Da']);
-      expect(result).toEqual([
-        {string: 'Da', shouldHighlight: true},
-        {string: 'ncing in the Dark', shouldHighlight: false}
-      ]);
-    });
+    describe('HighlightStringProps objects array', () => {
+      it('should return the whole string as a single part when highlight string is empty', () => {
+        const highlightString = [{
+          string: '',
+          ...mockHighlightStringProps
+        }];
+        const result = getArrayPartsByHighlight('Playground Screen', highlightString);
+        expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
+      });
+      it('should return the whole string as a single part when highlight string dont match', () => {
+        const highlightString = [{
+          string: 'aaa',
+          ...mockHighlightStringProps
+        }];
+        const result = getArrayPartsByHighlight('Playground Screen', highlightString);
+        expect(result).toEqual([{string: 'Playground Screen', shouldHighlight: false}]);
+      });
+      it('should break text to parts according to highlight string', () => {
+        const highlightString = [{
+          string: 'Scr',
+          ...mockHighlightStringProps
+        }];
+        const result = getArrayPartsByHighlight('Playground Screen', highlightString);
+        expect(result).toEqual([
+          {string: 'Playground ', shouldHighlight: false},
+          {string: 'Scr', shouldHighlight: true, ...mockHighlightStringProps},
+          {string: 'een', shouldHighlight: false}
+        ]);
+      });
 
-    it('should be case-insensitive', () => {
-      const result = getArrayPartsByHighlight('Dancing in the Dark', ['da']);
-      expect(result).toEqual([
-        {string: 'Da', shouldHighlight: true},
-        {string: 'ncing in the Dark', shouldHighlight: false}
-      ]);
-    });
+      it('highlight repeats more than once should color the first match', () => {
+        const highlightString = [{
+          string: 'Da',
+          ...mockHighlightStringProps
+        }];
+        const result = getArrayPartsByHighlight('Dancing in the Dark', highlightString);
+        expect(result).toEqual([
+          {string: 'Da', shouldHighlight: true, ...mockHighlightStringProps},
+          {string: 'ncing in the Dark', shouldHighlight: false}
+        ]);
+      });
 
-    it('Should handle special characters @', () => {
-      const result = getArrayPartsByHighlight('@ancing in the @ark', ['@a']);
-      expect(result).toEqual([
-        {string: '@a', shouldHighlight: true},
-        {string: 'ncing in the @ark', shouldHighlight: false}
-      ]);
-    });
+      it('should be case-insensitive', () => {
+        const highlightString = [{
+          string: 'da',
+          ...mockHighlightStringProps
+        }];
+        const result = getArrayPartsByHighlight('Dancing in the Dark', highlightString);
+        expect(result).toEqual([
+          {string: 'Da', shouldHighlight: true, ...mockHighlightStringProps},
+          {string: 'ncing in the Dark', shouldHighlight: false}
+        ]);
+      });
 
-    it('Should handle special characters !', () => {
-      const result = getArrayPartsByHighlight('!ancing in the !ark', ['!a']);
-      expect(result).toEqual([
-        {string: '!a', shouldHighlight: true},
-        {string: 'ncing in the !ark', shouldHighlight: false}
-      ]);
-    });
+      it('Should handle special characters @', () => {
+        const highlightString = [{
+          string: '@a',
+          ...mockHighlightStringProps
+        }];
+        const result = getArrayPartsByHighlight('@ancing in the @ark', highlightString);
+        expect(result).toEqual([
+          {string: '@a', shouldHighlight: true, ...mockHighlightStringProps},
+          {string: 'ncing in the @ark', shouldHighlight: false}
+        ]);
+      });
 
-    it('Should handle special characters starts with @', () => {
-      const result = getArrayPartsByHighlight('uilib@wix.com', ['@wix']);
-      expect(result).toEqual([
-        {string: 'uilib', shouldHighlight: false},
-        {string: '@wix', shouldHighlight: true},
-        {string: '.com', shouldHighlight: false}
-      ]);
-    });
+      it('Should handle special characters !', () => {
+        const highlightString = [{
+          string: '!a',
+          ...mockHighlightStringProps
+        }];
+        const result = getArrayPartsByHighlight('!ancing in the !ark', highlightString);
+        expect(result).toEqual([
+          {string: '!a', shouldHighlight: true, ...mockHighlightStringProps},
+          {string: 'ncing in the !ark', shouldHighlight: false}
+        ]);
+      });
 
-    it('Should handle full string.', () => {
-      const result = getArrayPartsByHighlight('Dancing in the Dark', ['Dancing in the Dark']);
-      expect(result).toEqual([{string: 'Dancing in the Dark', shouldHighlight: true}]);
-    });
+      it('Should handle special characters starts with @', () => {
+        const highlightString = [{
+          string: '@wix',
+          ...mockHighlightStringProps
+        }];
+        const result = getArrayPartsByHighlight('uilib@wix.com', highlightString);
+        expect(result).toEqual([
+          {string: 'uilib', shouldHighlight: false},
+          {string: '@wix', shouldHighlight: true, ...mockHighlightStringProps},
+          {string: '.com', shouldHighlight: false}
+        ]);
+      });
 
-    it('Should handle longer string.', () => {
-      const result = getArrayPartsByHighlight('Dancing in the Dark', ['Dancing in the Darker']);
-      expect(result).toEqual([{string: 'Dancing in the Dark', shouldHighlight: false}]);
+      it('Should handle full string.', () => {
+        const highlightString = [{
+          string: 'Dancing in the Dark',
+          ...mockHighlightStringProps
+        }];
+        const result = getArrayPartsByHighlight('Dancing in the Dark', highlightString);
+        expect(result).toEqual([{string: 'Dancing in the Dark', shouldHighlight: true, ...mockHighlightStringProps}]);
+      });
+
+      it('Should handle longer string.', () => {
+        const highlightString = [{
+          string: 'Dancing in the Darker',
+          ...mockHighlightStringProps
+        }];
+        const result = getArrayPartsByHighlight('Dancing in the Dark', highlightString);
+        expect(result).toEqual([{string: 'Dancing in the Dark', shouldHighlight: false}]);
+      });
+
+      it('Should handle multiple string.', () => {
+        const mockHighlightStringProps2 = {
+          onPress: jest.fn(),
+          style: {color: 'blue'},
+          testID: 'highlighted-string-test-id-2'
+        };
+
+        const highlightString = [
+          {
+            string: 'Dancing',
+            ...mockHighlightStringProps
+          },
+          {
+            string: 'Dark',
+            ...mockHighlightStringProps2
+          }];
+        const result = getArrayPartsByHighlight('Dancing in the Dark', highlightString);
+        expect(result).toEqual([
+          {string: 'Dancing', shouldHighlight: true, ...mockHighlightStringProps},
+          {string: ' in the ', shouldHighlight: false},
+          {string: 'Dark', shouldHighlight: true, ...mockHighlightStringProps2}
+        ]);
+      });
     });
   });
 });

--- a/src/utils/textUtils.ts
+++ b/src/utils/textUtils.ts
@@ -30,10 +30,10 @@ function isHighlightStringProps(highlightString: HighlightString): highlightStri
 }
 
 function getTextPartsByHighlight(targetString = '', highlightString: HighlightString = ''): TextPartByHighlight[] {
-  if (highlightString === '') {
+  const stringValue = getHighlightStringValue(highlightString);
+  if (stringValue === '') {
     return [{string: targetString, shouldHighlight: false}];
   }
-  const stringValue = getHighlightStringValue(highlightString);
   const textParts = [];
   let highlightIndex;
   do {

--- a/src/utils/textUtils.ts
+++ b/src/utils/textUtils.ts
@@ -1,8 +1,14 @@
 import {isEmpty, toLower} from 'lodash';
+import {HighlightString, HighlightStringProps} from '../components/text';
 
-function getPartsByHighlight(targetString = '', highlightString: string | string[]) {
-  if (typeof highlightString === 'string') {
-    if (isEmpty(highlightString.trim())) {
+interface TextPartByHighlight extends HighlightStringProps {
+  shouldHighlight: boolean;
+}
+
+function getPartsByHighlight(targetString = '', highlightString: HighlightString | HighlightString[]): TextPartByHighlight[] {
+  if (!Array.isArray(highlightString)) {
+    const stringValue = getHighlightStringValue(highlightString);
+    if (isEmpty(stringValue.trim())) {
       return [{string: targetString, shouldHighlight: false}];
     }
     return getTextPartsByHighlight(targetString, highlightString);
@@ -11,20 +17,42 @@ function getPartsByHighlight(targetString = '', highlightString: string | string
   }
 }
 
-function getTextPartsByHighlight(targetString = '', highlightString = '') {
+function getHighlightStringValue(highlightString: HighlightString): string {
+  if (isHighlightStringProps(highlightString)) {
+    return highlightString.string;
+  } else {
+    return highlightString;
+  }
+}
+
+function isHighlightStringProps(highlightString: HighlightString): highlightString is HighlightStringProps {
+  return typeof highlightString !== 'string';
+}
+
+function getTextPartsByHighlight(targetString = '', highlightString: HighlightString = ''): TextPartByHighlight[] {
   if (highlightString === '') {
     return [{string: targetString, shouldHighlight: false}];
   }
+  const stringValue = getHighlightStringValue(highlightString);
   const textParts = [];
   let highlightIndex;
   do {
-    highlightIndex = targetString.toLowerCase().indexOf(highlightString.toLowerCase());
+    highlightIndex = targetString.toLowerCase().indexOf(stringValue.toLowerCase());
     if (highlightIndex !== -1) {
       if (highlightIndex > 0) {
         textParts.push({string: targetString.substring(0, highlightIndex), shouldHighlight: false});
       }
-      textParts.push({string: targetString.substr(highlightIndex, highlightString.length), shouldHighlight: true});
-      targetString = targetString.substr(highlightIndex + highlightString.length);
+      const highlightStringProps = isHighlightStringProps(highlightString) ? {
+        onPress: highlightString.onPress,
+        style: highlightString.style,
+        testID: highlightString.testID
+      } : {};
+      textParts.push({
+        string: targetString.substr(highlightIndex, stringValue.length),
+        shouldHighlight: true,
+        ...highlightStringProps
+      });
+      targetString = targetString.substr(highlightIndex + stringValue.length);
     } else {
       textParts.push({string: targetString, shouldHighlight: false});
     }
@@ -33,13 +61,14 @@ function getTextPartsByHighlight(targetString = '', highlightString = '') {
   return textParts;
 }
 
-function getArrayPartsByHighlight(targetString = '', highlightString = ['']) {
+function getArrayPartsByHighlight(targetString = '', highlightString: HighlightString[] = ['']): TextPartByHighlight[] {
   const target = toLower(targetString);
   const indices = [];
   let index = 0;
   let lastWordLength = 0;
   for (let j = 0; j < highlightString.length; j++) {
-    const word = toLower(highlightString[j]);
+    const stringValue = getHighlightStringValue(highlightString[j]);
+    const word = toLower(stringValue);
     if (word.length === 0) {
       break;
     }
@@ -48,7 +77,11 @@ function getArrayPartsByHighlight(targetString = '', highlightString = ['']) {
     const i = targetSuffix.indexOf(word);
     if (i >= 0) {
       const newIndex = index + lastWordLength + i;
-      indices.push({start: index + lastWordLength + i, end: index + lastWordLength + i + word.length});
+      indices.push({
+        start: index + lastWordLength + i,
+        end: index + lastWordLength + i + word.length,
+        highlightStringIndex: j
+      });
       index = newIndex;
       lastWordLength = word.length;
     } else {
@@ -60,7 +93,17 @@ function getArrayPartsByHighlight(targetString = '', highlightString = ['']) {
     if (k === 0 && indices[k].start !== 0) {
       textParts.push({string: targetString.substring(0, indices[k].start), shouldHighlight: false});
     }
-    textParts.push({string: targetString.substring(indices[k].start, indices[k].end), shouldHighlight: true});
+    const currentHighlightString = highlightString[indices[k].highlightStringIndex];
+    const highlightStringProps = isHighlightStringProps(currentHighlightString) ? {
+      onPress: currentHighlightString.onPress,
+      style: currentHighlightString.style,
+      testID: currentHighlightString.testID
+    } : {};
+    textParts.push({
+      string: targetString.substring(indices[k].start, indices[k].end),
+      shouldHighlight: true,
+      ...highlightStringProps
+    });
     if (indices[k].end < targetString.length) {
       if (k === indices.length - 1) {
         textParts.push({string: targetString.substring(indices[k].end), shouldHighlight: false});


### PR DESCRIPTION
## Description
extended the `Text` component `highlightString` prop, to allow it to also receive a `HighlightStringProps` object (or an array of such objects) that enables the user to handle a highlight string `onPress` event, provide a `style` per highlight string and give it a `testID` for testing.

If a the `style` prop is not provided in a `HighlightStringProps` object, the general `highlightStringStyle` prop style is used for it.

## Changelog
`Text` component `highlightString` prop now enables to handle a highlighted string `onPress` event, provide a specific `style` to each highlighted string and give it a `testID` for better testing

## Additional info
this PR emerged from this [slack thread](https://wix.slack.com/archives/C6C38SVS4/p1688642226659659?thread_ts=1688635409.468709&cid=C6C38SVS4)
