### PR TITLE
TextField - fix web flexness

### DIFF
--- a/src/components/textField/FloatingPlaceholder.tsx
+++ b/src/components/textField/FloatingPlaceholder.tsx
@@ -87,6 +87,7 @@ const FloatingPlaceholder = (props: FloatingPlaceholderProps) => {
         onLayout={onPlaceholderLayout}
         testID={testID}
         recorderTag={'unmask'}
+        numberOfLines={1}
       >
         {shouldRenderIndication ? placeholder?.concat('*') : placeholder}
       </Text>

--- a/src/components/textField/index.tsx
+++ b/src/components/textField/index.tsx
@@ -156,7 +156,7 @@ const TextField = (props: InternalTextFieldProps) => {
             Known Issue: This slightly push the trailing accessory when entering a long text
           */}
           {children || (
-            <View flexG>
+            <View flexG={!Constants.isWeb} flex={Constants.isWeb}>
               {/* Note: Render dummy placeholder for Android center issues */}
               {Constants.isAndroid && centered && (
                 <Text marginR-s1 style={dummyPlaceholderStyle}>


### PR DESCRIPTION
## Description
TextField - fix web flexness
I opted for this (and not adding a new prop), it seems to solve it without the bug we have in mobile.

## Changelog
TextField - fix web flexness

## Additional info
WOAUILIB-3701
