### PR TITLE
Fix picked reanimated typings

### DIFF
--- a/src/components/view/index.tsx
+++ b/src/components/view/index.tsx
@@ -9,7 +9,7 @@ import type {RecorderProps} from '../../typings/recorderTypes';
 /**
  * Extra props when using reanimated (only non experimental props)
  */
-type ReanimatedProps = Pick<RNReanimatedProps<object>, 'entering' | 'exiting' | 'layout'>;
+type ReanimatedProps = Partial<Pick<RNReanimatedProps<object>, 'entering' | 'exiting' | 'layout'>>;
 
 export interface ViewProps
   extends Omit<RNViewProps, 'style'>,


### PR DESCRIPTION
## Description
Make picked reanimated type partial so they won't be mandatory
(For some reason we don't get an issue on this, but modules do)


## Changelog
Make picked reanimated type partial so they won't be mandatory

## Additional info
https://wix.slack.com/archives/C3B1EMVF0/p1693122291216409