### PR TITLE
new button presets

### DIFF
--- a/src/components/button/ButtonTypes.tsx
+++ b/src/components/button/ButtonTypes.tsx
@@ -46,7 +46,6 @@ export type ButtonTypeProp = ButtonTypes | `${ButtonTypes}`;
 export enum ButtonPresets {
   main = 'main',
   inverted = 'inverted',
-  // premium = 'premium',
   distructive = 'distructive'
 }
 

--- a/src/components/button/ButtonTypes.tsx
+++ b/src/components/button/ButtonTypes.tsx
@@ -27,12 +27,30 @@ export enum ButtonAnimationDirection {
   right = 'right'
 }
 
-export type ButtonPresetProp = ButtonPresets | `${ButtonPresets}`;
-
-export enum ButtonPresets {
+export enum ButtonPrioritys {
   primary = 'primary',
   secondary = 'secondary'
 }
+
+export type ButtonPriorityProp = ButtonPrioritys | `${ButtonPrioritys}`;
+
+export enum ButtonTypes {
+  standard = 'standard',
+  icon = 'icon',
+  link = 'link',
+  fullwidth = 'fullwidth'
+}
+
+export type ButtonTypeProp = ButtonTypes | `${ButtonTypes}`;
+
+export enum ButtonPresets {
+  main = 'main',
+  inverted = 'inverted',
+  // premium = 'premium',
+  distructive = 'distructive'
+}
+
+export type ButtonPresetProp = ButtonPresets | `${ButtonPresets}`;
 
 export type ButtonAnimationDirectionProp = ButtonAnimationDirection | `${ButtonAnimationDirection}`;
 
@@ -78,6 +96,14 @@ export type ButtonProps = TouchableOpacityProps &
      * Size of the button [large, medium, small, xSmall]
      */
     size?: ButtonSizeProp;
+    /**
+     * Predefined priority to apply on the button
+     */
+    priority?: ButtonPriorityProp;
+    /**
+     * Predefined type to apply on the button
+     */
+    type?: ButtonTypeProp;
     /**
      * Predefined preset to apply on the button
      */
@@ -172,7 +198,9 @@ export type Props = ButtonProps & BaseComponentInjectedProps & ForwardRefInjecte
 
 export const DEFAULT_PROPS = {
   iconOnRight: false,
-  preset: ButtonPresets.primary
+  priority: ButtonPrioritys.primary,
+  type: ButtonTypes.standard,
+  preset: ButtonPresets.main
 };
 
 /**
@@ -183,8 +211,8 @@ export const DEFAULT_PROPS = {
  * @gif: https://github.com/wix/react-native-ui-lib/blob/master/demo/showcase/Button/Button%20Animated.gif?raw=true
  * @example: https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/ButtonsScreen.tsx
  */
-// @ts-ignore 
-class FakeButtonForDocs extends PureComponent<ButtonProps> { // eslint-disable-line
+// @ts-ignore
+class FakeButtonForDocs extends PureComponent<ButtonProps> {// eslint-disable-line
   static displayName = 'Button';
 
   static defaultProps = DEFAULT_PROPS;

--- a/src/components/button/ButtonTypes.tsx
+++ b/src/components/button/ButtonTypes.tsx
@@ -27,6 +27,13 @@ export enum ButtonAnimationDirection {
   right = 'right'
 }
 
+export type ButtonPresetProp = ButtonPresets | `${ButtonPresets}`;
+
+export enum ButtonPresets {
+  primary = 'primary',
+  secondary = 'secondary'
+}
+
 export type ButtonAnimationDirectionProp = ButtonAnimationDirection | `${ButtonAnimationDirection}`;
 
 export type ButtonProps = TouchableOpacityProps &
@@ -71,6 +78,10 @@ export type ButtonProps = TouchableOpacityProps &
      * Size of the button [large, medium, small, xSmall]
      */
     size?: ButtonSizeProp;
+    /**
+     * Predefined preset to apply on the button
+     */
+    preset?: ButtonPresetProp;
     /**
      * Custom border radius.
      */
@@ -160,7 +171,8 @@ export type ButtonState = {
 export type Props = ButtonProps & BaseComponentInjectedProps & ForwardRefInjectedProps;
 
 export const DEFAULT_PROPS = {
-  iconOnRight: false
+  iconOnRight: false,
+  preset: ButtonPresets.primary
 };
 
 /**

--- a/src/components/button/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/button/__tests__/__snapshots__/index.spec.js.snap
@@ -4542,6 +4542,184 @@ exports[`Button outline should return undefined when link is true, even when out
 </View>
 `;
 
+exports[`Button priority - primary should render default button, primary priority 1`] = `
+<View
+  accessibilityRole="button"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onClick={[Function]}
+  onLayout={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    {
+      "alignItems": "center",
+      "backgroundColor": "#5A48F5",
+      "borderRadius": 999,
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "minWidth": 90,
+      "opacity": 1,
+      "paddingHorizontal": 20,
+      "paddingVertical": 9.5,
+    }
+  }
+>
+  <Text
+    fsTagName="unmask"
+    numberOfLines={1}
+    style={
+      [
+        {
+          "backgroundColor": "transparent",
+          "color": "#20303C",
+          "writingDirection": "ltr",
+        },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        [
+          {
+            "backgroundColor": "transparent",
+            "flexDirection": "row",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": "400",
+            "lineHeight": 24,
+          },
+          {
+            "color": "#FFFFFF",
+          },
+          undefined,
+          undefined,
+          undefined,
+        ],
+      ]
+    }
+    testID="undefined.label"
+  >
+    Button
+  </Text>
+</View>
+`;
+
+exports[`Button priority - secondary should render button with an outline, secondary priority 1`] = `
+<View
+  accessibilityRole="button"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onClick={[Function]}
+  onLayout={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    {
+      "alignItems": "center",
+      "backgroundColor": "transparent",
+      "borderColor": "#5A48F5",
+      "borderRadius": 999,
+      "borderWidth": 1,
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "minWidth": 90,
+      "opacity": 1,
+      "paddingHorizontal": 19,
+      "paddingVertical": 8.5,
+    }
+  }
+>
+  <Text
+    fsTagName="unmask"
+    numberOfLines={1}
+    style={
+      [
+        {
+          "backgroundColor": "transparent",
+          "color": "#20303C",
+          "writingDirection": "ltr",
+        },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        [
+          {
+            "backgroundColor": "transparent",
+            "flexDirection": "row",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": "400",
+            "lineHeight": 24,
+          },
+          {
+            "color": "#5A48F5",
+          },
+          undefined,
+          undefined,
+          undefined,
+        ],
+      ]
+    }
+    testID="undefined.label"
+  >
+    Button
+  </Text>
+</View>
+`;
+
 exports[`Button should render default button 1`] = `
 <View
   accessibilityRole="button"
@@ -4584,6 +4762,358 @@ exports[`Button should render default button 1`] = `
       "opacity": 1,
       "paddingHorizontal": 20,
       "paddingVertical": 9.5,
+    }
+  }
+>
+  <Text
+    fsTagName="unmask"
+    numberOfLines={1}
+    style={
+      [
+        {
+          "backgroundColor": "transparent",
+          "color": "#20303C",
+          "writingDirection": "ltr",
+        },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        [
+          {
+            "backgroundColor": "transparent",
+            "flexDirection": "row",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": "400",
+            "lineHeight": 24,
+          },
+          {
+            "color": "#FFFFFF",
+          },
+          undefined,
+          undefined,
+          undefined,
+        ],
+      ]
+    }
+    testID="undefined.label"
+  >
+    Button
+  </Text>
+</View>
+`;
+
+exports[`Button type should render default button, type standard 1`] = `
+<View
+  accessibilityRole="button"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onClick={[Function]}
+  onLayout={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    {
+      "alignItems": "center",
+      "backgroundColor": "#5A48F5",
+      "borderRadius": 999,
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "minWidth": 90,
+      "opacity": 1,
+      "paddingHorizontal": 20,
+      "paddingVertical": 9.5,
+    }
+  }
+>
+  <Text
+    fsTagName="unmask"
+    numberOfLines={1}
+    style={
+      [
+        {
+          "backgroundColor": "transparent",
+          "color": "#20303C",
+          "writingDirection": "ltr",
+        },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        [
+          {
+            "backgroundColor": "transparent",
+            "flexDirection": "row",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": "400",
+            "lineHeight": 24,
+          },
+          {
+            "color": "#FFFFFF",
+          },
+          undefined,
+          undefined,
+          undefined,
+        ],
+      ]
+    }
+    testID="undefined.label"
+  >
+    Button
+  </Text>
+</View>
+`;
+
+exports[`Button type should render full width button, type fullwidth 1`] = `
+<View
+  accessibilityRole="button"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onClick={[Function]}
+  onLayout={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    {
+      "alignItems": "center",
+      "backgroundColor": "#5A48F5",
+      "borderRadius": 0,
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "minWidth": 90,
+      "opacity": 1,
+      "paddingHorizontal": 20,
+      "paddingVertical": 9.5,
+    }
+  }
+>
+  <Text
+    fsTagName="unmask"
+    numberOfLines={1}
+    style={
+      [
+        {
+          "backgroundColor": "transparent",
+          "color": "#20303C",
+          "writingDirection": "ltr",
+        },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        [
+          {
+            "backgroundColor": "transparent",
+            "flexDirection": "row",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": "400",
+            "lineHeight": 24,
+          },
+          {
+            "color": "#FFFFFF",
+          },
+          undefined,
+          undefined,
+          undefined,
+        ],
+      ]
+    }
+    testID="undefined.label"
+  >
+    Button
+  </Text>
+</View>
+`;
+
+exports[`Button type should render link button, type link 1`] = `
+<View
+  accessibilityRole="button"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onClick={[Function]}
+  onLayout={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    {
+      "alignItems": "center",
+      "backgroundColor": "transparent",
+      "borderRadius": 0,
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "minWidth": undefined,
+      "opacity": 1,
+      "paddingHorizontal": undefined,
+      "paddingVertical": undefined,
+    }
+  }
+>
+  <Text
+    fsTagName="unmask"
+    numberOfLines={1}
+    style={
+      [
+        {
+          "backgroundColor": "transparent",
+          "color": "#20303C",
+          "writingDirection": "ltr",
+        },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        [
+          {
+            "backgroundColor": "transparent",
+            "flexDirection": "row",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": "400",
+            "lineHeight": 24,
+          },
+          {
+            "color": "#5A48F5",
+          },
+          undefined,
+          undefined,
+          undefined,
+        ],
+      ]
+    }
+    testID="undefined.label"
+  >
+    Button
+  </Text>
+</View>
+`;
+
+exports[`Button type should render round button, type icon 1`] = `
+<View
+  accessibilityRole="button"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onClick={[Function]}
+  onLayout={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    {
+      "alignItems": "center",
+      "backgroundColor": "#5A48F5",
+      "borderRadius": 999,
+      "flexDirection": "row",
+      "height": undefined,
+      "justifyContent": "center",
+      "opacity": 1,
+      "padding": 9.5,
+      "width": undefined,
     }
   }
 >

--- a/src/components/button/__tests__/index.spec.js
+++ b/src/components/button/__tests__/index.spec.js
@@ -15,6 +15,42 @@ describe('Button', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  describe('priority - primary', () => {
+    it('should render default button, primary priority', () => {
+      const tree = renderer.create(<Button label="Button" priority={'primary'}/>).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe('priority - secondary', () => {
+    it('should render button with an outline, secondary priority', () => {
+      const tree = renderer.create(<Button label="Button" priority={'secondary'}/>).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe('type', () => {
+    it('should render default button, type standard', () => {
+      const tree = renderer.create(<Button label="Button" type={'standard'}/>).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should render round button, type icon', () => {
+      const tree = renderer.create(<Button label="Button" type={'icon'}/>).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should render link button, type link', () => {
+      const tree = renderer.create(<Button label="Button" type={'link'}/>).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should render full width button, type fullwidth', () => {
+      const tree = renderer.create(<Button label="Button" type={'fullwidth'}/>).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
   describe('outline', () => {
     it('should render button with an outline', () => {
       const tree = renderer.create(<Button label="Button" outline/>).toJSON();

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -15,12 +15,12 @@ import {
   ButtonState,
   Props,
   DEFAULT_PROPS,
-  ButtonSizeProp
+  ButtonSizeProp,
+  ButtonPresets
 } from './ButtonTypes';
 import {PADDINGS, HORIZONTAL_PADDINGS, MIN_WIDTH, DEFAULT_SIZE} from './ButtonConstants';
 
-export {ButtonSize, ButtonAnimationDirection, ButtonProps};
-
+export {ButtonSize, ButtonAnimationDirection, ButtonProps, ButtonPresets};
 
 class Button extends PureComponent<Props, ButtonState> {
   static displayName = 'Button';
@@ -30,6 +30,8 @@ class Button extends PureComponent<Props, ButtonState> {
   static sizes = ButtonSize;
 
   static animationDirection = ButtonAnimationDirection;
+
+  static presets = ButtonPresets;
 
   // This redundant constructor for some reason fix tests :/
   // eslint-disable-next-line
@@ -64,8 +66,8 @@ class Button extends PureComponent<Props, ButtonState> {
   };
 
   get isOutline() {
-    const {outline, outlineColor} = this.props;
-    return Boolean(outline || outlineColor);
+    const {outline, outlineColor, preset} = this.props;
+    return Boolean(preset === ButtonPresets.secondary || outline || outlineColor);
   }
 
   get isLink() {
@@ -83,10 +85,10 @@ class Button extends PureComponent<Props, ButtonState> {
   }
 
   getBackgroundColor() {
-    const {disabled, outline, disabledBackgroundColor, backgroundColor, modifiers} = this.props;
+    const {disabled, outline, preset, disabledBackgroundColor, backgroundColor, modifiers} = this.props;
     const {backgroundColor: modifiersBackgroundColor} = modifiers;
 
-    if (!outline && !this.isLink) {
+    if (!(outline || preset === Button.presets.secondary) && !this.isLink) {
       if (disabled) {
         return disabledBackgroundColor || Colors.$backgroundDisabled;
       }
@@ -105,20 +107,30 @@ class Button extends PureComponent<Props, ButtonState> {
   }
 
   getLabelColor() {
-    const {linkColor, outline, outlineColor, disabled, color: propsColor, backgroundColor, modifiers} = this.props;
+    const {
+      linkColor,
+      outline,
+      preset,
+      outlineColor,
+      disabled,
+      color: propsColor,
+      backgroundColor,
+      modifiers
+    } = this.props;
     const {color: modifiersColor} = modifiers;
     const isLink = this.isLink;
+    const isOutline = this.isOutline;
 
     let color: string | undefined = Colors.$textDefaultLight;
     if (isLink) {
       color = linkColor || Colors.$textPrimary;
-    } else if (outline) {
+    } else if (outline || preset === Button.presets.secondary) {
       color = outlineColor || Colors.$textPrimary;
     } else if (this.isIconButton) {
       color = backgroundColor === 'transparent' ? undefined : Colors.$iconDefaultLight;
     }
 
-    if (disabled && (isLink || outline)) {
+    if (disabled && (isLink || isOutline)) {
       return Colors.$textDisabled;
     }
 
@@ -142,6 +154,7 @@ class Button extends PureComponent<Props, ButtonState> {
   getContainerSizeStyle() {
     const {
       outline,
+      preset,
       avoidMinWidth,
       avoidInnerPadding,
       round,
@@ -181,7 +194,7 @@ class Button extends PureComponent<Props, ButtonState> {
         minWidth: MIN_WIDTH.LARGE
       };
 
-    if (outline) {
+    if (outline || preset === Button.presets.secondary) {
       _.forEach(CONTAINER_STYLE_BY_SIZE, style => {
         if (round) {
           style.padding -= outlineWidth; // eslint-disable-line
@@ -213,10 +226,10 @@ class Button extends PureComponent<Props, ButtonState> {
   }
 
   getOutlineStyle() {
-    const {outline, outlineColor, outlineWidth, disabled} = this.props;
+    const {outlineColor, outlineWidth, disabled} = this.props;
 
     let outlineStyle;
-    if ((outline || outlineColor) && !this.isLink) {
+    if (this.isOutline && !this.isLink) {
       outlineStyle = {
         borderWidth: outlineWidth || 1,
         borderColor: outlineColor || Colors.$outlinePrimary


### PR DESCRIPTION
## Description
New Button presets `Primary` (set as default) and `Secondary` to use `outline`.
Next PR should include depreciation of the `outline` prop.

## Changelog
New Button presets `Primary` (set as default) and `Secondary` to use `outline`.

## Additional info
