### PR TITLE
fix: Picker label not updating when items prop changes

### DIFF
--- a/src/components/picker/helpers/usePickerLabel.tsx
+++ b/src/components/picker/helpers/usePickerLabel.tsx
@@ -20,7 +20,7 @@ const usePickerLabel = (props: UsePickerLabelProps) => {
       _.map(arr, item => (_.isPlainObject(item) ? getItemLabel?.(item) || item?.label : itemsByValue[item]?.label)),
     arr => _.join(arr, ', '))(value);
   },
-  [getItemLabel]);
+  [getItemLabel, items]);
 
   const _getLabel = useCallback((value: PickerValue) => {
     if (_.isFunction(getLabel) && !_.isUndefined(getLabel(value))) {


### PR DESCRIPTION
## Description
<!--
Enter description to help the reviewer understand what's the change about...
-->
Fix Picker label not updating when items prop changes

## Changelog
<!--
Add a quick message for our users about this change (include Component name, relevant props and general purpose of the PR)
-->
Fx Picker label not updating when items prop changes

## Additional info
<!--
If applicable, add additional info such as link to the bug being fixed by this PR etc
-->
