### PR TITLE
Revert "TextFiled - fix incompatible ref type TextFieldProps not assi…

### DIFF
--- a/src/components/textField/types.ts
+++ b/src/components/textField/types.ts
@@ -142,6 +142,7 @@ export interface CharCounterProps {
 
 export interface InputProps
   extends Omit<TextInputProps, 'placeholderTextColor'>,
+    Omit<React.ComponentPropsWithRef<typeof TextInput>, 'placeholderTextColor'>,
     MandatoryIndication,
     RecorderProps {
   /**


### PR DESCRIPTION
…gned to TextInput (#2868)"

This reverts commit 017a7cdb456fb7d78a805ef02b5a3f5dfaba77a4.

## Description
Revert #2868 - should fix some new TS errors in Picker

## Changelog
Revert #2868 - should fix some new TS errors in Picker

## Additional info
None