### PR TITLE
Removed initial page calculation

### DIFF
--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -60,12 +60,12 @@ class Carousel extends Component<CarouselProps, CarouselState> {
       currentStandingPage: props.initialPage || 0,
       pageWidth: defaultPageWidth,
       pageHeight,
-      initialOffset: presenter.calcOffset(props, {
-        // @ts-ignore (defaultProps)
-        currentPage: props.initialPage,
-        pageWidth: defaultPageWidth,
-        pageHeight
-      }),
+      // initialOffset: presenter.calcOffset(props, {
+      //   // @ts-ignore (defaultProps)
+      //   currentPage: props.initialPage,
+      //   pageWidth: defaultPageWidth,
+      //   pageHeight
+      // }),
       prevProps: props
     };
   }

--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -60,12 +60,7 @@ class Carousel extends Component<CarouselProps, CarouselState> {
       currentStandingPage: props.initialPage || 0,
       pageWidth: defaultPageWidth,
       pageHeight,
-      // initialOffset: presenter.calcOffset(props, {
-      //   // @ts-ignore (defaultProps)
-      //   currentPage: props.initialPage,
-      //   pageWidth: defaultPageWidth,
-      //   pageHeight
-      // }),
+      initialOffset: {},
       prevProps: props
     };
   }

--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -56,7 +56,7 @@ class Carousel extends Component<CarouselProps, CarouselState> {
     this.state = {
       containerWidth: undefined,
       // @ts-ignore (defaultProps)
-      currentPage: this.shouldUsePageWidth() ? this.getCalcIndex(props.initialPage) : props.initialPage,
+      currentPage: props.initialPage,
       currentStandingPage: props.initialPage || 0,
       pageWidth: defaultPageWidth,
       pageHeight,
@@ -219,15 +219,6 @@ class Carousel extends Component<CarouselProps, CarouselState> {
     // if (loop && currentPage === pagesCount) {
     //   this.goToPage(0, false);
     // }
-  }
-
-  getCalcIndex(index: number): number {
-    // to handle scrollView index issue in Android's RTL layout
-    if (Constants.isRTL && Constants.isAndroid) {
-      const length = presenter.getChildrenLength(this.props) - 1;
-      return length - index;
-    }
-    return index;
   }
 
   // TODO: currently this returns pagesCount offsets, not starting from 0; look into changing this into (pagesCount - 1) or to have the 1st item as 0


### PR DESCRIPTION
## Description
Initial page on the carousel is not being calculated correctly after the index calculation changes.

## Changelog
Carousel - Fixed initial page not working.

## Additional info
None
