### PR TITLE
ExpandableOverlay - fix dialog props

### DIFF
--- a/src/incubator/expandableOverlay/index.tsx
+++ b/src/incubator/expandableOverlay/index.tsx
@@ -17,7 +17,29 @@ export interface RenderCustomOverlayProps extends ExpandableOverlayMethods {
   visible: boolean;
 }
 
+export interface _DialogPropsOld {
+  /**
+   * The props to pass to the dialog expandable container
+   */
+  dialogProps?: DialogPropsOld;
+  migrateDialog?: false;
+}
+
+export interface _DialogPropsNew {
+  /**
+   * The props to pass to the dialog expandable container
+   */
+  dialogProps?: DialogPropsNew;
+  /**
+   * Migrate the Dialog to DialogNew (make sure you use only new props in dialogProps)
+   */
+  migrateDialog: true;
+}
+
+export type DialogProps = _DialogPropsOld | _DialogPropsNew;
+
 export type ExpandableOverlayProps = TouchableOpacityProps &
+  DialogProps &
   PropsWithChildren<{
     /**
      * The content to render inside the expandable modal/dialog
@@ -31,14 +53,6 @@ export type ExpandableOverlayProps = TouchableOpacityProps &
      * The props to pass to the modal expandable container
      */
     modalProps?: ModalProps;
-    /**
-     * The props to pass to the dialog expandable container
-     */
-    dialogProps?: DialogPropsOld | DialogPropsNew;
-    /**
-     * Migrate the Dialog to DialogNew (make sure you use only new props in dialogProps)
-     */
-    migrateDialog?: boolean;
     /**
      * Whether to render a modal top bar (relevant only for modal)
      */


### PR DESCRIPTION
## Description
ExpandableOverlay - fix dialog props
Note: you must have the `migrateDialog` in both types to prevent error.

## Changelog
ExpandableOverlay - fix dialog props

## Additional info
None