### PR TITLE
fix: add "moment" dependency to resolve module error

### DIFF
--- a/expoDemo/package.json
+++ b/expoDemo/package.json
@@ -16,6 +16,7 @@
     "fuzzysearch": "^1.0.3",
     "lodash": "^4.17.21",
     "metro-config": "^0.75.1",
+    "moment": "^2.30.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.71.3",


### PR DESCRIPTION
## Description
<!--

-->
I have added the "moment" dependency to the ExpoDemo project to resolve a module error.

## Changelog
<!--

-->
- **Added:** "moment" dependency to address module error.
## Additional info
If applicable, add additional info such as link to the bug being fixed by this PR etc
fixes:  #2871
Screenshot: 

 <img src="https://github.com/wix/react-native-ui-lib/assets/134603758/688955c2-4991-476f-b504-f099ed169fea"  height="500">


