### PR TITLE
Fix RadioButton typings to extend our ViewProps

### DIFF
--- a/src/components/radioButton/index.tsx
+++ b/src/components/radioButton/index.tsx
@@ -7,13 +7,12 @@ import {
   StyleProp,
   ImageSourcePropType,
   ImageStyle,
-  ViewStyle,
-  ViewProps
+  ViewStyle
 } from 'react-native';
 import {Colors} from '../../style';
 import {asBaseComponent, forwardRef, BaseComponentInjectedProps, ForwardRefInjectedProps} from '../../commons/new';
 import TouchableOpacity from '../touchableOpacity';
-import View from '../view';
+import View, {ViewProps} from '../view';
 import Text from '../text';
 import Image from '../image';
 import asRadioGroupChild from '../radioGroup/asRadioGroupChild';
@@ -187,7 +186,7 @@ class RadioButton extends PureComponent<Props, RadioButtonState> {
 
   getRadioButtonOutlineStyle() {
     const {color, size, borderRadius, style: propsStyle, disabled} = this.props;
-    const style = [this.styles.radioButtonOutline];
+    const style: ViewProps['style'][] = [this.styles.radioButtonOutline];
 
     if (size) {
       style.push({width: size, height: size});


### PR DESCRIPTION
## Description
Our RadioButton didn't extend our ViewProps but ReactNative's 
For some reason only now we got a complaint about missing types 🤷 
Anyway, this PR should fix it

## Changelog
Fix RadioButton typings to extend ours ViewProps

## Additional info
