### PR TITLE
chore: infer SVG size from style

### DIFF
--- a/src/components/button/ButtonTypes.tsx
+++ b/src/components/button/ButtonTypes.tsx
@@ -52,6 +52,10 @@ export type ButtonProps = TouchableOpacityProps &
      */
     iconStyle?: StyleProp<ImageStyle>;
     /**
+     * Other image props that will be passed to the image
+     */
+    iconProps?: Partial<ImageProps>;
+    /**
      * Should the icon be right to the label
      */
     iconOnRight?: boolean;
@@ -171,7 +175,7 @@ export const DEFAULT_PROPS = {
  * @gif: https://github.com/wix/react-native-ui-lib/blob/master/demo/showcase/Button/Button%20Animated.gif?raw=true
  * @example: https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/ButtonsScreen.tsx
  */
-// @ts-ignore 
+// @ts-ignore
 class FakeButtonForDocs extends PureComponent<ButtonProps> { // eslint-disable-line
   static displayName = 'Button';
 

--- a/src/components/button/button.api.json
+++ b/src/components/button/button.api.json
@@ -25,6 +25,7 @@
       "description": "Icon image source or a callback function that returns a source"
     },
     {"name": "iconStyle", "type": "ImageStyle", "description": "Icon image style"},
+    {"name": "iconProps", "type": "Partial<ImageProps>", "description": "Icon image props"},
     {"name": "iconOnRight", "type": "boolean", "description": "Should the icon be right to the label"},
     {"name": "supportRTL", "type": "boolean", "description": "whether the icon should flip horizontally on RTL locals"},
     {"name": "backgroundColor", "type": "string", "description": "Color of the button background"},

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -292,7 +292,7 @@ class Button extends PureComponent<Props, ButtonState> {
   }
 
   renderIcon() {
-    const {iconSource, supportRTL, testID} = this.props;
+    const {iconSource, supportRTL, testID, iconProps} = this.props;
 
     if (iconSource) {
       const iconStyle = this.getIconStyle();
@@ -302,10 +302,24 @@ class Button extends PureComponent<Props, ButtonState> {
       } else {
         if (Constants.isWeb) {
           return (
-            <Icon style={iconStyle} tintColor={Colors.$iconDefault} source={iconSource} testID={`${testID}.icon`}/>
+            <Icon
+              style={iconStyle}
+              tintColor={Colors.$iconDefault}
+              source={iconSource}
+              testID={`${testID}.icon`}
+              {...iconProps}
+            />
           );
         }
-        return <Image source={iconSource} supportRTL={supportRTL} style={iconStyle} testID={`${testID}.icon`}/>;
+        return (
+          <Image
+            source={iconSource}
+            supportRTL={supportRTL}
+            style={iconStyle}
+            testID={`${testID}.icon`}
+            {...iconProps}
+          />
+        );
       }
     }
     return null;

--- a/src/components/svgImage/index.tsx
+++ b/src/components/svgImage/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {ImageStyle, StyleProp, StyleSheet} from 'react-native';
 import {isSvg, isSvgUri} from '../../utils/imageUtils';
 import {SvgPackage} from '../../optionalDependencies';
 
@@ -12,6 +13,7 @@ export interface SvgImageProps {
    */
   tintColor?: string | null;
   data: any; // TODO: I thought this should be string | React.ReactNode but it doesn't work properly
+  style?: StyleProp<ImageStyle>;
 }
 
 function SvgImage(props: SvgImageProps) {
@@ -28,7 +30,12 @@ function SvgImage(props: SvgImageProps) {
   if (isSvgUri(data)) {
     return <SvgCssUri {...others} uri={data.uri}/>;
   } else if (typeof data === 'string') {
-    return <SvgXml xml={data} {...others}/>;
+    const flattenStyle = StyleSheet.flatten(props.style) as Record<string, any>;
+    const dimensions = {
+      ...(flattenStyle?.width ? {width: flattenStyle.width} : {}),
+      ...(flattenStyle?.height ? {height: flattenStyle.height} : {})
+    };
+    return <SvgXml xml={data} {...dimensions} {...others}/>;
   } else if (data) {
     const File = data; // Must be with capital letter
     return <File {...others}/>;

--- a/src/components/svgImage/index.tsx
+++ b/src/components/svgImage/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {ImageStyle, StyleProp, StyleSheet} from 'react-native';
 import {isSvg, isSvgUri} from '../../utils/imageUtils';
 import {SvgPackage} from '../../optionalDependencies';
 
@@ -13,7 +12,6 @@ export interface SvgImageProps {
    */
   tintColor?: string | null;
   data: any; // TODO: I thought this should be string | React.ReactNode but it doesn't work properly
-  style?: StyleProp<ImageStyle>;
 }
 
 function SvgImage(props: SvgImageProps) {
@@ -30,12 +28,7 @@ function SvgImage(props: SvgImageProps) {
   if (isSvgUri(data)) {
     return <SvgCssUri {...others} uri={data.uri}/>;
   } else if (typeof data === 'string') {
-    const flattenStyle = StyleSheet.flatten(props.style) as Record<string, any>;
-    const dimensions = {
-      ...(flattenStyle?.width ? {width: flattenStyle.width} : {}),
-      ...(flattenStyle?.height ? {height: flattenStyle.height} : {})
-    };
-    return <SvgXml xml={data} {...dimensions} {...others}/>;
+    return <SvgXml xml={data} {...others}/>;
   } else if (data) {
     const File = data; // Must be with capital letter
     return <File {...others}/>;


### PR DESCRIPTION
## Description
<!--
Enter description to help the reviewer understand what's the change about...
-->
allow SVG to infer size from the style object

## Changelog
<!--
Add a quick message for our users about this change (include Component name, relevant props and general purpose of the PR)
-->
Now SVG can infer size from style

## Additional info
<!--
If applicable, add additional info such as link to the bug being fixed by this PR etc
-->
