### PR TITLE
fix: add null check for ReactScreenMonitor.java

### DIFF
--- a/lib/android/src/main/java/com/wix/reactnativeuilib/keyboardinput/ReactScreenMonitor.java
+++ b/lib/android/src/main/java/com/wix/reactnativeuilib/keyboardinput/ReactScreenMonitor.java
@@ -62,7 +62,9 @@ public class ReactScreenMonitor implements LifecycleEventListener {
     }
 
     private void registerWindowLayoutListener() {
-        getWindow().getDecorView().getViewTreeObserver().addOnGlobalLayoutListener(mWindowLayoutListener);
+        if (getWindow() != null) {
+            getWindow().getDecorView().getViewTreeObserver().addOnGlobalLayoutListener(mWindowLayoutListener);
+        }
     }
 
     private void removeWindowLayoutListener() {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "react-native-ui-lib",
+  "name": "@ddx0510/react-native-ui-lib",
   "version": "7.0.0",
   "main": "src/index.ts",
   "types": "src/index.d.ts",
-  "author": "Ethan Sharabi <ethan.shar@gmail.com>",
+  "author": "Ethan Sharabi <ethan.shar@gmail.com>, ddx <ddx0510@gmail.com>",
   "homepage": "https://github.com/wix/react-native-ui-lib",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
## Description
<!--
Enter description to help the reviewer understand what's the change about...
-->
Add an extra null check before adding the listener

## Changelog
<!--
Add a quick message for our users about this change (include Component name, relevant props and general purpose of the PR)
-->

Check getWindow() is not null before getDecorView()

## Additional info
<!--
If applicable, add additional info such as link to the bug being fixed by this PR etc
-->

#2875 Plz help check if this is the cause