### PR TITLE
TextFiled - fix incompatible ref types TS error

### DIFF
--- a/src/components/textField/types.ts
+++ b/src/components/textField/types.ts
@@ -142,7 +142,6 @@ export interface CharCounterProps {
 
 export interface InputProps
   extends Omit<TextInputProps, 'placeholderTextColor'>,
-    Omit<React.ComponentPropsWithRef<typeof TextInput>, 'placeholderTextColor'>,
     MandatoryIndication,
     RecorderProps {
   /**


### PR DESCRIPTION
## Description
Fix ts error: 
```
Types of property 'ref' are incompatible.
Type 'Ref<TextInput> | undefined' is not assignable to type 'LegacyRef<Component<TextFieldProps, any, any>> | undefined'.
```

To reproduce add this code to playgroundScreen: 
```
export const ExpandableTextField = ({...textFieldProps}: TextFieldProps) => {
  return <TextField {...textFieldProps}/>;
};
```

## Changelog
TextField - fix TS error: Types of property 'ref' are incompatible

## Additional info
Ticket 3899
