### PR TITLE
Vertical center Picker's wheel header

### DIFF
--- a/src/components/picker/PickerItemsList.tsx
+++ b/src/components/picker/PickerItemsList.tsx
@@ -89,7 +89,7 @@ const PickerItemsList = (props: PickerItemsListProps) => {
   const renderWheel = () => {
     return (
       <View>
-        <View row spread padding-page>
+        <View row spread centerV padding-page>
           <Text>{topBarProps?.title}</Text>
           <Text text70 $textPrimary accessibilityRole={'button'} onPress={() => context.onPress(wheelPickerValue)}>
             {topBarProps?.doneLabel ?? 'Select'}


### PR DESCRIPTION
## Description
The text blocks in the Picker's wheel header are not vertically centered, which looks ugly

## Changelog
Picker: vertical center wheel header
