### PR TITLE
fix: [WOAUILIB-3903] TextField multiline auto-expanding on web

### DIFF
--- a/src/components/textField/Input.tsx
+++ b/src/components/textField/Input.tsx
@@ -1,5 +1,6 @@
 import React, {useContext, useMemo} from 'react';
-import {TextInput as RNTextInput, StyleSheet, Platform} from 'react-native';
+import {StyleSheet, Platform} from 'react-native';
+import {TextInput as RNTextInput} from './textInput';
 import {Constants, ForwardRefInjectedProps} from '../../commons/new';
 import {InputProps} from './types';
 import {getColorByState} from './Presenter';

--- a/src/components/textField/textInput/index.tsx
+++ b/src/components/textField/textInput/index.tsx
@@ -1,0 +1,1 @@
+export {TextInput} from 'react-native';

--- a/src/components/textField/textInput/index.web.tsx
+++ b/src/components/textField/textInput/index.web.tsx
@@ -1,0 +1,43 @@
+import React, {type BaseSyntheticEvent, useCallback} from 'react';
+import {TextInput as RNTextInput, type TextInputChangeEventData, type TextInputProps, type LayoutChangeEvent} from 'react-native';
+
+// we need this wrapper to TextInput on web because of multiline bug in react-native-web
+// https://github.com/necolas/react-native-web/issues/795
+export const TextInput = (props: TextInputProps) => {
+  const {multiline, onChange, onLayout, ...other} = props;
+
+  const adjustInputHeight = useCallback((element: BaseSyntheticEvent<TextInputProps, TextInputProps>['target']) => {
+    element.style.height = 0;
+    const newHeight = element.offsetHeight - element.clientHeight + element.scrollHeight;
+    element.style.height = `${newHeight}px`;
+  }, []);
+
+  const _onLayout = useCallback((event: LayoutChangeEvent) => {
+    const element = event?.target;
+
+    if (element && multiline) {
+      adjustInputHeight(element);
+    }
+
+    onLayout?.(event);
+  }, [multiline, onLayout, adjustInputHeight]);
+
+  const _onChange = useCallback((event: BaseSyntheticEvent<TextInputChangeEventData>) => {
+    const element = event?.target || event?.nativeEvent?.target;
+    
+    if (element && multiline) {
+      adjustInputHeight(element);
+    }
+
+    onChange?.(event);
+  }, [multiline, onChange, adjustInputHeight]);
+
+  return (
+    <RNTextInput
+      {...other}
+      multiline={multiline}
+      onChange={_onChange}
+      onLayout={_onLayout}
+    />
+  );
+};

--- a/src/components/textField/textInput/index.web.tsx
+++ b/src/components/textField/textInput/index.web.tsx
@@ -1,16 +1,16 @@
 import React, {type BaseSyntheticEvent, useCallback} from 'react';
 import {TextInput as RNTextInput, type TextInputChangeEventData, type TextInputProps, type LayoutChangeEvent} from 'react-native';
 
-// we need this wrapper to TextInput on web because of multiline bug in react-native-web
+const adjustInputHeight = (element: BaseSyntheticEvent<TextInputProps, TextInputProps>['target']) => {
+  element.style.height = 0;
+  const newHeight = element.offsetHeight - element.clientHeight + element.scrollHeight;
+  element.style.height = `${newHeight}px`;
+};
+
+// we need this wrapper of TextInput on web because of multiline bug in react-native-web
 // https://github.com/necolas/react-native-web/issues/795
 export const TextInput = (props: TextInputProps) => {
   const {multiline, onChange, onLayout, ...other} = props;
-
-  const adjustInputHeight = useCallback((element: BaseSyntheticEvent<TextInputProps, TextInputProps>['target']) => {
-    element.style.height = 0;
-    const newHeight = element.offsetHeight - element.clientHeight + element.scrollHeight;
-    element.style.height = `${newHeight}px`;
-  }, []);
 
   const _onLayout = useCallback((event: LayoutChangeEvent) => {
     const element = event?.target;
@@ -20,7 +20,7 @@ export const TextInput = (props: TextInputProps) => {
     }
 
     onLayout?.(event);
-  }, [multiline, onLayout, adjustInputHeight]);
+  }, [multiline, onLayout]);
 
   const _onChange = useCallback((event: BaseSyntheticEvent<TextInputChangeEventData>) => {
     const element = event?.target || event?.nativeEvent?.target;
@@ -30,7 +30,7 @@ export const TextInput = (props: TextInputProps) => {
     }
 
     onChange?.(event);
-  }, [multiline, onChange, adjustInputHeight]);
+  }, [multiline, onChange]);
 
   return (
     <RNTextInput

--- a/webDemo/src/App.tsx
+++ b/webDemo/src/App.tsx
@@ -203,7 +203,7 @@ const itemsToRender: ItemToRender[] = [
     }
   },
   {
-    title: 'TextField1',
+    title: 'TextField',
     FC: () => {
       const [defaultValue, setDefaultValue] = useState('I am Default value');
       const updateDefaultValue = () => {

--- a/webDemo/src/App.tsx
+++ b/webDemo/src/App.tsx
@@ -203,7 +203,7 @@ const itemsToRender: ItemToRender[] = [
     }
   },
   {
-    title: 'TextField',
+    title: 'TextField1',
     FC: () => {
       const [defaultValue, setDefaultValue] = useState('I am Default value');
       const updateDefaultValue = () => {
@@ -216,6 +216,7 @@ const itemsToRender: ItemToRender[] = [
           <Incubator.TextField
             text70
             migrate
+            multiline
             defaultValue={defaultValue}
             containerStyle={{marginBottom: 10}}
             placeholder="Enter your email..."


### PR DESCRIPTION
## Description
<!--
Enter description to help the reviewer understand what's the change about...
-->
There is a bug on react-native-web that multiline TextInput doesn't auto-expand
https://github.com/necolas/react-native-web/issues/795

## Changelog
<!--
Add a quick message for our users about this change (include Component name, relevant props and general purpose of the PR)
-->
Fix TextField multiline auto-expanding on web

## Additional info
<!--
If applicable, add additional info such as link to the bug being fixed by this PR etc
-->
WOAUILIB-3903