### PR TITLE
Picker support useDialog

### DIFF
--- a/demo/src/screens/componentScreens/PickerScreen.tsx
+++ b/demo/src/screens/componentScreens/PickerScreen.tsx
@@ -54,6 +54,7 @@ export default class PickerScreen extends Component {
     language2: options[2].value,
     languages: [],
     nativePickerValue: 'java',
+    dialogPickerValue: 'java',
     customModalValues: [],
     filter: filters[0].value,
     scheme: schemes[0].value,
@@ -161,6 +162,21 @@ export default class PickerScreen extends Component {
                 labelStyle={Typography.text65}
                 disabled={option.disabled}
               />
+            ))}
+          </Picker>
+
+          <Picker
+            label="Dialog Picker"
+            placeholder="Pick a Language"
+            useDialog
+            //pass customPickerProps to use the new dialog
+            customPickerProps={{migrateDialog: true}}
+            value={this.state.dialogPickerValue}
+            onChange={dialogPickerValue => this.setState({dialogPickerValue})}
+            trailingAccessory={<Icon source={dropdown}/>}
+          >
+            {_.map(options, option => (
+              <Picker.Item key={option.value} value={option.value} label={option.label} disabled={option.disabled}/>
             ))}
           </Picker>
 

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -64,6 +64,7 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
     renderCustomSearch,
     // useNativePicker,
     useWheelPicker,
+    useDialog,
     renderPicker,
     customPickerProps,
     containerStyle,
@@ -287,7 +288,7 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
     <PickerContext.Provider value={contextValue}>
       <ExpandableOverlay
         ref={pickerExpandable}
-        useDialog={useWheelPicker}
+        useDialog={useDialog || useWheelPicker}
         modalProps={modalProps}
         dialogProps={DIALOG_PROPS}
         expandableContent={expandableModalContent}

--- a/src/components/picker/types.tsx
+++ b/src/components/picker/types.tsx
@@ -157,6 +157,10 @@ export type PickerBaseProps = Omit<NewTextFieldProps, 'value' | 'onChange'> &
      */
     useWheelPicker?: boolean;
     /**
+     * Use dialog instead of modal picker
+     */
+    useDialog?: boolean;
+    /**
      * Pass props to the list component that wraps the picker options (allows to control FlatList behavior)
      */
     listProps?: Partial<FlatListProps<any>>;


### PR DESCRIPTION
## Description
Picker support `useDialog` prop to render picker in Dialog instead of Modal.

## Changelog
Picker support `useDialog` prop to render picker in Dialog instead of Modal.