### PR TITLE
Revert "Revert "TextFiled - fix incompatible ref type TextFieldProps …

### DIFF
--- a/src/components/textField/types.ts
+++ b/src/components/textField/types.ts
@@ -142,7 +142,6 @@ export interface CharCounterProps {
 
 export interface InputProps
   extends Omit<TextInputProps, 'placeholderTextColor'>,
-    Omit<React.ComponentPropsWithRef<typeof TextInput>, 'placeholderTextColor'>,
     MandatoryIndication,
     RecorderProps {
   /**


### PR DESCRIPTION
…not assigned to TextInput (#2868)" (#2883)"

This reverts commit 4ab11908e76764597710c2d288efcbce7a255855.

## Description
Another revert

## Changelog
None

## Additional info
None