### PR TITLE
fix: [WEB] svgImage sizing

### DIFF
--- a/src/components/svgImage/index.web.tsx
+++ b/src/components/svgImage/index.web.tsx
@@ -13,6 +13,23 @@ export interface SvgImageProps {
   style?: object[];
 }
 
+function setSVGSize(data: SvgImageProps['data'], style: SvgImageProps['style']) {
+  const tempElement = document.createElement('div');
+  tempElement.innerHTML = data.trim();
+  const svgElement = tempElement.querySelector('svg');
+
+  if (svgElement) {
+    const flattenStyle = StyleSheet.flatten(style) as {width?: string; height?: string};
+
+    svgElement?.setAttribute('width', `${flattenStyle?.width ?? DEFAULT_SIZE}`);
+    svgElement?.setAttribute('height', `${flattenStyle?.height ?? DEFAULT_SIZE}`);
+
+    return svgElement?.outerHTML;
+  }
+
+  return data;
+}
+
 function SvgImage(props: SvgImageProps) {
   const {data, style = [], tintColor, ...others} = props;
   const [svgStyleCss, setSvgStyleCss] = useState<string | undefined>(undefined);
@@ -45,21 +62,21 @@ function SvgImage(props: SvgImageProps) {
     }
     return <img {...others} src={data} style={StyleSheet.flatten(style)}/>;
   } else if (data) {
-    
+
     const PostCssPackage = require('../../optionalDependencies').PostCssPackage;
     if (PostCssPackage) {
       if (!postCssStyleCalled) {
         createStyleSvgCss(PostCssPackage, StyleSheet.flatten(style));
         return null;
       }
-      
+
       if (svgStyleCss) {
         const svgStyleTag = `<style> ${svgStyleCss} </style>`;
         return (
           <div
             {...others}
             // eslint-disable-next-line react/no-danger
-            dangerouslySetInnerHTML={{__html: svgStyleTag + data}}
+            dangerouslySetInnerHTML={{__html: svgStyleTag + setSVGSize(data, style)}}
           />
         );
       }


### PR DESCRIPTION
## Description
<!--
Enter description to help the reviewer understand what's the change about...
-->
When rendering `svgImage` with size, it doesn't override the size attr on the svg element.
for exmaple with this props the 200 on the svg element will be taken care instead of 24 from style:
```
{
    "fsTagName": "mask",
    "data": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<svg data-bbox=\"19 55.5 162 89\" xmlns=\"http://www.w3.org/2000/svg\" width=\"200\" height=\"200\" viewBox=\"0 0 200 200\" data-type=\"color\">\n    <g>\n        <path d=\"m181 63.5-8-8-73 72-73-72-8 8 81 81 81-81z\" fill=\"#ff0000\" data-color=\"1\"/>\n    </g>\n</svg>\n",
    "assetGroup": "icons",
    "style": [
        {
            "tintColor": "#fff"
        },
        {
            "width": 24,
            "height": 24,
            "tintColor": "#fff"
        }
    ],
    "tintColor": "#20303C",
    "source": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<svg data-bbox=\"19 55.5 162 89\" xmlns=\"http://www.w3.org/2000/svg\" width=\"200\" height=\"200\" viewBox=\"0 0 200 200\" data-type=\"color\">\n    <g>\n        <path d=\"m181 63.5-8-8-73 72-73-72-8 8 81 81 81-81z\" fill=\"#ff0000\" data-color=\"1\"/>\n    </g>\n</svg>\n",
    "testID": "buttonElement.icon",
    "recorderTag": "mask",
    "modifiers": {},
    "width": 16,
    "height": 16
}
```

## Changelog
<!--
Add a quick message for our users about this change (include Component name, relevant props and general purpose of the PR)
-->
fix svgImage sizing on web

## Additional info
<!--
If applicable, add additional info such as link to the bug being fixed by this PR etc
-->
