### PR TITLE
fixed the ts error on ExpandableOverlay dialogProps in Picker.

### DIFF
--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -286,46 +286,49 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
 
   return (
     <PickerContext.Provider value={contextValue}>
-      <ExpandableOverlay
-        ref={pickerExpandable}
-        useDialog={useWheelPicker}
-        modalProps={modalProps}
-        dialogProps={DIALOG_PROPS}
-        migrateDialog={migrateDialog}
-        expandableContent={expandableModalContent}
-        renderCustomOverlay={renderCustomModal ? _renderCustomModal : undefined}
-        onPress={onPress}
-        testID={testID}
-        {...customPickerProps}
-        disabled={themeProps.editable === false}
-      >
-        {renderPicker ? (
-          // @ts-expect-error - hopefully will be solved after the picker migration ends
-          renderPicker(value, label)
-        ) : (
-          <TextFieldMigrator
-            migrate={migrateTextField}
-            // customWarning="RNUILib Picker component's internal TextField will soon be replaced with a new implementation, in order to start the migration - please pass to Picker the 'migrateTextField' prop"
-            // @ts-expect-error
-            ref={pickerRef}
-            // {...textInputProps}
-            {...others}
-            {...propsByFieldType}
-            testID={`${testID}.input`}
-            // @ts-expect-error
-            containerStyle={[containerStyle, propsByFieldType?.containerStyle]}
-            labelStyle={[propsByFieldType?.labelStyle, labelStyle]}
-            {...accessibilityInfo}
-            importantForAccessibility={'no-hide-descendants'}
-            value={label}
-            selection={Constants.isAndroid ? {start: 0} : undefined}
-            /* Note: Disable TextField expandable feature */
-            // topBarProps={undefined}
-          >
-            {renderPickerInnerInput()}
-          </TextFieldMigrator>
-        )}
-      </ExpandableOverlay>
+      {
+        // @ts-expect-error
+        <ExpandableOverlay
+          ref={pickerExpandable}
+          useDialog={useWheelPicker}
+          modalProps={modalProps}
+          dialogProps={DIALOG_PROPS}
+          migrateDialog={migrateDialog}
+          expandableContent={expandableModalContent}
+          renderCustomOverlay={renderCustomModal ? _renderCustomModal : undefined}
+          onPress={onPress}
+          testID={testID}
+          {...customPickerProps}
+          disabled={themeProps.editable === false}
+        >
+          {renderPicker ? (
+            // @ts-expect-error - hopefully will be solved after the picker migration ends
+            renderPicker(value, label)
+          ) : (
+            <TextFieldMigrator
+              migrate={migrateTextField}
+              // customWarning="RNUILib Picker component's internal TextField will soon be replaced with a new implementation, in order to start the migration - please pass to Picker the 'migrateTextField' prop"
+              // @ts-expect-error
+              ref={pickerRef}
+              // {...textInputProps}
+              {...others}
+              {...propsByFieldType}
+              testID={`${testID}.input`}
+              // @ts-expect-error
+              containerStyle={[containerStyle, propsByFieldType?.containerStyle]}
+              labelStyle={[propsByFieldType?.labelStyle, labelStyle]}
+              {...accessibilityInfo}
+              importantForAccessibility={'no-hide-descendants'}
+              value={label}
+              selection={Constants.isAndroid ? {start: 0} : undefined}
+              /* Note: Disable TextField expandable feature */
+              // topBarProps={undefined}
+            >
+              {renderPickerInnerInput()}
+            </TextFieldMigrator>
+          )}
+        </ExpandableOverlay>
+      }
     </PickerContext.Provider>
   );
 });

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -88,7 +88,6 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
     // TODO: Remove migrate props and migrate code
     migrate = true,
     migrateTextField = true,
-    migrateDialog,
     accessibilityLabel,
     accessibilityHint,
     items: propItems,
@@ -286,49 +285,45 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
 
   return (
     <PickerContext.Provider value={contextValue}>
-      {
-        // @ts-expect-error
-        <ExpandableOverlay
-          ref={pickerExpandable}
-          useDialog={useWheelPicker}
-          modalProps={modalProps}
-          dialogProps={DIALOG_PROPS}
-          migrateDialog={migrateDialog}
-          expandableContent={expandableModalContent}
-          renderCustomOverlay={renderCustomModal ? _renderCustomModal : undefined}
-          onPress={onPress}
-          testID={testID}
-          {...customPickerProps}
-          disabled={themeProps.editable === false}
-        >
-          {renderPicker ? (
-            // @ts-expect-error - hopefully will be solved after the picker migration ends
-            renderPicker(value, label)
-          ) : (
-            <TextFieldMigrator
-              migrate={migrateTextField}
-              // customWarning="RNUILib Picker component's internal TextField will soon be replaced with a new implementation, in order to start the migration - please pass to Picker the 'migrateTextField' prop"
-              // @ts-expect-error
-              ref={pickerRef}
-              // {...textInputProps}
-              {...others}
-              {...propsByFieldType}
-              testID={`${testID}.input`}
-              // @ts-expect-error
-              containerStyle={[containerStyle, propsByFieldType?.containerStyle]}
-              labelStyle={[propsByFieldType?.labelStyle, labelStyle]}
-              {...accessibilityInfo}
-              importantForAccessibility={'no-hide-descendants'}
-              value={label}
-              selection={Constants.isAndroid ? {start: 0} : undefined}
-              /* Note: Disable TextField expandable feature */
-              // topBarProps={undefined}
-            >
-              {renderPickerInnerInput()}
-            </TextFieldMigrator>
-          )}
-        </ExpandableOverlay>
-      }
+      <ExpandableOverlay
+        ref={pickerExpandable}
+        useDialog={useWheelPicker}
+        modalProps={modalProps}
+        dialogProps={DIALOG_PROPS}
+        expandableContent={expandableModalContent}
+        renderCustomOverlay={renderCustomModal ? _renderCustomModal : undefined}
+        onPress={onPress}
+        testID={testID}
+        {...customPickerProps}
+        disabled={themeProps.editable === false}
+      >
+        {renderPicker ? (
+          // @ts-expect-error - hopefully will be solved after the picker migration ends
+          renderPicker(value, label)
+        ) : (
+          <TextFieldMigrator
+            migrate={migrateTextField}
+            // customWarning="RNUILib Picker component's internal TextField will soon be replaced with a new implementation, in order to start the migration - please pass to Picker the 'migrateTextField' prop"
+            // @ts-expect-error
+            ref={pickerRef}
+            // {...textInputProps}
+            {...others}
+            {...propsByFieldType}
+            testID={`${testID}.input`}
+            // @ts-expect-error
+            containerStyle={[containerStyle, propsByFieldType?.containerStyle]}
+            labelStyle={[propsByFieldType?.labelStyle, labelStyle]}
+            {...accessibilityInfo}
+            importantForAccessibility={'no-hide-descendants'}
+            value={label}
+            selection={Constants.isAndroid ? {start: 0} : undefined}
+            /* Note: Disable TextField expandable feature */
+            // topBarProps={undefined}
+          >
+            {renderPickerInnerInput()}
+          </TextFieldMigrator>
+        )}
+      </ExpandableOverlay>
     </PickerContext.Provider>
   );
 });

--- a/src/components/picker/types.tsx
+++ b/src/components/picker/types.tsx
@@ -59,10 +59,6 @@ export type PickerBaseProps = Omit<NewTextFieldProps, 'value' | 'onChange'> &
      */
     migrateTextField?: boolean;
     /**
-     * Migrate the Dialog to DialogNew (make sure you use only new props in dialogProps)
-     */
-    migrateDialog?: boolean;
-    /**
      * Pass for different field type UI (form, filter or settings)
      */
     fieldType?: PickerFieldTypes;


### PR DESCRIPTION
## Description
Picker - ExpandableOverlay had ts error over the dialogProps.
We had the same error inside ExpandableOverlay `renderDialog`, it's coming from the `null` type for `height` prop in the old `Dialog` props.

## Changelog
Picker ts error fix.

## Additional info
<!--
If applicable, add additional info such as link to the bug being fixed by this PR etc
-->
