### PR TITLE
Fix/carousel android rtl jumps

### DIFF
--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -204,7 +204,8 @@ class Carousel extends Component<CarouselProps, CarouselState> {
     const {loop} = this.props;
     let nextPageIndex;
     if (currentPage === pagesCount + 1) {
-      return this.goToPage(0, false);
+      this.goToPage(0, false);
+      return;
     }
     if (loop) {
       nextPageIndex = currentPage + 1;

--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -472,8 +472,7 @@ class Carousel extends Component<CarouselProps, CarouselState> {
   }
 
   renderAccessibleLayout() {
-    const {containerStyle, children: propsChildren, testID} = this.props;
-    const children = Constants.isRTL && Constants.isAndroid ? React.Children.toArray(propsChildren) : propsChildren;
+    const {containerStyle, children, testID} = this.props;
     return (
       <View style={containerStyle} onLayout={this.onContainerLayout}>
         <ScrollView

--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -307,14 +307,13 @@ class Carousel extends Component<CarouselProps, CarouselState> {
   onMomentumScrollEnd = () => {
     // finished full page scroll
     const {currentStandingPage, currentPage} = this.state;
-    const index = currentPage;
     const pagesCount = presenter.getChildrenLength(this.props);
 
-    if (index < pagesCount) {
-      this.setState({currentStandingPage: index});
+    if (currentPage < pagesCount) {
+      this.setState({currentStandingPage: currentPage});
 
-      if (currentStandingPage !== index) {
-        this.props.onChangePage?.(index, currentStandingPage, {isAutoScrolled: this.isAutoScrolled});
+      if (currentStandingPage !== currentPage) {
+        this.props.onChangePage?.(currentPage, currentStandingPage, {isAutoScrolled: this.isAutoScrolled});
         this.isAutoScrolled = false;
       }
     }
@@ -425,6 +424,7 @@ class Carousel extends Component<CarouselProps, CarouselState> {
 
   renderPageControl() {
     const {pageControlPosition, pageControlProps = {}} = this.props;
+    const {currentStandingPage} = this.state;
 
     if (pageControlPosition) {
       const {
@@ -449,7 +449,7 @@ class Carousel extends Component<CarouselProps, CarouselState> {
           color={color}
           {...others}
           numOfPages={pagesCount}
-          currentPage={this.state.currentStandingPage}
+          currentPage={currentStandingPage}
         />
       );
     }

--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -457,14 +457,14 @@ class Carousel extends Component<CarouselProps, CarouselState> {
 
   renderCounter() {
     const {pageWidth, showCounter, counterTextStyle} = this.props;
-    const {currentPage} = this.state;
+    const {currentStandingPage} = this.state;
     const pagesCount = presenter.getChildrenLength(this.props);
 
     if (showCounter && !pageWidth) {
       return (
         <View center style={styles.counter}>
           <Text grey80 text90 style={[{fontWeight: 'bold'}, counterTextStyle]}>
-            {currentPage + 1}/{pagesCount}
+            {currentStandingPage + 1}/{pagesCount}
           </Text>
         </View>
       );

--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -52,7 +52,7 @@ class Carousel extends Component<CarouselProps, CarouselState> {
     const defaultPageWidth = props.loop || !props.pageWidth ? Constants.screenWidth : props.pageWidth;
     const pageHeight = props.pageHeight ?? Constants.screenHeight;
     this.isAutoScrolled = false;
-    
+
     this.state = {
       containerWidth: undefined,
       // @ts-ignore (defaultProps)
@@ -239,10 +239,8 @@ class Carousel extends Component<CarouselProps, CarouselState> {
     if (containerWidth) {
       const spacings = pageWidth === containerWidth ? 0 : this.getItemSpacings(this.props);
       const initialBreak = pageWidth - (containerWidth - pageWidth - spacings) / 2;
-      const snapToOffsets = _.times(
-        presenter.getChildrenLength(this.props),
-        index => initialBreak + index * pageWidth + this.getContainerMarginHorizontal()
-      );
+      const snapToOffsets = _.times(presenter.getChildrenLength(this.props),
+        index => initialBreak + index * pageWidth + this.getContainerMarginHorizontal());
       return snapToOffsets;
     }
   };
@@ -355,10 +353,11 @@ class Carousel extends Component<CarouselProps, CarouselState> {
   };
 
   onScrollEvent = Animated.event([
-    {nativeEvent: 
-      {contentOffset: 
-        // @ts-ignore
-        {y: this.props?.animatedScrollOffset?.y, x: this.props?.animatedScrollOffset?.x}
+    {
+      nativeEvent: {
+        contentOffset:
+            // @ts-ignore
+            {y: this.props?.animatedScrollOffset?.y, x: this.props?.animatedScrollOffset?.x}
       }
     }
   ],
@@ -501,11 +500,7 @@ class Carousel extends Component<CarouselProps, CarouselState> {
     const ScrollContainer = animatedScrollOffset ? Animated.ScrollView : ScrollView;
     const contentOffset = this.getInitialContentOffset(snapToOffsets);
     return (
-      <View
-        animated={animated}
-        style={[{marginBottom}, containerStyle]}
-        onLayout={this.onContainerLayout}
-      >
+      <View animated={animated} style={[{marginBottom}, containerStyle]} onLayout={this.onContainerLayout}>
         <ScrollContainer
           showsHorizontalScrollIndicator={false}
           showsVerticalScrollIndicator={false}

--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -449,7 +449,7 @@ class Carousel extends Component<CarouselProps, CarouselState> {
           color={color}
           {...others}
           numOfPages={pagesCount}
-          currentPage={this.getCalcIndex(this.state.currentPage)}
+          currentPage={this.state.currentPage}
         />
       );
     }
@@ -493,7 +493,7 @@ class Carousel extends Component<CarouselProps, CarouselState> {
   }
 
   renderCarousel() {
-    const {containerStyle, animated, horizontal, animatedScrollOffset, ...others} = this.props;
+    const {containerStyle, animated, horizontal, animatedScrollOffset, style, ...others} = this.props;
     const scrollContainerStyle = this.shouldUsePageWidth()
       ? {paddingRight: this.getItemSpacings(this.props)}
       : undefined;
@@ -501,6 +501,7 @@ class Carousel extends Component<CarouselProps, CarouselState> {
     const marginBottom = Math.max(0, this.getContainerPaddingVertical() - 16);
     const ScrollContainer = animatedScrollOffset ? Animated.ScrollView : ScrollView;
     const contentOffset = this.getInitialContentOffset(snapToOffsets);
+    const _style = Constants.isRTL && Constants.isAndroid ? [styles.invertedView, style] : style;
     return (
       <View animated={animated} style={[{marginBottom}, containerStyle]} onLayout={this.onContainerLayout}>
         <ScrollContainer
@@ -518,6 +519,7 @@ class Carousel extends Component<CarouselProps, CarouselState> {
           contentOffset={contentOffset}
           // onContentSizeChange={this.onContentSizeChange}
           onMomentumScrollEnd={this.onMomentumScrollEnd}
+          style={_style}
         >
           {this.renderChildren()}
         </ScrollContainer>
@@ -553,5 +555,8 @@ const styles = StyleSheet.create({
   hiddenText: {
     position: 'absolute',
     width: 1
+  },
+  invertedView: {
+    transform: [{scaleX: -1}]
   }
 });

--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -203,11 +203,11 @@ class Carousel extends Component<CarouselProps, CarouselState> {
     const pagesCount = presenter.getChildrenLength(this.props);
     const {loop} = this.props;
     let nextPageIndex;
-    if (currentPage === pagesCount + 1) {
-      this.goToPage(0, false);
-      return;
-    }
     if (loop) {
+      if (currentPage === pagesCount + 1) {
+        this.goToPage(0, false);
+        return;
+      }
       nextPageIndex = currentPage + 1;
     } else {
       nextPageIndex = Math.min(pagesCount - 1, currentPage + 1);

--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -195,7 +195,7 @@ class Carousel extends Component<CarouselProps, CarouselState> {
   }
 
   goToPage(pageIndex: number, animated = true) {
-    this.setState({currentPage: this.getCalcIndex(pageIndex)}, () => this.updateOffset(animated));
+    this.setState({currentPage: pageIndex}, () => this.updateOffset(animated));
   }
 
   goToNextPage() {
@@ -203,7 +203,9 @@ class Carousel extends Component<CarouselProps, CarouselState> {
     const pagesCount = presenter.getChildrenLength(this.props);
     const {loop} = this.props;
     let nextPageIndex;
-
+    if (currentPage === pagesCount + 1) {
+      return this.goToPage(0, false);
+    }
     if (loop) {
       nextPageIndex = currentPage + 1;
     } else {
@@ -211,12 +213,11 @@ class Carousel extends Component<CarouselProps, CarouselState> {
     }
 
     this.goToPage(nextPageIndex, true);
-
-    // in case of a loop, after we advanced right to the cloned first page,
-    // we return silently to the real first page
-    if (loop && currentPage === pagesCount) {
-      this.goToPage(0, false);
-    }
+    // // in case of a loop, after we advanced right to the cloned first page,
+    // // we return silently to the real first page
+    // if (loop && currentPage === pagesCount) {
+    //   this.goToPage(0, false);
+    // }
   }
 
   getCalcIndex(index: number): number {
@@ -403,9 +404,10 @@ class Carousel extends Component<CarouselProps, CarouselState> {
   };
 
   renderChildren() {
-    const {children, loop} = this.props;
+    const {children: propsChildren, loop} = this.props;
     const length = presenter.getChildrenLength(this.props);
-
+    const children =
+      Constants.isRTL && Constants.isAndroid ? React.Children.toArray(propsChildren).reverse() : propsChildren;
     const childrenArray = React.Children.map(children, (child, index) => {
       return this.renderChild(child, `${index}`);
     });
@@ -454,14 +456,14 @@ class Carousel extends Component<CarouselProps, CarouselState> {
 
   renderCounter() {
     const {pageWidth, showCounter, counterTextStyle} = this.props;
-    const {currentStandingPage} = this.state;
+    const {currentPage} = this.state;
     const pagesCount = presenter.getChildrenLength(this.props);
 
     if (showCounter && !pageWidth) {
       return (
         <View center style={styles.counter}>
           <Text grey80 text90 style={[{fontWeight: 'bold'}, counterTextStyle]}>
-            {currentStandingPage + 1}/{pagesCount}
+            {currentPage + 1}/{pagesCount}
           </Text>
         </View>
       );
@@ -469,8 +471,8 @@ class Carousel extends Component<CarouselProps, CarouselState> {
   }
 
   renderAccessibleLayout() {
-    const {containerStyle, children, testID} = this.props;
-
+    const {containerStyle, children: propsChildren, testID} = this.props;
+    const children = Constants.isRTL && Constants.isAndroid ? React.Children.toArray(propsChildren) : propsChildren;
     return (
       <View style={containerStyle} onLayout={this.onContainerLayout}>
         <ScrollView

--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -307,7 +307,7 @@ class Carousel extends Component<CarouselProps, CarouselState> {
   onMomentumScrollEnd = () => {
     // finished full page scroll
     const {currentStandingPage, currentPage} = this.state;
-    const index = this.getCalcIndex(currentPage);
+    const index = currentPage;
     const pagesCount = presenter.getChildrenLength(this.props);
 
     if (index < pagesCount) {

--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -449,7 +449,7 @@ class Carousel extends Component<CarouselProps, CarouselState> {
           color={color}
           {...others}
           numOfPages={pagesCount}
-          currentPage={this.state.currentPage}
+          currentPage={this.state.currentStandingPage}
         />
       );
     }


### PR DESCRIPTION
## Description
There was a problem with the currentPage calculation. I removed the usage of the getCalcIndex from the goToPage and moved the page calculation in the goToNextPage. On android RTL the children is passed reversed for some reason so I revered so the first item will show first.

## Changelog
Carousel - Fixed Android RTL jumps on random items.

## Additional info
<!--
If applicable, add additional info such as link to the bug being fixed by this PR etc
-->
