### PR TITLE
Colors - expose shouldSupportDarkMode

### DIFF
--- a/src/style/colors.ts
+++ b/src/style/colors.ts
@@ -27,7 +27,7 @@ export type GeneratePaletteOptions = {
 }
 export class Colors {
   [key: string]: any;
-  private shouldSupportDarkMode = false;
+  shouldSupportDarkMode = false;
 
   constructor() {
     const colors = Object.assign(colorsPalette);


### PR DESCRIPTION
## Description
Colors - expose shouldSupportDarkMode
We need it to know if we should flip to DM or not even if the Scheme is 'dark'

## Changelog
Colors - expose shouldSupportDarkMode

## Additional info

