### PR TITLE
Fix react-native.config has wrong file for DynamicFont

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -8,11 +8,11 @@ module.exports = {
       // },
       android: {
         sourceDir: './lib/android/',
-        packageImportPath: `import com.wix.reactnativeuilib.dynamicfont.DynamicFontModule;
+        packageImportPath: `import com.wix.reactnativeuilib.dynamicfont.DynamicFontPackage;
 import com.wix.reactnativeuilib.highlighterview.HighlighterViewPackage;
 import com.wix.reactnativeuilib.keyboardinput.KeyboardInputPackage;
 import com.wix.reactnativeuilib.textinput.TextInputDelKeyHandlerPackage;`,
-        packageInstance: `new DynamicFontModule(),
+        packageInstance: `new DynamicFontPackage(),
       new HighlighterViewPackage(),
       new TextInputDelKeyHandlerPackage(),
       new KeyboardInputPackage(getApplication())`


### PR DESCRIPTION
## Description
Fix react-native.config has wrong file for DynamicFont.
Unfortunately we use a different mechanism so we did not find this when testing in private...
Fixes #2764 

## Changelog
Fix react-native.config has wrong file for DynamicFont

## Additional info
https://github.com/wix/react-native-ui-lib/issues/2764
