### PR TITLE
Avoid failing rgba API

### DIFF
--- a/src/style/__tests__/colors.spec.js
+++ b/src/style/__tests__/colors.spec.js
@@ -36,7 +36,7 @@ describe('style/Colors', () => {
     expect(uut.rgba(101, 136, 0.7)).toBe(undefined);
     expect(logServiceSpy).toHaveBeenCalledWith('Colors.rgba fail due to invalid arguments');
     expect(uut.rgba(undefined, 0.2)).toBe(undefined);
-    expect(logServiceSpy).toHaveBeenCalledWith('Colors.rgba fail due to invalid arguments');
+    expect(logServiceSpy).toHaveBeenNthCalledWith(2, 'Colors.rgba fail due to invalid arguments');
   });
 
   it('should handle invalid rgb code', () => {

--- a/src/style/__tests__/colors.spec.js
+++ b/src/style/__tests__/colors.spec.js
@@ -1,8 +1,12 @@
 import uut from '../colors';
+import LogService from '../../services/LogService';
+
 const SYSTEM_COLORS = ['grey', 'white', 'black'];
 const GetColorsByHexOptions = {validColors: SYSTEM_COLORS};
 
 describe('style/Colors', () => {
+  const logServiceSpy = jest.spyOn(LogService, 'error');
+  // jest.mock('../../services/LogService');
   it('should add alpha to hex color value', () => {
     expect(uut.rgba(uut.green30, 0.7)).toBe('rgba(0, 168, 126, 0.7)');
     expect(uut.rgba(uut.red10, 0.7)).toBe('rgba(213, 39, 18, 0.7)');
@@ -29,7 +33,10 @@ describe('style/Colors', () => {
   });
 
   it('should handle wrong number of params', () => {
-    expect(() => uut.rgba(101, 136, 0.7)).toThrow(new Error('rgba can work with either 2 or 4 arguments'));
+    expect(uut.rgba(101, 136, 0.7)).toBe(undefined);
+    expect(logServiceSpy).toHaveBeenCalledWith('Colors.rgba fail due to invalid arguments');
+    expect(uut.rgba(undefined, 0.2)).toBe(undefined);
+    expect(logServiceSpy).toHaveBeenCalledWith('Colors.rgba fail due to invalid arguments');
   });
 
   it('should handle invalid rgb code', () => {

--- a/src/style/__tests__/colors.spec.js
+++ b/src/style/__tests__/colors.spec.js
@@ -6,7 +6,6 @@ const GetColorsByHexOptions = {validColors: SYSTEM_COLORS};
 
 describe('style/Colors', () => {
   const logServiceSpy = jest.spyOn(LogService, 'error');
-  // jest.mock('../../services/LogService');
   it('should add alpha to hex color value', () => {
     expect(uut.rgba(uut.green30, 0.7)).toBe('rgba(0, 168, 126, 0.7)');
     expect(uut.rgba(uut.red10, 0.7)).toBe('rgba(213, 39, 18, 0.7)');
@@ -34,7 +33,6 @@ describe('style/Colors', () => {
 
   it('should handle wrong number of params', () => {
     expect(uut.rgba(101, 136, 0.7)).toBe(undefined);
-    expect(logServiceSpy).toHaveBeenCalledWith('Colors.rgba fail due to invalid arguments');
     expect(uut.rgba(undefined, 0.2)).toBe(undefined);
     expect(logServiceSpy).toHaveBeenNthCalledWith(2, 'Colors.rgba fail due to invalid arguments');
   });

--- a/src/style/colors.ts
+++ b/src/style/colors.ts
@@ -10,6 +10,7 @@ import DesignTokensDM from './designTokensDM';
 import ColorName from './colorName';
 import Scheme, {Schemes, SchemeType} from './scheme';
 import type {ExtendTypeWith} from '../typings/common';
+import LogService from '../services/LogService';
 
 export type DesignToken = {semantic?: [string]; resource_paths?: [string]; toString: Function};
 export type TokensOptions = {primaryColor: string};
@@ -101,9 +102,9 @@ export class Colors {
    * p3 - B part of RGB
    * p4 - opacity
    */
-  rgba(p1: string, p2: number): string;
-  rgba(p1: number, p2: number, p3: number, p4: number): string;
-  rgba(p1: number | string, p2: number, p3?: number, p4?: number): string {
+  rgba(p1: string, p2: number): string | undefined;
+  rgba(p1: number, p2: number, p3: number, p4: number): string | undefined;
+  rgba(p1: number | string, p2: number, p3?: number, p4?: number): string | undefined {
     let hex;
     let opacity;
     let red;
@@ -129,7 +130,8 @@ export class Colors {
       blue = validateRGB(p3!);
       opacity = p4;
     } else {
-      throw new Error('rgba can work with either 2 or 4 arguments');
+      LogService.error('Colors.rgba fail due to invalid arguments');
+      return undefined;
     }
     return `rgba(${red}, ${green}, ${blue}, ${opacity})`;
   }


### PR DESCRIPTION
## Description
Avoid failing Colors.rgba API on invalid input to avoid app crashes

## Changelog
Avoid failing Colors.rgba API on invalid input to avoid app crashes

## Additional info
<!--
If applicable, add additional info such as link to the bug being fixed by this PR etc
-->
