### PR TITLE
Text - default alignment

### DIFF
--- a/demo/src/screens/__tests__/__snapshots__/AvatarScreen.spec.js.snap
+++ b/demo/src/screens/__tests__/__snapshots__/AvatarScreen.spec.js.snap
@@ -36,6 +36,7 @@ exports[`AvatarScreen renders screen 1`] = `
             {
               "backgroundColor": "transparent",
               "color": "#20303C",
+              "writingDirection": "ltr",
             },
             undefined,
             {
@@ -158,6 +159,7 @@ exports[`AvatarScreen renders screen 1`] = `
             {
               "backgroundColor": "transparent",
               "color": "#20303C",
+              "writingDirection": "ltr",
             },
             undefined,
             {
@@ -287,6 +289,7 @@ exports[`AvatarScreen renders screen 1`] = `
                 {
                   "backgroundColor": "transparent",
                   "color": "#20303C",
+                  "writingDirection": "ltr",
                 },
                 {
                   "fontFamily": "System",
@@ -339,6 +342,7 @@ exports[`AvatarScreen renders screen 1`] = `
             {
               "backgroundColor": "transparent",
               "color": "#20303C",
+              "writingDirection": "ltr",
             },
             undefined,
             {
@@ -440,6 +444,7 @@ exports[`AvatarScreen renders screen 1`] = `
                 {
                   "backgroundColor": "transparent",
                   "color": "#20303C",
+                  "writingDirection": "ltr",
                 },
                 undefined,
                 undefined,
@@ -509,6 +514,7 @@ exports[`AvatarScreen renders screen 1`] = `
                 {
                   "backgroundColor": "transparent",
                   "color": "#20303C",
+                  "writingDirection": "ltr",
                 },
                 {
                   "fontFamily": "System",
@@ -561,6 +567,7 @@ exports[`AvatarScreen renders screen 1`] = `
             {
               "backgroundColor": "transparent",
               "color": "#20303C",
+              "writingDirection": "ltr",
             },
             undefined,
             {
@@ -662,6 +669,7 @@ exports[`AvatarScreen renders screen 1`] = `
                 {
                   "backgroundColor": "transparent",
                   "color": "#20303C",
+                  "writingDirection": "ltr",
                 },
                 undefined,
                 undefined,
@@ -789,6 +797,7 @@ exports[`AvatarScreen renders screen 1`] = `
             {
               "backgroundColor": "transparent",
               "color": "#20303C",
+              "writingDirection": "ltr",
             },
             undefined,
             {
@@ -1039,6 +1048,7 @@ exports[`AvatarScreen renders screen 1`] = `
             {
               "backgroundColor": "transparent",
               "color": "#20303C",
+              "writingDirection": "ltr",
             },
             undefined,
             {
@@ -1289,6 +1299,7 @@ exports[`AvatarScreen renders screen 1`] = `
             {
               "backgroundColor": "transparent",
               "color": "#20303C",
+              "writingDirection": "ltr",
             },
             undefined,
             {
@@ -1490,6 +1501,7 @@ exports[`AvatarScreen renders screen 1`] = `
             {
               "backgroundColor": "transparent",
               "color": "#20303C",
+              "writingDirection": "ltr",
             },
             undefined,
             {
@@ -1740,6 +1752,7 @@ exports[`AvatarScreen renders screen 1`] = `
             {
               "backgroundColor": "transparent",
               "color": "#20303C",
+              "writingDirection": "ltr",
             },
             undefined,
             {
@@ -2034,6 +2047,7 @@ exports[`AvatarScreen renders screen 1`] = `
             {
               "backgroundColor": "transparent",
               "color": "#20303C",
+              "writingDirection": "ltr",
             },
             undefined,
             {
@@ -2217,6 +2231,7 @@ exports[`AvatarScreen renders screen 1`] = `
             {
               "backgroundColor": "transparent",
               "color": "#20303C",
+              "writingDirection": "ltr",
             },
             undefined,
             {
@@ -2323,6 +2338,7 @@ exports[`AvatarScreen renders screen 1`] = `
                 {
                   "backgroundColor": "transparent",
                   "color": "#20303C",
+                  "writingDirection": "ltr",
                 },
                 undefined,
                 undefined,
@@ -2441,6 +2457,7 @@ exports[`AvatarScreen renders screen 1`] = `
             {
               "backgroundColor": "transparent",
               "color": "#20303C",
+              "writingDirection": "ltr",
             },
             undefined,
             {
@@ -2547,6 +2564,7 @@ exports[`AvatarScreen renders screen 1`] = `
                 {
                   "backgroundColor": "transparent",
                   "color": "#20303C",
+                  "writingDirection": "ltr",
                 },
                 undefined,
                 undefined,
@@ -2665,6 +2683,7 @@ exports[`AvatarScreen renders screen 1`] = `
             {
               "backgroundColor": "transparent",
               "color": "#20303C",
+              "writingDirection": "ltr",
             },
             undefined,
             {
@@ -2848,6 +2867,7 @@ exports[`AvatarScreen renders screen 1`] = `
             {
               "backgroundColor": "transparent",
               "color": "#20303C",
+              "writingDirection": "ltr",
             },
             undefined,
             {
@@ -2949,6 +2969,7 @@ exports[`AvatarScreen renders screen 1`] = `
                 {
                   "backgroundColor": "transparent",
                   "color": "#20303C",
+                  "writingDirection": "ltr",
                 },
                 undefined,
                 undefined,
@@ -3058,6 +3079,7 @@ exports[`AvatarScreen renders screen 1`] = `
                   {
                     "backgroundColor": "transparent",
                     "color": "#20303C",
+                    "writingDirection": "ltr",
                   },
                   undefined,
                   undefined,

--- a/demo/src/screens/__tests__/__snapshots__/AvatarScreen.spec.js.snap
+++ b/demo/src/screens/__tests__/__snapshots__/AvatarScreen.spec.js.snap
@@ -36,7 +36,6 @@ exports[`AvatarScreen renders screen 1`] = `
             {
               "backgroundColor": "transparent",
               "color": "#20303C",
-              "textAlign": "left",
             },
             undefined,
             {
@@ -159,7 +158,6 @@ exports[`AvatarScreen renders screen 1`] = `
             {
               "backgroundColor": "transparent",
               "color": "#20303C",
-              "textAlign": "left",
             },
             undefined,
             {
@@ -289,7 +287,6 @@ exports[`AvatarScreen renders screen 1`] = `
                 {
                   "backgroundColor": "transparent",
                   "color": "#20303C",
-                  "textAlign": "left",
                 },
                 {
                   "fontFamily": "System",
@@ -342,7 +339,6 @@ exports[`AvatarScreen renders screen 1`] = `
             {
               "backgroundColor": "transparent",
               "color": "#20303C",
-              "textAlign": "left",
             },
             undefined,
             {
@@ -444,7 +440,6 @@ exports[`AvatarScreen renders screen 1`] = `
                 {
                   "backgroundColor": "transparent",
                   "color": "#20303C",
-                  "textAlign": "left",
                 },
                 undefined,
                 undefined,
@@ -514,7 +509,6 @@ exports[`AvatarScreen renders screen 1`] = `
                 {
                   "backgroundColor": "transparent",
                   "color": "#20303C",
-                  "textAlign": "left",
                 },
                 {
                   "fontFamily": "System",
@@ -567,7 +561,6 @@ exports[`AvatarScreen renders screen 1`] = `
             {
               "backgroundColor": "transparent",
               "color": "#20303C",
-              "textAlign": "left",
             },
             undefined,
             {
@@ -669,7 +662,6 @@ exports[`AvatarScreen renders screen 1`] = `
                 {
                   "backgroundColor": "transparent",
                   "color": "#20303C",
-                  "textAlign": "left",
                 },
                 undefined,
                 undefined,
@@ -797,7 +789,6 @@ exports[`AvatarScreen renders screen 1`] = `
             {
               "backgroundColor": "transparent",
               "color": "#20303C",
-              "textAlign": "left",
             },
             undefined,
             {
@@ -1048,7 +1039,6 @@ exports[`AvatarScreen renders screen 1`] = `
             {
               "backgroundColor": "transparent",
               "color": "#20303C",
-              "textAlign": "left",
             },
             undefined,
             {
@@ -1299,7 +1289,6 @@ exports[`AvatarScreen renders screen 1`] = `
             {
               "backgroundColor": "transparent",
               "color": "#20303C",
-              "textAlign": "left",
             },
             undefined,
             {
@@ -1501,7 +1490,6 @@ exports[`AvatarScreen renders screen 1`] = `
             {
               "backgroundColor": "transparent",
               "color": "#20303C",
-              "textAlign": "left",
             },
             undefined,
             {
@@ -1752,7 +1740,6 @@ exports[`AvatarScreen renders screen 1`] = `
             {
               "backgroundColor": "transparent",
               "color": "#20303C",
-              "textAlign": "left",
             },
             undefined,
             {
@@ -2047,7 +2034,6 @@ exports[`AvatarScreen renders screen 1`] = `
             {
               "backgroundColor": "transparent",
               "color": "#20303C",
-              "textAlign": "left",
             },
             undefined,
             {
@@ -2231,7 +2217,6 @@ exports[`AvatarScreen renders screen 1`] = `
             {
               "backgroundColor": "transparent",
               "color": "#20303C",
-              "textAlign": "left",
             },
             undefined,
             {
@@ -2338,7 +2323,6 @@ exports[`AvatarScreen renders screen 1`] = `
                 {
                   "backgroundColor": "transparent",
                   "color": "#20303C",
-                  "textAlign": "left",
                 },
                 undefined,
                 undefined,
@@ -2457,7 +2441,6 @@ exports[`AvatarScreen renders screen 1`] = `
             {
               "backgroundColor": "transparent",
               "color": "#20303C",
-              "textAlign": "left",
             },
             undefined,
             {
@@ -2564,7 +2547,6 @@ exports[`AvatarScreen renders screen 1`] = `
                 {
                   "backgroundColor": "transparent",
                   "color": "#20303C",
-                  "textAlign": "left",
                 },
                 undefined,
                 undefined,
@@ -2683,7 +2665,6 @@ exports[`AvatarScreen renders screen 1`] = `
             {
               "backgroundColor": "transparent",
               "color": "#20303C",
-              "textAlign": "left",
             },
             undefined,
             {
@@ -2867,7 +2848,6 @@ exports[`AvatarScreen renders screen 1`] = `
             {
               "backgroundColor": "transparent",
               "color": "#20303C",
-              "textAlign": "left",
             },
             undefined,
             {
@@ -2969,7 +2949,6 @@ exports[`AvatarScreen renders screen 1`] = `
                 {
                   "backgroundColor": "transparent",
                   "color": "#20303C",
-                  "textAlign": "left",
                 },
                 undefined,
                 undefined,
@@ -3079,7 +3058,6 @@ exports[`AvatarScreen renders screen 1`] = `
                   {
                     "backgroundColor": "transparent",
                     "color": "#20303C",
-                    "textAlign": "left",
                   },
                   undefined,
                   undefined,

--- a/src/components/button/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/button/__tests__/__snapshots__/index.spec.js.snap
@@ -53,7 +53,6 @@ exports[`Button backgroundColor should return backgroundColor according to modif
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -141,7 +140,6 @@ exports[`Button backgroundColor should return backgroundColor according to prop 
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -229,7 +227,6 @@ exports[`Button backgroundColor should return defined theme backgroundColor 1`] 
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -317,7 +314,6 @@ exports[`Button backgroundColor should return theme disabled color if button is 
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -405,7 +401,6 @@ exports[`Button backgroundColor should return undefined if this button is link 1
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -495,7 +490,6 @@ exports[`Button backgroundColor should return undefined if this button is outlin
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -583,7 +577,6 @@ exports[`Button border radius should return 0 border radius when border radius p
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -671,7 +664,6 @@ exports[`Button border radius should return 0 border radius when button is full 
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -759,7 +751,6 @@ exports[`Button border radius should return given border radius when use plain n
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -847,7 +838,6 @@ exports[`Button container size should avoid minWidth limitation if avoidMinWidth
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -940,7 +930,6 @@ exports[`Button container size should have no padding if avoidInnerPadding prop 
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -1033,7 +1022,6 @@ exports[`Button container size should have no padding of button is a link nor mi
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -1155,7 +1143,6 @@ exports[`Button container size should have no padding of button is an icon butto
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -1250,7 +1237,6 @@ exports[`Button container size should reduce padding by outlineWidth in case of 
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -1338,7 +1324,6 @@ exports[`Button container size should return style for large button 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -1428,7 +1413,6 @@ exports[`Button container size should return style for large button 2`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -1516,7 +1500,6 @@ exports[`Button container size should return style for medium button 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -1611,7 +1594,6 @@ exports[`Button container size should return style for medium button 2`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -1704,7 +1686,6 @@ exports[`Button container size should return style for round button 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -1792,7 +1773,6 @@ exports[`Button container size should return style for small button 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -1887,7 +1867,6 @@ exports[`Button container size should return style for small button 2`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -1980,7 +1959,6 @@ exports[`Button container size should return style for xSmall button 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -2075,7 +2053,6 @@ exports[`Button container size should return style for xSmall button 2`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -2168,7 +2145,6 @@ exports[`Button hyperlink should render button as a hyperlink 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -2719,7 +2695,6 @@ exports[`Button icon should return the right spacing according to button size wh
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -2807,7 +2782,6 @@ exports[`Button icon should return the right spacing according to button size wh
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -2900,7 +2874,6 @@ exports[`Button icon should return the right spacing according to button size wh
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -2993,7 +2966,6 @@ exports[`Button icon should return the right spacing according to button size wh
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -3086,7 +3058,6 @@ exports[`Button label size should return style for large button 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -3174,7 +3145,6 @@ exports[`Button label size should return style for medium button 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -3267,7 +3237,6 @@ exports[`Button label size should return style for small button 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -3360,7 +3329,6 @@ exports[`Button label size should return style for xSmall button 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -3453,7 +3421,6 @@ exports[`Button labelColor should return Theme linkColor color for link 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -3541,7 +3508,6 @@ exports[`Button labelColor should return color according to color modifier 1`] =
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -3629,7 +3595,6 @@ exports[`Button labelColor should return color according to color prop 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -3717,7 +3682,6 @@ exports[`Button labelColor should return disabled text color according to theme 
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -3805,7 +3769,6 @@ exports[`Button labelColor should return linkColor color for link 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -3969,7 +3932,6 @@ exports[`Button link should render button as a link 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -4059,7 +4021,6 @@ exports[`Button outline should render button with an outline 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -4149,7 +4110,6 @@ exports[`Button outline should render button with an outlineColor 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -4239,7 +4199,6 @@ exports[`Button outline should render button with outline and outlineColor 1`] =
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -4329,7 +4288,6 @@ exports[`Button outline should return custom borderWidth according to outlineWid
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -4419,7 +4377,6 @@ exports[`Button outline should return disabled color for outline if button is di
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -4507,7 +4464,6 @@ exports[`Button outline should return undefined when link is true, even when out
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,
@@ -4595,7 +4551,6 @@ exports[`Button should render default button 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
-          "textAlign": "left",
         },
         undefined,
         undefined,

--- a/src/components/button/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/button/__tests__/__snapshots__/index.spec.js.snap
@@ -53,6 +53,7 @@ exports[`Button backgroundColor should return backgroundColor according to modif
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -140,6 +141,7 @@ exports[`Button backgroundColor should return backgroundColor according to prop 
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -227,6 +229,7 @@ exports[`Button backgroundColor should return defined theme backgroundColor 1`] 
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -314,6 +317,7 @@ exports[`Button backgroundColor should return theme disabled color if button is 
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -401,6 +405,7 @@ exports[`Button backgroundColor should return undefined if this button is link 1
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -490,6 +495,7 @@ exports[`Button backgroundColor should return undefined if this button is outlin
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -577,6 +583,7 @@ exports[`Button border radius should return 0 border radius when border radius p
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -664,6 +671,7 @@ exports[`Button border radius should return 0 border radius when button is full 
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -751,6 +759,7 @@ exports[`Button border radius should return given border radius when use plain n
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -838,6 +847,7 @@ exports[`Button container size should avoid minWidth limitation if avoidMinWidth
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -930,6 +940,7 @@ exports[`Button container size should have no padding if avoidInnerPadding prop 
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -1022,6 +1033,7 @@ exports[`Button container size should have no padding of button is a link nor mi
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -1143,6 +1155,7 @@ exports[`Button container size should have no padding of button is an icon butto
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -1237,6 +1250,7 @@ exports[`Button container size should reduce padding by outlineWidth in case of 
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -1324,6 +1338,7 @@ exports[`Button container size should return style for large button 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -1413,6 +1428,7 @@ exports[`Button container size should return style for large button 2`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -1500,6 +1516,7 @@ exports[`Button container size should return style for medium button 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -1594,6 +1611,7 @@ exports[`Button container size should return style for medium button 2`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -1686,6 +1704,7 @@ exports[`Button container size should return style for round button 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -1773,6 +1792,7 @@ exports[`Button container size should return style for small button 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -1867,6 +1887,7 @@ exports[`Button container size should return style for small button 2`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -1959,6 +1980,7 @@ exports[`Button container size should return style for xSmall button 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -2053,6 +2075,7 @@ exports[`Button container size should return style for xSmall button 2`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -2145,6 +2168,7 @@ exports[`Button hyperlink should render button as a hyperlink 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -2695,6 +2719,7 @@ exports[`Button icon should return the right spacing according to button size wh
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -2782,6 +2807,7 @@ exports[`Button icon should return the right spacing according to button size wh
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -2874,6 +2900,7 @@ exports[`Button icon should return the right spacing according to button size wh
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -2966,6 +2993,7 @@ exports[`Button icon should return the right spacing according to button size wh
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -3058,6 +3086,7 @@ exports[`Button label size should return style for large button 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -3145,6 +3174,7 @@ exports[`Button label size should return style for medium button 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -3237,6 +3267,7 @@ exports[`Button label size should return style for small button 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -3329,6 +3360,7 @@ exports[`Button label size should return style for xSmall button 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -3421,6 +3453,7 @@ exports[`Button labelColor should return Theme linkColor color for link 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -3508,6 +3541,7 @@ exports[`Button labelColor should return color according to color modifier 1`] =
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -3595,6 +3629,7 @@ exports[`Button labelColor should return color according to color prop 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -3682,6 +3717,7 @@ exports[`Button labelColor should return disabled text color according to theme 
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -3769,6 +3805,7 @@ exports[`Button labelColor should return linkColor color for link 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -3932,6 +3969,7 @@ exports[`Button link should render button as a link 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -4021,6 +4059,7 @@ exports[`Button outline should render button with an outline 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -4110,6 +4149,7 @@ exports[`Button outline should render button with an outlineColor 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -4199,6 +4239,7 @@ exports[`Button outline should render button with outline and outlineColor 1`] =
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -4288,6 +4329,7 @@ exports[`Button outline should return custom borderWidth according to outlineWid
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -4377,6 +4419,7 @@ exports[`Button outline should return disabled color for outline if button is di
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -4464,6 +4507,7 @@ exports[`Button outline should return undefined when link is true, even when out
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,
@@ -4551,6 +4595,7 @@ exports[`Button should render default button 1`] = `
         {
           "backgroundColor": "transparent",
           "color": "#20303C",
+          "writingDirection": "ltr",
         },
         undefined,
         undefined,

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -1,6 +1,6 @@
+import _ from 'lodash';
 import React, {PureComponent} from 'react';
 import {Text as RNText, StyleSheet, TextProps as RNTextProps, TextStyle, Animated, StyleProp} from 'react-native';
-import _ from 'lodash';
 import {
   asBaseComponent,
   forwardRef,
@@ -9,7 +9,8 @@ import {
   MarginModifiers,
   TypographyModifiers,
   ColorsModifiers,
-  FlexModifiers
+  FlexModifiers,
+  Constants
 } from '../../commons/new';
 import {RecorderProps} from '../../../typings/recorderTypes';
 import {Colors} from 'style';
@@ -157,7 +158,9 @@ class Text extends PureComponent<PropsTypes> {
 const styles = StyleSheet.create({
   container: {
     backgroundColor: 'transparent',
-    color: Colors.$textDefault
+    color: Colors.$textDefault,
+    // textAlign: 'left'
+    writingDirection: Constants.isRTL ? 'rtl' : 'ltr'
   },
   centered: {
     textAlign: 'center'

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -165,7 +165,7 @@ const styles = StyleSheet.create({
     backgroundColor: 'transparent',
     color: Colors.$textDefault,
     // textAlign: 'left'
-    writingDirection: Constants.isRTL ? writingDirectionTypes.RTL : writingDirectionTypes.LTR
+    writingDirection: Constants.isRTL ? writingDirectionTypes.RTL : writingDirectionTypes.LTR // iOS only
   },
   centered: {
     textAlign: 'center'

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -16,6 +16,11 @@ import {RecorderProps} from '../../../typings/recorderTypes';
 import {Colors} from 'style';
 import {TextUtils} from 'utils';
 
+enum writingDirectionTypes {
+  RTL = 'rtl',
+  LTR = 'ltr'
+}
+
 export type TextProps = RNTextProps &
   TypographyModifiers &
   ColorsModifiers &
@@ -160,7 +165,7 @@ const styles = StyleSheet.create({
     backgroundColor: 'transparent',
     color: Colors.$textDefault,
     // textAlign: 'left'
-    writingDirection: Constants.isRTL ? 'rtl' : 'ltr'
+    writingDirection: Constants.isRTL ? writingDirectionTypes.RTL : writingDirectionTypes.LTR
   },
   centered: {
     textAlign: 'center'

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -157,7 +157,6 @@ class Text extends PureComponent<PropsTypes> {
 const styles = StyleSheet.create({
   container: {
     backgroundColor: 'transparent',
-    textAlign: 'left',
     color: Colors.$textDefault
   },
   centered: {


### PR DESCRIPTION
## Description
Text - remove default textAlign style to fix iOS child Text not inheriting from its parent.
⚠️ Note: on Android, the Text will not align to the right on RTL if the actual language is not RTL language (back to its default behavior in RN)

## Changelog
Text - remove default textAlign style to fix iOS child Text not inheriting from its parent.

## Additional info
Solves #2457 
