### PR TITLE
[HOTFIX] Inverted child inner view on android RTL.

### DIFF
--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -381,14 +381,17 @@ class Carousel extends Component<CarouselProps, CarouselState> {
 
       return (
         <View
-          style={{
-            width: pageWidth,
-            height: !horizontal ? pageHeight : undefined,
-            paddingLeft,
-            marginLeft,
-            marginRight,
-            paddingVertical
-          }}
+          style={[
+            {
+              width: pageWidth,
+              height: !horizontal ? pageHeight : undefined,
+              paddingLeft,
+              marginLeft,
+              marginRight,
+              paddingVertical
+            },
+            Constants.isRTL && Constants.isAndroid && styles.invertedView
+          ]}
           key={key}
           collapsable={false}
         >


### PR DESCRIPTION
## Description
On #2831 I fixed the jumping bugs on android. In order to do that I inverted the ScrollView so we wont have to deal with index calculations. Inverting the ScrollView caused the children to also be inverted so I inverted them back in that case.

## Changelog
Carousel - Fixed inversion on Android RTL.

## Additional info
None
