### PR TITLE
gridList - fixContainerWidth

### DIFF
--- a/src/components/gridList/useGridLayout.ts
+++ b/src/components/gridList/useGridLayout.ts
@@ -21,7 +21,7 @@ const useGridLayout = (props: GridListBaseProps) => {
   const {orientation} = useOrientation();
 
   const _containerWidth = useMemo(() => {
-    return (containerWidth ?? Constants.screenWidth - Constants.getPageMargins()) - listPadding * 2;
+    return (containerWidth ?? Constants.screenWidth - 2 * Constants.getPageMargins()) - listPadding * 2;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [listPadding, orientation, containerWidth]);
 


### PR DESCRIPTION
## Description
While using sortableGridList on Tablets, I noticed that there was a wrong calculation.
I didn't check if this change can affect other modules, just open the PR, so you can take a look at it, and decide if it is not harmful.

## Changelog
fix the containerWidth calculation for GridList components

## Additional info
see the record of sortableGridList in ipad before the change 

https://github.com/wix/react-native-ui-lib/assets/47741208/ac2ec20c-ee80-4590-8186-0ef290f6a447
