### PR TITLE
Removed migrate to new slider in colorpicker.

### DIFF
--- a/src/components/colorPicker/index.tsx
+++ b/src/components/colorPicker/index.tsx
@@ -124,7 +124,6 @@ class ColorPicker extends PureComponent<Props> {
             doneButton: accessibilityLabels?.doneButton,
             input: accessibilityLabels?.input
           }}
-          migrate
         />
       </View>
     );


### PR DESCRIPTION
## Description
Reverted the migration to the new slider in the ColorPicker component.

## Changelog
ColorPicker - Removed migrate from ColorPickerDialog