### PR TITLE
docs: Updated dead link of Reanimated setup guide

### DIFF
--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -34,7 +34,7 @@ If you plan on using specific components, see **UILib Packages** above.
 
 ### Peer Dependencies
 UILIb has mandatory peer dependencies on the following packages:
-- react-native-reanimated (Make sure to follow [Reanimated setup guide](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation))
+- react-native-reanimated (Make sure to follow [Reanimated setup guide](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started))
 - react-native-gesture-handler
 
 ### Optional Dependencies


### PR DESCRIPTION
## Description
`react-native-reanimated` setup guide link seem to be invalid & leads to 404 page.
 
## Changelog
docs: fixed dead link of react-native-reanimated setup guide