### PR TITLE
Chip - change margin to padding

### DIFF
--- a/src/components/chip/index.tsx
+++ b/src/components/chip/index.tsx
@@ -278,7 +278,7 @@ const Chip = ({
               marginRight: Spacings.s2
             };
           } else {
-            return {marginHorizontal: Spacings.s3};
+            return {paddingHorizontal: Spacings.s3};
           }
         case 'avatar':
           return {


### PR DESCRIPTION
## Description
Using a margin cause a cut in the chip in some cases. moving to padding keeps the same UI without this bug.

## Changelog
Fix cut chips 

## Additional info
WOAUILIB-3665