### PR TITLE
useCombinedRefs running effect on every call.

### DIFF
--- a/src/hooks/useCombinedRefs/index.ts
+++ b/src/hooks/useCombinedRefs/index.ts
@@ -10,7 +10,6 @@ const useCombinedRefs = (...refs: React.Ref<any>[]) => {
       if (!ref) {
         return;
       }
-      console.log('hello');
       if (typeof ref === 'function') {
         ref(targetRef.current);
       } else {

--- a/src/hooks/useCombinedRefs/index.ts
+++ b/src/hooks/useCombinedRefs/index.ts
@@ -1,14 +1,16 @@
+import _ from 'lodash';
 import React from 'react';
 
 const useCombinedRefs = (...refs: React.Ref<any>[]) => {
   const targetRef = React.useRef();
+  console.log(refs);
 
   React.useEffect(() => {
     refs.forEach(ref => {
       if (!ref) {
         return;
       }
-
+      console.log('hello');
       if (typeof ref === 'function') {
         ref(targetRef.current);
       } else {
@@ -16,7 +18,8 @@ const useCombinedRefs = (...refs: React.Ref<any>[]) => {
         ref.current = targetRef.current;
       }
     });
-  }, [refs]);
+  },
+  _.isArray(refs) ? refs : [refs]);
 
   return targetRef;
 };

--- a/src/hooks/useCombinedRefs/index.ts
+++ b/src/hooks/useCombinedRefs/index.ts
@@ -3,7 +3,6 @@ import React from 'react';
 
 const useCombinedRefs = (...refs: React.Ref<any>[]) => {
   const targetRef = React.useRef();
-  console.log(refs);
 
   React.useEffect(() => {
     refs.forEach(ref => {

--- a/src/hooks/useCombinedRefs/index.ts
+++ b/src/hooks/useCombinedRefs/index.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import React from 'react';
 
 const useCombinedRefs = (...refs: React.Ref<any>[]) => {
@@ -16,8 +15,7 @@ const useCombinedRefs = (...refs: React.Ref<any>[]) => {
         ref.current = targetRef.current;
       }
     });
-  },
-  _.isArray(refs) ? refs : [refs]);
+  }, refs);
 
   return targetRef;
 };


### PR DESCRIPTION
## Description
When sending more than two refs to the hook it will always create a new array on each call causing the useEffect to run every time. Until now this didn't happen because we didn't pass more than one ref.

## Changelog
useCombinedRef - Added handling for receiving more than one ref.

## Additional info
None
