### PR TITLE
Fix/text field focused when disable

### DIFF
--- a/src/incubator/TextField/Input.tsx
+++ b/src/incubator/TextField/Input.tsx
@@ -70,6 +70,7 @@ const Input = ({
       ref={inputRef}
       underlineColorAndroid="transparent"
       accessibilityState={{disabled}}
+      pointerEvents={disabled ? 'none' : 'auto'}
     />
   );
 };

--- a/src/incubator/TextField/Input.tsx
+++ b/src/incubator/TextField/Input.tsx
@@ -36,6 +36,7 @@ const Input = ({
   useGestureHandlerInput,
   readonly,
   recorderTag,
+  pointerEvents,
   ...props
 }: InputProps & ForwardRefInjectedProps) => {
   const inputRef = useImperativeInputHandle(forwardedRef, {onChangeText: props.onChangeText});
@@ -70,7 +71,7 @@ const Input = ({
       ref={inputRef}
       underlineColorAndroid="transparent"
       accessibilityState={{disabled}}
-      pointerEvents={disabled ? 'none' : 'auto'}
+      pointerEvents={disabled ? 'none' : pointerEvents}
     />
   );
 };


### PR DESCRIPTION
## Description
Changed pointerEvents to none if the TextInput is disabled. I took the pointerEvents from the props which by default is set to 'auto' if we ever want to pass it from the parent.

## Changelog
TextField - Fixed text field still sends keyboardDidShow and keyboardWillShow on iOS

## Additional info
WOAUILIB-3622
