### PR TITLE
remove static default backgroundColor prop

### DIFF
--- a/src/components/tabController/TabBar.tsx
+++ b/src/components/tabController/TabBar.tsx
@@ -20,7 +20,6 @@ import {useDidUpdate} from 'hooks';
 
 const FIX_RTL = Constants.isRTL && Constants.isAndroid;
 const DEFAULT_HEIGHT = 48;
-const DEFAULT_BACKGROUND_COLOR = Colors.$backgroundElevated;
 
 const DEFAULT_LABEL_STYLE = {
   ...Typography.text80M,
@@ -151,7 +150,7 @@ const TabBar = (props: Props) => {
     iconColor,
     selectedIconColor,
     activeBackgroundColor,
-    backgroundColor,
+    backgroundColor = Colors.$backgroundElevated,
     faderProps,
     containerWidth: propsContainerWidth,
     centerSelected,
@@ -322,7 +321,6 @@ TabBar.displayName = 'TabController.TabBar';
 TabBar.defaultProps = {
   labelStyle: DEFAULT_LABEL_STYLE,
   selectedLabelStyle: DEFAULT_SELECTED_LABEL_STYLE,
-  backgroundColor: DEFAULT_BACKGROUND_COLOR,
   faderProps: DEFAULT_FADER_PROPS,
   spreadItems: true
 };


### PR DESCRIPTION
## Description
Remove TabBar's default static backgroundColor prop value to avoid race condition when loading design tokens

## Changelog
Remove TabBar's default static backgroundColor prop value to avoid race condition when loading design tokens

## Additional info
<!--
If applicable, add additional info such as link to the bug being fixed by this PR etc
-->
