### PR TITLE
fix: [WEB] SvgImage update styles

### DIFF
--- a/src/components/svgImage/index.web.tsx
+++ b/src/components/svgImage/index.web.tsx
@@ -27,7 +27,7 @@ function SvgImage(props: SvgImageProps) {
         .process(styleObj, {parser: cssjs})
         .then((style: {css: any}) => {
           const svgPathCss = (styleObj?.tintColor) ? `#${id} svg path {fill: ${styleObj?.tintColor}}` : '';
-          setSvgStyleCss(`#${id} svg {${style.css}} ${svgPathCss}}`);
+          setSvgStyleCss(`#${id} svg {${style.css}} #${id} {${style.css}} ${svgPathCss}}`);
         });
     }
   }, [style, id]);

--- a/src/components/svgImage/index.web.tsx
+++ b/src/components/svgImage/index.web.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {StyleSheet} from 'react-native';
 import Image from '../image';
 import {isSvg, isSvgUri, isBase64ImageContent} from '../../utils/imageUtils';
@@ -15,19 +15,22 @@ export interface SvgImageProps {
 
 function SvgImage(props: SvgImageProps) {
   const {data, style = [], tintColor, ...others} = props;
+  const [id] = useState(`svg-${new Date().getTime().toString()}`);
   const [svgStyleCss, setSvgStyleCss] = useState<string | undefined>(undefined);
-  const [postCssStyleCalled, setPostCssStyleCalled] = useState(false);
 
-  const createStyleSvgCss = async (PostCssPackage: {postcss: any; cssjs: any}, styleObj?: Record<string, any>) => {
-    setPostCssStyleCalled(true);
-    const {postcss, cssjs} = PostCssPackage;
-    postcss()
-      .process(styleObj, {parser: cssjs})
-      .then((style: {css: any}) => {
-        const svgPathCss = (styleObj?.tintColor) ? `svg path {fill: ${styleObj?.tintColor}}` : '';
-        setSvgStyleCss(`svg {${style.css}} ${svgPathCss}}`);
-      });
-  };
+  useEffect(() => {
+    const PostCssPackage = require('../../optionalDependencies').PostCssPackage;
+    if (PostCssPackage) {
+      const {postcss, cssjs} = PostCssPackage;
+      const styleObj: Record<string, any> = StyleSheet.flatten(style);
+      postcss()
+        .process(styleObj, {parser: cssjs})
+        .then((style: {css: any}) => {
+          const svgPathCss = (styleObj?.tintColor) ? `#${id} svg path {fill: ${styleObj?.tintColor}}` : '';
+          setSvgStyleCss(`#${id} svg {${style.css}} ${svgPathCss}}`);
+        });
+    }
+  }, [style, id]);
 
   if (isSvgUri(data)) {
     return <img {...others} src={data.uri} style={StyleSheet.flatten(style)}/>;
@@ -44,26 +47,16 @@ function SvgImage(props: SvgImageProps) {
       );
     }
     return <img {...others} src={data} style={StyleSheet.flatten(style)}/>;
-  } else if (data) {
-    
-    const PostCssPackage = require('../../optionalDependencies').PostCssPackage;
-    if (PostCssPackage) {
-      if (!postCssStyleCalled) {
-        createStyleSvgCss(PostCssPackage, StyleSheet.flatten(style));
-        return null;
-      }
-      
-      if (svgStyleCss) {
-        const svgStyleTag = `<style> ${svgStyleCss} </style>`;
-        return (
-          <div
-            {...others}
-            // eslint-disable-next-line react/no-danger
-            dangerouslySetInnerHTML={{__html: svgStyleTag + data}}
-          />
-        );
-      }
-    }
+  } else if (data && svgStyleCss) {
+    const svgStyleTag = `<style> ${svgStyleCss} </style>`;
+    return (
+      <div
+        id={id}
+        {...others}
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{__html: svgStyleTag + data}}
+      />
+    );
   }
   return null;
 }

--- a/src/components/svgImage/index.web.tsx
+++ b/src/components/svgImage/index.web.tsx
@@ -3,6 +3,8 @@ import {StyleSheet} from 'react-native';
 import Image from '../image';
 import {isSvg, isSvgUri, isBase64ImageContent} from '../../utils/imageUtils';
 
+const PostCssPackage = require('../../optionalDependencies').PostCssPackage;
+
 const DEFAULT_SIZE = 16;
 export interface SvgImageProps {
   /**
@@ -19,7 +21,6 @@ function SvgImage(props: SvgImageProps) {
   const [svgStyleCss, setSvgStyleCss] = useState<string | undefined>(undefined);
 
   useEffect(() => {
-    const PostCssPackage = require('../../optionalDependencies').PostCssPackage;
     if (PostCssPackage) {
       const {postcss, cssjs} = PostCssPackage;
       const styleObj: Record<string, any> = StyleSheet.flatten(style);

--- a/webDemo/src/App.tsx
+++ b/webDemo/src/App.tsx
@@ -42,6 +42,32 @@ const svgData = '<svg data-bbox="18.5 31.5 163.1 137.2" viewBox="0 0 200 200" he
 
 const itemsToRender: ItemToRender[] = [
   {
+    title: 'IconButton SVG Resize',
+    FC: () => {
+      const [size, setSize] = useState(Spacings.s4);
+
+      console.log('$$ IconButton SVG Resize', {size});
+
+      return (
+        <Button
+          round
+          id={'iconButton_resize_svg'}
+          size={Button.sizes.large}
+          iconSource={svgData}
+          iconStyle={{
+            width: size,
+            height: size,
+            tintColor: '#ffffff'
+          }}
+          onPress={() => {
+            const newSize = size === Spacings.s4 ? Spacings.s6 : Spacings.s4;
+            setSize(newSize);
+          }}
+        />
+      );
+    }
+  },
+  {
     title: 'Carousel',
     FC: CarouselWrapper
 
@@ -97,6 +123,7 @@ const itemsToRender: ItemToRender[] = [
     FC: () => (
       <Button
         label={'Svg tag'}
+        id={'iconButton'}
         size={Button.sizes.large}
         iconSource={svgData}
         iconStyle={{


### PR DESCRIPTION
## Description
This PR is fixing 3 bugs in web svg component:
1. when rendering more than 1 svg, the style of the last one will override all of them
2. the style is initialized once, and doesn't been updated
3. the height of the svg wrapper bigger than the svg's height - caused an offest inside the button. the svg took too much space
<img width="335" alt="image" src="https://github.com/wix/react-native-ui-lib/assets/47475100/30474507-c934-41c0-83e9-f9e2fa5ce1b5">

**changes:**
1. add component to the web demo with `IconButton` that changes size
2. add unique id to each svg component
3. apply style also on the div wrapper
4. update the css when the style changes
## Changelog
<!--
Add a quick message for our users about this change (include Component name, relevant props and general purpose of the PR)
-->
fix: [WEB] Svg image unique style tag and update styles

## Additional info
<!--
If applicable, add additional info such as link to the bug being fixed by this PR etc
-->
