### PR TITLE
Add TS support for shorthand gap attribute

### DIFF
--- a/src/components/view/index.tsx
+++ b/src/components/view/index.tsx
@@ -36,6 +36,10 @@ export interface ViewProps extends Omit<RNViewProps, 'style'>, ReanimatedProps, 
    */
   height?: string | number;
   /**
+   * Set flexbox gap
+   */
+  gap?: number;
+  /**
    * Experimental: Pass time in ms to delay render
    */
   renderDelay?: number;


### PR DESCRIPTION
## Description
Add shorthand prop support for [gap property](https://reactnative.dev/docs/flexbox#row-gap-column-gap-and-gap)

## Changelog
View - TS support for shorthand `gap` style.
