### PR TITLE
Fixing phantom label on the wheel picker.

### DIFF
--- a/src/components/WheelPicker/Item.tsx
+++ b/src/components/WheelPicker/Item.tsx
@@ -73,7 +73,7 @@ const WheelPickerItem = memo(({
     return [animatedColorStyle, style, fakeLabel ? textWithLabelPaddingStyle : styles.textPadding];
   }, [style, fakeLabel, animatedColorStyle, textWithLabelPaddingStyle]);
 
-  const _fakeLabelStyle = useMemo(() => StyleSheet.compose(fakeLabelStyle, styles.hidden), [fakeLabelStyle]);
+  const _fakeLabelStyle = useMemo(() => StyleSheet.flatten([fakeLabelStyle, styles.hidden]), [fakeLabelStyle]);
   return (
     <AnimatedTouchableOpacity
       activeOpacity={1}

--- a/src/components/WheelPicker/Item.tsx
+++ b/src/components/WheelPicker/Item.tsx
@@ -73,7 +73,7 @@ const WheelPickerItem = memo(({
     return [animatedColorStyle, style, fakeLabel ? textWithLabelPaddingStyle : styles.textPadding];
   }, [style, fakeLabel, animatedColorStyle, textWithLabelPaddingStyle]);
 
-  const _fakeLabelStyle = useMemo(() => StyleSheet.flatten([fakeLabelStyle, styles.hidden]), [fakeLabelStyle]);
+  const _fakeLabelStyle = useMemo(() => StyleSheet.compose(fakeLabelStyle, styles.hidden), [fakeLabelStyle]);
   return (
     <AnimatedTouchableOpacity
       activeOpacity={1}

--- a/src/components/WheelPicker/Item.tsx
+++ b/src/components/WheelPicker/Item.tsx
@@ -73,6 +73,7 @@ const WheelPickerItem = memo(({
     return [animatedColorStyle, style, fakeLabel ? textWithLabelPaddingStyle : styles.textPadding];
   }, [style, fakeLabel, animatedColorStyle, textWithLabelPaddingStyle]);
 
+  const _fakeLabelStyle = useMemo(() => StyleSheet.flatten([fakeLabelStyle, styles.hidden]), [fakeLabelStyle]);
   return (
     <AnimatedTouchableOpacity
       activeOpacity={1}
@@ -92,7 +93,7 @@ const WheelPickerItem = memo(({
         {label}
       </AnimatedText>
       {fakeLabel && (
-        <Text text80M $textDefaultLight {...fakeLabelProps} style={fakeLabelStyle}>
+        <Text text80M $textDefaultLight {...fakeLabelProps} style={_fakeLabelStyle}>
           {fakeLabel}
         </Text>
       )}
@@ -111,5 +112,8 @@ const styles = StyleSheet.create({
   },
   disableRTL: {
     flexDirection: 'row-reverse'
+  },
+  hidden: {
+    opacity: 0
   }
 });

--- a/src/components/WheelPicker/Item.tsx
+++ b/src/components/WheelPicker/Item.tsx
@@ -88,22 +88,11 @@ const WheelPickerItem = memo(({
       testID={testID}
       row
     >
-      <AnimatedText
-        text60R
-        testID={`${testID}.text`}
-        numberOfLines={1}
-        style={textStyle}
-        recorderTag={'unmask'}
-      >
+      <AnimatedText text60R testID={`${testID}.text`} numberOfLines={1} style={textStyle} recorderTag={'unmask'}>
         {label}
       </AnimatedText>
       {fakeLabel && (
-        <Text
-          text80M
-          $textDefaultLight
-          {...fakeLabelProps}
-          style={fakeLabelStyle}
-        >
+        <Text text80M $textDefaultLight {...fakeLabelProps} style={fakeLabelStyle}>
           {fakeLabel}
         </Text>
       )}

--- a/src/components/WheelPicker/index.tsx
+++ b/src/components/WheelPicker/index.tsx
@@ -222,7 +222,7 @@ const WheelPicker = ({
   const fakeLabelProps = useMemo(() => {
     return {...labelMargins, ...labelProps};
   }, [labelMargins, labelProps]);
-  const itemLabelStyle = useMemo(() => ({...labelStyle, opacity: 0}), [labelStyle]);
+
   const renderItem = useCallback(({item, index}: ListRenderItemInfo<ItemProps>) => {
     return (
       <Item
@@ -235,7 +235,7 @@ const WheelPicker = ({
         {...item}
         disableRTL={shouldDisableRTL}
         fakeLabel={label}
-        fakeLabelStyle={itemLabelStyle}
+        fakeLabelStyle={labelStyle}
         fakeLabelProps={fakeLabelProps}
         centerH={!label}
         onSelect={selectItem}
@@ -249,7 +249,7 @@ const WheelPicker = ({
     fakeLabelProps,
     offset,
     testID,
-    itemLabelStyle,
+    labelStyle,
     label,
     activeTextColor,
     inactiveTextColor,

--- a/src/components/WheelPicker/index.tsx
+++ b/src/components/WheelPicker/index.tsx
@@ -222,7 +222,7 @@ const WheelPicker = ({
   const fakeLabelProps = useMemo(() => {
     return {...labelMargins, ...labelProps};
   }, [labelMargins, labelProps]);
-
+  const itemLabelStyle = useMemo(() => ({...labelStyle, opacity: 0}), [labelStyle]);
   const renderItem = useCallback(({item, index}: ListRenderItemInfo<ItemProps>) => {
     return (
       <Item
@@ -235,7 +235,7 @@ const WheelPicker = ({
         {...item}
         disableRTL={shouldDisableRTL}
         fakeLabel={label}
-        fakeLabelStyle={labelStyle}
+        fakeLabelStyle={itemLabelStyle}
         fakeLabelProps={fakeLabelProps}
         centerH={!label}
         onSelect={selectItem}

--- a/src/components/WheelPicker/index.tsx
+++ b/src/components/WheelPicker/index.tsx
@@ -249,7 +249,7 @@ const WheelPicker = ({
     fakeLabelProps,
     offset,
     testID,
-    labelStyle,
+    itemLabelStyle,
     label,
     activeTextColor,
     inactiveTextColor,


### PR DESCRIPTION
## Description
There were labels near the values of the wheel picker. Because they were white they could only be seen on darker backgrounds. I added opacity = 0 because removing this label was causing the entire layout to change.

## Changelog
WheelPicker - fixed value labels showing near every label.

## Additional info
WOAUILIB-3875