### PR TITLE
Reuse timeline for activity log

### DIFF
--- a/src/components/timeline/Line.tsx
+++ b/src/components/timeline/Line.tsx
@@ -17,7 +17,7 @@ const Line = React.memo((props: LinePropsInternal) => {
 
   const solidLineStyle = useMemo(() => {
     return [style, styles.line, {width, backgroundColor: color}];
-  }, [color, style]);
+  }, [color, style, width]);
 
   const dashedLineStyle = useMemo(() => {
     return [style, styles.line];

--- a/src/components/timeline/Line.tsx
+++ b/src/components/timeline/Line.tsx
@@ -16,11 +16,11 @@ const Line = React.memo((props: LinePropsInternal) => {
   const {type, color = 'transparent', entry, top, style, width = LINE_WIDTH} = props;
 
   const solidLineStyle = useMemo(() => {
-    return [style, styles.solidLine, {width, backgroundColor: color}];
+    return [style, styles.line, {width, backgroundColor: color}];
   }, [color, style]);
 
   const dashedLineStyle = useMemo(() => {
-    return [style, styles.dashedLine];
+    return [style, styles.line];
   }, [style]);
 
   const renderStartPoint = () => {
@@ -52,10 +52,7 @@ const styles = StyleSheet.create({
     width: 12,
     height: ENTRY_POINT_HEIGHT
   },
-  solidLine: {
+  line: {
     overflow: 'hidden'
   },
-  dashedLine: {
-    overflow: 'hidden'
-  }
 });

--- a/src/components/timeline/Line.tsx
+++ b/src/components/timeline/Line.tsx
@@ -54,5 +54,5 @@ const styles = StyleSheet.create({
   },
   line: {
     overflow: 'hidden'
-  },
+  }
 });

--- a/src/components/timeline/Line.tsx
+++ b/src/components/timeline/Line.tsx
@@ -13,10 +13,10 @@ type LinePropsInternal = LineProps & {
 };
 
 const Line = React.memo((props: LinePropsInternal) => {
-  const {type, color = 'transparent', entry, top, style} = props;
+  const {type, color = 'transparent', entry, top, style, width = LINE_WIDTH} = props;
 
   const solidLineStyle = useMemo(() => {
-    return [style, styles.solidLine, {backgroundColor: color}];
+    return [style, styles.solidLine, {width, backgroundColor: color}];
   }, [color, style]);
 
   const dashedLineStyle = useMemo(() => {
@@ -53,7 +53,6 @@ const styles = StyleSheet.create({
     height: ENTRY_POINT_HEIGHT
   },
   solidLine: {
-    width: LINE_WIDTH,
     overflow: 'hidden'
   },
   dashedLine: {

--- a/src/components/timeline/Point.tsx
+++ b/src/components/timeline/Point.tsx
@@ -20,7 +20,7 @@ type PointPropsInternal = PointProps & {
 };
 
 const Point = (props: PointPropsInternal) => {
-  const {icon, label, type, color, onLayout} = props;
+  const {icon, iconProps, label, type, color, onLayout} = props;
 
   const pointStyle = useMemo(() => {
     const hasOutline = type === PointTypes.OUTLINE;
@@ -43,7 +43,7 @@ const Point = (props: PointPropsInternal) => {
 
   const renderPointContent = () => {
     if (icon) {
-      return <Icon source={icon} size={ICON_SIZE} tintColor={Colors.$iconDefaultLight}/>;
+      return <Icon size={ICON_SIZE} tintColor={Colors.$iconDefaultLight} {...iconProps} source={icon}/>;
     } else if (label) {
       return <Text recorderTag={'unmask'} $textDefaultLight subtextBold>{label}</Text>;
     }

--- a/src/components/timeline/types.ts
+++ b/src/components/timeline/types.ts
@@ -1,6 +1,6 @@
 import React, {PropsWithChildren} from 'react';
 import {ImageRequireSource} from 'react-native';
-import { IconProps } from '../icon';
+import {IconProps} from '../icon';
 
 export enum StateTypes {
   CURRENT = 'current', // default

--- a/src/components/timeline/types.ts
+++ b/src/components/timeline/types.ts
@@ -1,5 +1,6 @@
 import React, {PropsWithChildren} from 'react';
 import {ImageRequireSource} from 'react-native';
+import { IconProps } from '../icon';
 
 export enum StateTypes {
   CURRENT = 'current', // default
@@ -25,6 +26,7 @@ export type LineProps = {
   color?: string;
   /** to mark as entry point */
   entry?: boolean;
+  width?: number;
 }
 
 export type PointProps = {
@@ -32,6 +34,7 @@ export type PointProps = {
   type?: PointTypes;
   color?: string;
   icon?: ImageRequireSource;
+  iconProps?: IconProps;
   label?: number;
   /** to align point to this view's center */
   anchorRef?: React.MutableRefObject<undefined>;


### PR DESCRIPTION
## Description
UX leans on reusing timeline component for activity log, so adding minimal required adjustments. Ideally, icon size would be equal to text line height and width of a line is one. This can be achieved with this PR.

## Changelog
Adding width prop to Line component & iconProps to Point component. This makes some of the previously static values dynamic

## Additional info
Required for activity log integration
