### PR TITLE
Feature: allow setting the floating placeholder animation duration

### DIFF
--- a/src/components/textField/index.tsx
+++ b/src/components/textField/index.tsx
@@ -45,6 +45,7 @@ const LABEL_TYPOGRAPHY = Typography.text80;
 const ICON_SIZE = 24;
 const ICON_LEFT_PADDING = 6;
 const FLOATING_PLACEHOLDER_SCALE = 0.875;
+const FLOATING_PLACEHOLDER_ANIMATION_DURATION = 150;
 
 /**
  * @description: A wrapper for TextInput component with extra functionality like floating placeholder and validations (This is an uncontrolled component)
@@ -72,6 +73,10 @@ export default class TextField extends BaseInput {
      * Custom style for floating placeholder
      */
     floatingPlaceholderStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
+    /**
+     * Number in ms that describes how long floating placeholder will take it's place
+     */
+    floatingPlaceholderAnimationDuration: PropTypes.number,
     /**
      * This text will appear as a placeholder when the textInput becomes focused, only when passing floatingPlaceholder
      * as well (NOT for expandable textInputs)
@@ -189,7 +194,8 @@ export default class TextField extends BaseInput {
 
   static defaultProps = {
     enableErrors: true,
-    validateOnBlur: true
+    validateOnBlur: true,
+    floatingPlaceholderAnimationDuration: FLOATING_PLACEHOLDER_ANIMATION_DURATION
   };
 
   constructor(props) {
@@ -271,7 +277,7 @@ export default class TextField extends BaseInput {
     } else {
       Animated.spring(this.state.floatingPlaceholderState, {
         toValue: this.shouldFloatPlaceholder() ? 1 : 0,
-        duration: 150,
+        duration: this.props.floatingPlaceholderAnimationDuration,
         useNativeDriver: true
       }).start();
     }

--- a/src/incubator/TextField/FloatingPlaceholder.tsx
+++ b/src/incubator/TextField/FloatingPlaceholder.tsx
@@ -10,12 +10,15 @@ import Text from '../../components/text';
 import FieldContext from './FieldContext';
 
 const FLOATING_PLACEHOLDER_SCALE = 0.875;
+const FLOATING_PLACEHOLDER_ANIMATION_DURATION = 200;
+
 
 const FloatingPlaceholder = (props: FloatingPlaceholderProps) => {
   const {
     placeholder,
     floatingPlaceholderColor = Colors.$textNeutralLight,
     floatingPlaceholderStyle,
+    floatingPlaceholderAnimationDuration = FLOATING_PLACEHOLDER_ANIMATION_DURATION,
     validationMessagePosition,
     extraOffset = 0,
     testID
@@ -33,7 +36,7 @@ const FloatingPlaceholder = (props: FloatingPlaceholderProps) => {
   useDidUpdate(() => {
     Animated.timing(animation, {
       toValue: Number(shouldFloat),
-      duration: 200,
+      duration: floatingPlaceholderAnimationDuration,
       useNativeDriver: true
     }).start();
   }, [shouldFloat]);

--- a/src/incubator/TextField/index.tsx
+++ b/src/incubator/TextField/index.tsx
@@ -53,6 +53,7 @@ const TextField = (props: InternalTextFieldProps) => {
     floatingPlaceholder,
     floatingPlaceholderColor,
     floatingPlaceholderStyle,
+    floatingPlaceholderAnimationDuration,
     floatOnFocus,
     placeholderTextColor,
     hint,
@@ -167,6 +168,7 @@ const TextField = (props: InternalTextFieldProps) => {
                   placeholder={placeholder}
                   floatingPlaceholderStyle={_floatingPlaceholderStyle}
                   floatingPlaceholderColor={floatingPlaceholderColor}
+                  floatingPlaceholderAnimationDuration={floatingPlaceholderAnimationDuration}
                   floatOnFocus={floatOnFocus}
                   validationMessagePosition={validationMessagePosition}
                   extraOffset={leadingAccessoryMeasurements?.width}

--- a/src/incubator/TextField/types.ts
+++ b/src/incubator/TextField/types.ts
@@ -96,7 +96,7 @@ export interface FloatingPlaceholderProps {
   /**
    * Number in ms that describes how long floating placeholder will take it's place
    */
-  floatingPlaceholderAnimationDuration: number;
+  floatingPlaceholderAnimationDuration?: number;
   validationMessagePosition?: ValidationMessagePositionType;
   extraOffset?: number;
   defaultValue?: TextInputProps['defaultValue'];
@@ -205,7 +205,7 @@ export type TextFieldProps = MarginModifiers &
     /**
      * Number in ms that describes how long floating placeholder will take it's place
      */
-    floatingPlaceholderAnimationDuration: number;
+    floatingPlaceholderAnimationDuration?: number;
     /**
      * Should validate when the TextField mounts
      */

--- a/src/incubator/TextField/types.ts
+++ b/src/incubator/TextField/types.ts
@@ -93,6 +93,10 @@ export interface FloatingPlaceholderProps {
    * Should placeholder float on focus or when start typing
    */
   floatOnFocus?: boolean;
+  /**
+   * Number in ms that describes how long floating placeholder will take it's place
+   */
+  floatingPlaceholderAnimationDuration: number;
   validationMessagePosition?: ValidationMessagePositionType;
   extraOffset?: number;
   defaultValue?: TextInputProps['defaultValue'];
@@ -198,6 +202,10 @@ export type TextFieldProps = MarginModifiers &
      * A single or multiple validator. Can be a string (required, email) or custom function.
      */
     validate?: Validator | Validator[];
+    /**
+     * Number in ms that describes how long floating placeholder will take it's place
+     */
+    floatingPlaceholderAnimationDuration: number;
     /**
      * Should validate when the TextField mounts
      */


### PR DESCRIPTION

## Description
Added `floatingPlaceholderAnimationDuration` prop that configures float animation duration


## Changelog

Added `floatingPlaceholderAnimationDuration` prop to `TextField` component that allow configure float animation duration

## Additional info

I was asking for some help in [this discussion thread](https://github.com/wix/react-native-ui-lib/discussions/2669)

