### PR TITLE
Fixed chips scroll on press

### DIFF
--- a/demo/src/screens/MainScreen.js
+++ b/demo/src/screens/MainScreen.js
@@ -117,7 +117,7 @@ class MainScreen extends Component {
     this?.sectionListRef?.current?.scrollToLocation({
       animated: true,
       sectionIndex: index,
-      itemIndex: 0,
+      itemIndex: 1,
       viewPosition: 0
     });
   };


### PR DESCRIPTION
## Description
Fixed bug where clicking on the chips wouldn't scroll to the appropriate section.

## Changelog
Tiny change in scrollToSection function

## Additional info
<!--
If applicable, add additional info such as link to the bug being fixed by this PR etc
-->
