### PR TITLE
Ref Typings

### DIFF
--- a/demo/src/screens/componentScreens/SliderScreen.tsx
+++ b/demo/src/screens/componentScreens/SliderScreen.tsx
@@ -264,7 +264,6 @@ export default class SliderScreen extends Component<SliderScreenProps, SliderScr
             color={color}
             containerStyle={styles.gradientSliderContainer}
             onValueChange={this.onGradientValueChange}
-            // @ts-expect-error
             ref={this.gradientSlider}
           />
           <View style={styles.box}>

--- a/demo/src/screens/componentScreens/TextFieldScreen.tsx
+++ b/demo/src/screens/componentScreens/TextFieldScreen.tsx
@@ -59,9 +59,7 @@ export default class TextFieldScreen extends Component {
           <Text h3 marginV-s4>
             Default
           </Text>
-          {/* @ts-expect-error */}
           <TextField ref={this.input} label="Name" placeholder="Enter full name"/>
-
           <Text h3 marginV-s4>
             Static vs Floating Placeholder
           </Text>
@@ -89,7 +87,6 @@ export default class TextFieldScreen extends Component {
           </Text>
 
           <TextField
-            // @ts-expect-error
             ref={this.input2}
             placeholder="Enter search term"
             text70
@@ -99,7 +96,6 @@ export default class TextFieldScreen extends Component {
           />
 
           <TextField
-            // @ts-expect-error
             ref={this.input2}
             placeholder="Enter URL"
             floatingPlaceholder
@@ -114,7 +110,6 @@ export default class TextFieldScreen extends Component {
           />
 
           <TextField
-            // @ts-expect-error
             ref={this.input2}
             placeholder="Enter weight"
             text70
@@ -166,7 +161,6 @@ export default class TextFieldScreen extends Component {
 
           <View row top marginT-s4>
             <TextField
-              // @ts-expect-error
               ref={this.inputWithValidation}
               placeholder="Enter full name"
               validate="required"

--- a/demo/src/screens/componentScreens/TextScreen.tsx
+++ b/demo/src/screens/componentScreens/TextScreen.tsx
@@ -124,7 +124,6 @@ class TextScreen extends Component {
             <Text
               text70
               animated
-              // @ts-expect-error
               style={{transform: [{scale: this.animatedValue.interpolate({inputRange: [0, 1], outputRange: [1, 2]})}]}}
               onPress={this.animate}
             >

--- a/demo/src/screens/incubatorScreens/IncubatorSliderScreen.tsx
+++ b/demo/src/screens/incubatorScreens/IncubatorSliderScreen.tsx
@@ -23,10 +23,10 @@ const IncubatorSliderScreen = () => {
   const [color, setColor] = useState(COLOR);
   const [alpha, setAlpha] = useState(1);
 
-  const slider = useRef<typeof Incubator.Slider>();
-  const customSlider = useRef<typeof Incubator.Slider>();
-  const negativeSlider = useRef<typeof Incubator.Slider>();
-  const rangeSlider = useRef<typeof Incubator.Slider>();
+  const slider = useRef<Incubator.SliderRef>(null);
+  const customSlider = useRef<Incubator.SliderRef>(null);
+  const negativeSlider = useRef<Incubator.SliderRef>(null);
+  const rangeSlider = useRef<Incubator.SliderRef>(null);
 
   const resetSliders = useCallback(() => {
     slider.current?.reset();
@@ -92,7 +92,6 @@ const IncubatorSliderScreen = () => {
         </Text>
         {renderValuesBox(sliderValue)}
         <Incubator.Slider
-          // @ts-expect-error TODO: need to properly support SliderMethods type to use for ref
           ref={slider}
           onValueChange={onValueChange}
           containerStyle={styles.container}
@@ -124,7 +123,6 @@ const IncubatorSliderScreen = () => {
         </Text>
         {renderValuesBox(customSliderValue)}
         <Incubator.Slider
-          // @ts-expect-error
           ref={customSlider}
           onValueChange={onCustomValueChange}
           value={20}
@@ -152,7 +150,6 @@ const IncubatorSliderScreen = () => {
         </Text>
         {renderValuesBox(negativeSliderValue)}
         <Incubator.Slider
-          // @ts-expect-error
           ref={negativeSlider}
           onValueChange={onNegativeValueChange}
           value={-30}
@@ -175,7 +172,6 @@ const IncubatorSliderScreen = () => {
         <View marginH-20>
           {renderValuesBox(sliderMinValue, sliderMaxValue)}
           <Incubator.Slider
-            // @ts-expect-error
             ref={rangeSlider}
             useRange
             onRangeChange={onRangeChange}

--- a/src/commons/asBaseComponent.tsx
+++ b/src/commons/asBaseComponent.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import hoistStatics from 'hoist-non-react-statics';
 import * as Modifiers from './modifiers';
 import {Scheme, SchemeChangeListener, ThemeManager} from '../style';
-import forwardRef from './forwardRef';
+import forwardRef, {ForwardRefInjectedProps} from './forwardRef';
 import UIComponent from './UIComponent';
 
 export interface BaseComponentInjectedProps {
@@ -21,9 +21,9 @@ export interface AsBaseComponentOptions {
 const EMPTY_MODIFIERS = {};
 const colorScheme = Scheme.getSchemeType();
 
-function asBaseComponent<PROPS, STATICS = {}>(WrappedComponent: React.ComponentType<any>,
-  options: AsBaseComponentOptions = {}): React.ComponentClass<PROPS> & STATICS {
-  class BaseComponent extends UIComponent {
+function asBaseComponent<PROPS, STATICS extends {[key: string]: true} = {}, RefInterface = any>(WrappedComponent: React.ComponentType<any>,
+  options: AsBaseComponentOptions = {}) {
+  class BaseComponent extends UIComponent<PROPS & ForwardRefInjectedProps<RefInterface>> {
     static displayName: string | undefined;
     static propTypes: any;
     static defaultProps: any;
@@ -85,8 +85,7 @@ function asBaseComponent<PROPS, STATICS = {}>(WrappedComponent: React.ComponentT
   if (ThemeContext) {
     BaseComponent.contextType = ThemeContext;
   }
-
-  return forwardRef(BaseComponent) as any;
+  return forwardRef<PROPS, STATICS, RefInterface>(BaseComponent);
 }
 
 export default asBaseComponent;

--- a/src/commons/asBaseComponent.tsx
+++ b/src/commons/asBaseComponent.tsx
@@ -21,7 +21,7 @@ export interface AsBaseComponentOptions {
 const EMPTY_MODIFIERS = {};
 const colorScheme = Scheme.getSchemeType();
 
-function asBaseComponent<PROPS, STATICS extends object = {}, RefInterface = any>(WrappedComponent: React.ComponentType<any>,
+function asBaseComponent<PROPS, STATICS = {}, RefInterface = any>(WrappedComponent: React.ComponentType<any>,
   options: AsBaseComponentOptions = {}) {
   class BaseComponent extends UIComponent<PROPS & ForwardRefInjectedProps<RefInterface>> {
     static displayName: string | undefined;

--- a/src/commons/asBaseComponent.tsx
+++ b/src/commons/asBaseComponent.tsx
@@ -21,7 +21,7 @@ export interface AsBaseComponentOptions {
 const EMPTY_MODIFIERS = {};
 const colorScheme = Scheme.getSchemeType();
 
-function asBaseComponent<PROPS, STATICS extends {[key: string]: true} = {}, RefInterface = any>(WrappedComponent: React.ComponentType<any>,
+function asBaseComponent<PROPS, STATICS extends object = {}, RefInterface = any>(WrappedComponent: React.ComponentType<any>,
   options: AsBaseComponentOptions = {}) {
   class BaseComponent extends UIComponent<PROPS & ForwardRefInjectedProps<RefInterface>> {
     static displayName: string | undefined;

--- a/src/commons/forwardRef.tsx
+++ b/src/commons/forwardRef.tsx
@@ -8,22 +8,20 @@ export interface ForwardRefInjectedProps<T> {
   forwardedRef: Ref<T>;
 }
 
-type DerivedStatics<T> = {[K in keyof T]: true};
-
-export default function forwardRef<P, STATICS extends object, RefInterface = any>(WrappedComponent: ComponentType<P & ForwardRefInjectedProps<RefInterface>>) {
+export default function forwardRef<P, STATICS = {}, RefInterface = any>(WrappedComponent: ComponentType<P & ForwardRefInjectedProps<RefInterface>>) {
   function forwardRef(props: P, ref: Ref<RefInterface>) {
     return <WrappedComponent {...props} forwardedRef={ref}/>;
   }
 
   const ForwardedComponent = React.forwardRef<RefInterface, P>(forwardRef);
 
-  const FinalComponent = hoistStatics<typeof ForwardedComponent, typeof WrappedComponent, DerivedStatics<STATICS>>(ForwardedComponent,
-    WrappedComponent);
-  FinalComponent.displayName = WrappedComponent.displayName;
+  hoistStatics(ForwardedComponent, WrappedComponent);
   //@ts-ignore
-  FinalComponent.propTypes = WrappedComponent.propTypes;
+  ForwardedComponent.displayName = WrappedComponent.displayName;
   //@ts-ignore
-  FinalComponent.defaultProps = WrappedComponent.defaultProps;
+  ForwardedComponent.propTypes = WrappedComponent.propTypes;
+  //@ts-ignore
+  ForwardedComponent.defaultProps = WrappedComponent.defaultProps;
 
-  return FinalComponent;
+  return ForwardedComponent as typeof ForwardedComponent & STATICS;
 }

--- a/src/commons/forwardRef.tsx
+++ b/src/commons/forwardRef.tsx
@@ -1,4 +1,4 @@
-import React, {Ref} from 'react';
+import React, {Ref, ComponentType} from 'react';
 import hoistStatics from 'hoist-non-react-statics';
 
 export interface ForwardRefInjectedProps<T> {
@@ -8,14 +8,16 @@ export interface ForwardRefInjectedProps<T> {
   forwardedRef: Ref<T>;
 }
 
-export default function forwardRef<P = {}, STATICS extends {[key: string]: true} = {}, RefInterface = any>(WrappedComponent: React.ComponentType<P & ForwardRefInjectedProps<RefInterface>>) {
+type DerivedStatics<T> = {[K in keyof T]: true};
+
+export default function forwardRef<P, STATICS extends object, RefInterface = any>(WrappedComponent: ComponentType<P & ForwardRefInjectedProps<RefInterface>>) {
   function forwardRef(props: P, ref: Ref<RefInterface>) {
     return <WrappedComponent {...props} forwardedRef={ref}/>;
   }
 
   const ForwardedComponent = React.forwardRef<RefInterface, P>(forwardRef);
 
-  const FinalComponent = hoistStatics<typeof ForwardedComponent, typeof WrappedComponent, STATICS>(ForwardedComponent,
+  const FinalComponent = hoistStatics<typeof ForwardedComponent, typeof WrappedComponent, DerivedStatics<STATICS>>(ForwardedComponent,
     WrappedComponent);
   FinalComponent.displayName = WrappedComponent.displayName;
   //@ts-ignore

--- a/src/commons/forwardRef.tsx
+++ b/src/commons/forwardRef.tsx
@@ -1,5 +1,4 @@
-import React, {useRef, Ref, ForwardedRef, useImperativeHandle, useEffect} from 'react';
-import {TextInput, View, Text} from 'react-native';
+import React, {Ref} from 'react';
 import hoistStatics from 'hoist-non-react-statics';
 
 export interface ForwardRefInjectedProps<T> {
@@ -26,32 +25,3 @@ export default function forwardRef<P = {}, STATICS extends {[key: string]: true}
 
   return FinalComponent;
 }
-
-type TestProps = {
-  labelColor: string;
-};
-
-type TestRef = {
-  hello: () => void;
-  focus: () => void;
-};
-
-const Test = (props: TestProps & ForwardRefInjectedProps<TestRef>) => {
-  const {labelColor, forwardedRef} = props;
-  useImperativeHandle(forwardedRef, () => ({hello: () => console.log('hello'), focus: () => console.log('focus')}), []);
-  return (
-    <View>
-      <Text style={{color: labelColor}}>Test passing ref</Text>
-      <TextInput/>
-    </View>
-  );
-};
-const T = forwardRef<TestProps, {}, TestRef>(Test);
-
-const App = () => {
-  const inputRef = useRef<TestRef>(null);
-  useEffect(() => {
-    inputRef.current?.hello();
-  }, []);
-  return <T labelColor="red" ref={inputRef}/>;
-};

--- a/src/commons/forwardRef.tsx
+++ b/src/commons/forwardRef.tsx
@@ -1,26 +1,57 @@
-import React from 'react';
+import React, {useRef, Ref, ForwardedRef, useImperativeHandle, useEffect} from 'react';
+import {TextInput, View, Text} from 'react-native';
 import hoistStatics from 'hoist-non-react-statics';
 
-export interface ForwardRefInjectedProps {
+export interface ForwardRefInjectedProps<T> {
   /**
    * The forwarded ref of the containing element
    */
-  forwardedRef: any;
+  forwardedRef: Ref<T>;
 }
 
-export default function forwardRef<P = any, STATICS = {}>(WrappedComponent: React.ComponentType<P>): React.ComponentType<P> & STATICS {
-  function forwardRef(props: P, ref: any) {
+export default function forwardRef<P = {}, STATICS extends {[key: string]: true} = {}, T = any>(WrappedComponent: React.ComponentType<P & ForwardRefInjectedProps<T>>) {
+  function forwardRef(props: P, ref: Ref<T>) {
     return <WrappedComponent {...props} forwardedRef={ref}/>;
   }
 
-  const ForwardedComponent = React.forwardRef(forwardRef);
+  const ForwardedComponent = React.forwardRef<T, P>(forwardRef);
 
-  hoistStatics(ForwardedComponent, WrappedComponent);
-  ForwardedComponent.displayName = WrappedComponent.displayName;
+  const FinalComponent = hoistStatics<typeof ForwardedComponent, typeof WrappedComponent, STATICS>(ForwardedComponent,
+    WrappedComponent);
+  FinalComponent.displayName = WrappedComponent.displayName;
   //@ts-ignore
-  ForwardedComponent.propTypes = WrappedComponent.propTypes;
+  FinalComponent.propTypes = WrappedComponent.propTypes;
   //@ts-ignore
-  ForwardedComponent.defaultProps = WrappedComponent.defaultProps;
+  FinalComponent.defaultProps = WrappedComponent.defaultProps;
 
-  return ForwardedComponent as any;
+  return FinalComponent;
 }
+
+type TestProps = {
+  labelColor: string;
+};
+
+type TestRef = {
+  hello: () => void;
+  focus: () => void;
+};
+
+const Test = (props: TestProps & ForwardRefInjectedProps<TestRef>) => {
+  const {labelColor, forwardedRef} = props;
+  useImperativeHandle(forwardedRef, () => ({hello: () => console.log('hello'), focus: () => console.log('focus')}), []);
+  return (
+    <View>
+      <Text style={{color: labelColor}}>Test passing ref</Text>
+      <TextInput/>
+    </View>
+  );
+};
+const T = forwardRef<TestProps, {}, TestRef>(Test);
+
+const App = () => {
+  const inputRef = useRef<TestRef>(null);
+  useEffect(() => {
+    inputRef.current?.hello();
+  }, []);
+  return <T labelColor="red" ref={inputRef}/>;
+};

--- a/src/commons/forwardRef.tsx
+++ b/src/commons/forwardRef.tsx
@@ -1,15 +1,15 @@
-import React, {Ref, ComponentType} from 'react';
+import React, {ComponentType, ForwardedRef} from 'react';
 import hoistStatics from 'hoist-non-react-statics';
 
-export interface ForwardRefInjectedProps<T> {
+export interface ForwardRefInjectedProps<T = any> {
   /**
    * The forwarded ref of the containing element
    */
-  forwardedRef: Ref<T>;
+  forwardedRef: ForwardedRef<T>;
 }
 
 export default function forwardRef<P, STATICS = {}, RefInterface = any>(WrappedComponent: ComponentType<P & ForwardRefInjectedProps<RefInterface>>) {
-  function forwardRef(props: P, ref: Ref<RefInterface>) {
+  function forwardRef(props: P, ref: ForwardedRef<RefInterface>) {
     return <WrappedComponent {...props} forwardedRef={ref}/>;
   }
 

--- a/src/commons/forwardRef.tsx
+++ b/src/commons/forwardRef.tsx
@@ -8,12 +8,12 @@ export interface ForwardRefInjectedProps<T> {
   forwardedRef: Ref<T>;
 }
 
-export default function forwardRef<P = {}, STATICS extends {[key: string]: true} = {}, T = any>(WrappedComponent: React.ComponentType<P & ForwardRefInjectedProps<T>>) {
-  function forwardRef(props: P, ref: Ref<T>) {
+export default function forwardRef<P = {}, STATICS extends {[key: string]: true} = {}, RefInterface = any>(WrappedComponent: React.ComponentType<P & ForwardRefInjectedProps<RefInterface>>) {
+  function forwardRef(props: P, ref: Ref<RefInterface>) {
     return <WrappedComponent {...props} forwardedRef={ref}/>;
   }
 
-  const ForwardedComponent = React.forwardRef<T, P>(forwardRef);
+  const ForwardedComponent = React.forwardRef<RefInterface, P>(forwardRef);
 
   const FinalComponent = hoistStatics<typeof ForwardedComponent, typeof WrappedComponent, STATICS>(ForwardedComponent,
     WrappedComponent);

--- a/src/components/button/ButtonTypes.tsx
+++ b/src/components/button/ButtonTypes.tsx
@@ -27,7 +27,6 @@ export enum ButtonAnimationDirection {
   right = 'right'
 }
 
-
 export type ButtonAnimationDirectionProp = ButtonAnimationDirection | `${ButtonAnimationDirection}`;
 
 export type ButtonProps = TouchableOpacityProps &

--- a/src/components/button/ButtonTypes.tsx
+++ b/src/components/button/ButtonTypes.tsx
@@ -27,6 +27,12 @@ export enum ButtonAnimationDirection {
   right = 'right'
 }
 
+export type ButtonStatics = {
+  sizes: typeof ButtonSize;
+
+  animationDirection: typeof ButtonAnimationDirection;
+}
+
 export type ButtonAnimationDirectionProp = ButtonAnimationDirection | `${ButtonAnimationDirection}`;
 
 export type ButtonProps = TouchableOpacityProps &

--- a/src/components/button/ButtonTypes.tsx
+++ b/src/components/button/ButtonTypes.tsx
@@ -27,11 +27,6 @@ export enum ButtonAnimationDirection {
   right = 'right'
 }
 
-export type ButtonStatics = {
-  sizes: typeof ButtonSize;
-
-  animationDirection: typeof ButtonAnimationDirection;
-}
 
 export type ButtonAnimationDirectionProp = ButtonAnimationDirection | `${ButtonAnimationDirection}`;
 

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -21,6 +21,11 @@ import {PADDINGS, HORIZONTAL_PADDINGS, MIN_WIDTH, DEFAULT_SIZE} from './ButtonCo
 
 export {ButtonSize, ButtonAnimationDirection, ButtonProps};
 
+type ButtonStatics = {
+  sizes: typeof ButtonSize;
+
+  animationDirection: typeof ButtonAnimationDirection;
+}
 
 class Button extends PureComponent<Props, ButtonState> {
   static displayName = 'Button';
@@ -430,4 +435,4 @@ const modifiersOptions = {
   color: true
 };
 
-export default asBaseComponent<ButtonProps, typeof Button>(forwardRef<Props>(Button), {modifiersOptions});
+export default asBaseComponent<ButtonProps, ButtonStatics, {}>(forwardRef(Button), {modifiersOptions});

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -4,7 +4,7 @@ import {Platform, StyleSheet, LayoutAnimation, LayoutChangeEvent, ImageStyle, Te
 import {asBaseComponent, forwardRef, Constants} from '../../commons/new';
 import {Colors, Typography, BorderRadiuses} from 'style';
 import TouchableOpacity from '../touchableOpacity';
-import type {Dictionary} from '../../typings/common';
+import type {Dictionary, ComponentStatics} from '../../typings/common';
 import Text from '../text';
 import Image from '../image';
 import Icon from '../icon';
@@ -15,8 +15,7 @@ import {
   ButtonState,
   Props,
   DEFAULT_PROPS,
-  ButtonSizeProp,
-  ButtonStatics
+  ButtonSizeProp
 } from './ButtonTypes';
 import {PADDINGS, HORIZONTAL_PADDINGS, MIN_WIDTH, DEFAULT_SIZE} from './ButtonConstants';
 
@@ -429,5 +428,6 @@ const modifiersOptions = {
   typography: true,
   color: true
 };
-
-export default asBaseComponent<ButtonProps, ButtonStatics, {}>(forwardRef(Button), {modifiersOptions});
+export default asBaseComponent<ButtonProps, ComponentStatics<typeof Button>, {}>(forwardRef(Button), {
+  modifiersOptions
+});

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -15,17 +15,12 @@ import {
   ButtonState,
   Props,
   DEFAULT_PROPS,
-  ButtonSizeProp
+  ButtonSizeProp,
+  ButtonStatics
 } from './ButtonTypes';
 import {PADDINGS, HORIZONTAL_PADDINGS, MIN_WIDTH, DEFAULT_SIZE} from './ButtonConstants';
 
 export {ButtonSize, ButtonAnimationDirection, ButtonProps};
-
-type ButtonStatics = {
-  sizes: typeof ButtonSize;
-
-  animationDirection: typeof ButtonAnimationDirection;
-}
 
 class Button extends PureComponent<Props, ButtonState> {
   static displayName = 'Button';

--- a/src/components/fadedScrollView/index.tsx
+++ b/src/components/fadedScrollView/index.tsx
@@ -6,12 +6,12 @@ import {
   NativeScrollEvent,
   LayoutChangeEvent
 } from 'react-native';
+import {ScrollView as GestureScrollView} from 'react-native-gesture-handler';
 import Fader, {FaderProps} from '../fader';
 import useScrollEnabler from '../../hooks/useScrollEnabler';
 import useScrollReached from '../../hooks/useScrollReached';
 import {forwardRef, ForwardRefInjectedProps} from '../../commons/new';
-import {ScrollView as GestureScrollView} from 'react-native-gesture-handler';
-import {ComponentStatics} from 'src/typings/common';
+import {ComponentStatics} from '../../typings/common';
 
 export type FadedScrollViewProps = ScrollViewProps & {
   /**

--- a/src/components/fadedScrollView/index.tsx
+++ b/src/components/fadedScrollView/index.tsx
@@ -11,7 +11,7 @@ import useScrollEnabler from '../../hooks/useScrollEnabler';
 import useScrollReached from '../../hooks/useScrollReached';
 import {forwardRef, ForwardRefInjectedProps} from '../../commons/new';
 import {ScrollView as GestureScrollView} from 'react-native-gesture-handler';
-import { ComponentStatics } from 'src/typings/common';
+import {ComponentStatics} from 'src/typings/common';
 
 export type FadedScrollViewProps = ScrollViewProps & {
   /**

--- a/src/components/fadedScrollView/index.tsx
+++ b/src/components/fadedScrollView/index.tsx
@@ -11,6 +11,7 @@ import useScrollEnabler from '../../hooks/useScrollEnabler';
 import useScrollReached from '../../hooks/useScrollReached';
 import {forwardRef, ForwardRefInjectedProps} from '../../commons/new';
 import {ScrollView as GestureScrollView} from 'react-native-gesture-handler';
+import { ComponentStatics } from 'src/typings/common';
 
 export type FadedScrollViewProps = ScrollViewProps & {
   /**
@@ -37,7 +38,7 @@ export type FadedScrollViewProps = ScrollViewProps & {
 };
 
 type Props = FadedScrollViewProps & ForwardRefInjectedProps;
-interface Statics {
+export interface FadedScrollViewRef {
   scrollTo(
     y?: number | {x?: number | undefined; y?: number | undefined; animated?: boolean | undefined},
     x?: number,
@@ -139,5 +140,4 @@ const FadedScrollView = (props: Props) => {
 };
 
 FadedScrollView.displayName = 'IGNORE';
-// @ts-expect-error
-export default forwardRef<FadedScrollViewProps, Statics>(FadedScrollView);
+export default forwardRef<FadedScrollViewProps, ComponentStatics<FadedScrollViewProps>, FadedScrollViewRef>(FadedScrollView);

--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -2,7 +2,7 @@ import isUndefined from 'lodash/isUndefined';
 import React, {useMemo, forwardRef} from 'react';
 import {Image, ImageProps, StyleSheet} from 'react-native';
 import {asBaseComponent, BaseComponentInjectedProps, MarginModifiers, Constants} from '../../commons/new';
-import { ComponentStatics } from '../../typings/common';
+import {ComponentStatics} from '../../typings/common';
 import {getAsset, isSvg, isBase64ImageContent} from '../../utils/imageUtils';
 import {RecorderProps} from '../../typings/recorderTypes';
 import SvgImage from '../svgImage';

--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -2,6 +2,7 @@ import isUndefined from 'lodash/isUndefined';
 import React, {useMemo, forwardRef} from 'react';
 import {Image, ImageProps, StyleSheet} from 'react-native';
 import {asBaseComponent, BaseComponentInjectedProps, MarginModifiers, Constants} from '../../commons/new';
+import { ComponentStatics } from '../../typings/common';
 import {getAsset, isSvg, isBase64ImageContent} from '../../utils/imageUtils';
 import {RecorderProps} from '../../typings/recorderTypes';
 import SvgImage from '../svgImage';
@@ -89,7 +90,8 @@ Icon.displayName = 'Icon';
 Icon.defaultProps = {
   assetGroup: 'icons'
 };
-export default asBaseComponent<IconProps, typeof Icon>(Icon, {modifiersOptions: {margins: true}});
+
+export default asBaseComponent<IconProps, ComponentStatics<typeof Icon>>(Icon, {modifiersOptions: {margins: true}});
 
 const styles = StyleSheet.create({
   rtlFlipped: {

--- a/src/components/pageControl/index.tsx
+++ b/src/components/pageControl/index.tsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React, {PureComponent} from 'react';
 import {StyleSheet, LayoutAnimation, StyleProp, ViewStyle} from 'react-native';
-import {asBaseComponent, forwardRef} from '../../commons/new';
+import {asBaseComponent} from '../../commons/new';
 import {Colors} from '../../style';
 import TouchableOpacity, {TouchableOpacityProps} from '../touchableOpacity';
 import View from '../view';
@@ -239,7 +239,8 @@ class PageControl extends PureComponent<PageControlProps, State> {
   }
 }
 
-export default asBaseComponent<PageControlProps>(forwardRef(PageControl));
+// @ts-expect-error
+export default asBaseComponent<PageControlProps>(PageControl);
 
 const styles = StyleSheet.create({
   container: {

--- a/src/components/scrollBar/index.tsx
+++ b/src/components/scrollBar/index.tsx
@@ -277,4 +277,4 @@ const Item = ({children, index, onLayout}: any) => {
 
 Item.displayName = 'IGNORE';
 ScrollBar.Item = Item;
-export default asBaseComponent<ScrollBarProps, ComponentStatics<typeof ScrollBar>, {}>(forwardRef(ScrollBar));
+export default asBaseComponent<ScrollBarProps, ComponentStatics<typeof ScrollBar>>(forwardRef(ScrollBar));

--- a/src/components/scrollBar/index.tsx
+++ b/src/components/scrollBar/index.tsx
@@ -11,6 +11,7 @@ import {
 import {ScrollView, FlatList} from 'react-native-gesture-handler';
 import {Colors} from '../../style';
 import {Constants, asBaseComponent, forwardRef, ForwardRefInjectedProps} from '../../commons/new';
+import { ComponentStatics } from '../../typings/common';
 import View from '../view';
 import Image from '../image';
 
@@ -276,4 +277,4 @@ const Item = ({children, index, onLayout}: any) => {
 
 Item.displayName = 'IGNORE';
 ScrollBar.Item = Item;
-export default asBaseComponent<ScrollBarProps, typeof ScrollBar>(forwardRef(ScrollBar));
+export default asBaseComponent<ScrollBarProps, ComponentStatics<typeof ScrollBar>, {}>(forwardRef(ScrollBar));

--- a/src/components/scrollBar/index.tsx
+++ b/src/components/scrollBar/index.tsx
@@ -11,7 +11,7 @@ import {
 import {ScrollView, FlatList} from 'react-native-gesture-handler';
 import {Colors} from '../../style';
 import {Constants, asBaseComponent, forwardRef, ForwardRefInjectedProps} from '../../commons/new';
-import { ComponentStatics } from '../../typings/common';
+import {ComponentStatics} from '../../typings/common';
 import View from '../view';
 import Image from '../image';
 

--- a/src/components/slider/GradientSlider.tsx
+++ b/src/components/slider/GradientSlider.tsx
@@ -4,6 +4,7 @@ import React, {useCallback, useEffect, useState} from 'react';
 import {StyleProp, ViewStyle} from 'react-native';
 import {Colors} from '../../style';
 import {asBaseComponent, forwardRef, ForwardRefInjectedProps} from '../../commons/new';
+import {ComponentStatics} from '../../typings/common';
 import Slider, {SliderProps} from './index';
 import {Slider as NewSlider} from '../../incubator';
 import {SliderContextProps} from './context/SliderContext';
@@ -192,7 +193,6 @@ const GradientSlider = (props: Props) => {
   return (
     <SliderComponent
       {...others}
-      //@ts-expect-error
       ref={forwardedRef}
       onReset={reset}
       renderTrack={renderTrack}
@@ -213,4 +213,5 @@ GradientSlider.displayName = 'GradientSlider';
 GradientSlider.types = GradientSliderTypes;
 
 // eslint-disable-next-line max-len
-export default asBaseComponent<GradientSliderProps, typeof GradientSlider>(forwardRef(asSliderGroupChild(forwardRef(GradientSlider))));
+// @ts-expect-error
+export default asBaseComponent<GradientSliderProps, ComponentStatics<typeof GradientSlider>, {}>(forwardRef(asSliderGroupChild(forwardRef(GradientSlider))));

--- a/src/components/slider/GradientSlider.tsx
+++ b/src/components/slider/GradientSlider.tsx
@@ -214,4 +214,4 @@ GradientSlider.types = GradientSliderTypes;
 
 // eslint-disable-next-line max-len
 // @ts-expect-error
-export default asBaseComponent<GradientSliderProps, ComponentStatics<typeof GradientSlider>, {}>(forwardRef(asSliderGroupChild(forwardRef(GradientSlider))));
+export default asBaseComponent<GradientSliderProps, ComponentStatics<typeof GradientSlider>>(forwardRef(asSliderGroupChild(forwardRef(GradientSlider))));

--- a/src/components/tabController/TabBar.tsx
+++ b/src/components/tabController/TabBar.tsx
@@ -13,7 +13,7 @@ import {
 } from '../../commons/new';
 import View from '../view';
 import {Colors, Spacings, Typography} from '../../style';
-import FadedScrollView from '../fadedScrollView';
+import FadedScrollView, {FadedScrollViewRef} from '../fadedScrollView';
 import {FaderProps} from '../fader';
 import useScrollToItem from './useScrollToItem';
 import {useDidUpdate} from 'hooks';
@@ -161,7 +161,7 @@ const TabBar = (props: Props) => {
     testID
   } = props;
 
-  const tabBar = useRef<typeof FadedScrollView>();
+  const tabBar = useRef<FadedScrollViewRef>(null);
   const [key, setKey] = useState<string>(generateKey(Constants.orientation, labelColor, selectedLabelColor));
   const context = useContext(TabBarContext);
   const {items: contextItems, currentPage, targetPage, containerWidth: contextContainerWidth} = context;
@@ -295,7 +295,6 @@ const TabBar = (props: Props) => {
   return (
     <View style={_containerStyle} key={key} bg-$backgroundElevated>
       <FadedScrollView
-        // @ts-expect-error
         ref={tabBar}
         horizontal
         showsHorizontalScrollIndicator={false}

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -47,7 +47,7 @@ export interface HighlightStringProps {
 
 export type HighlightString = string | HighlightStringProps;
 
-export type TextProps = RNTextProps &
+export type TextProps = Omit<RNTextProps, 'style'> &
   TypographyModifiers &
   ColorsModifiers &
   MarginModifiers &

--- a/src/components/textField/index.tsx
+++ b/src/components/textField/index.tsx
@@ -235,7 +235,7 @@ export {
   ValidationMessagePositionType as TextFieldValidationMessagePositionType,
   MandatoryIndication as TextFieldMandatoryIndication
 };
-export default asBaseComponent<TextFieldProps, StaticMembers>(forwardRef(TextField as any), {
+export default asBaseComponent<TextFieldProps, StaticMembers, TextFieldRef>(forwardRef(TextField as any), {
   modifiersOptions: {
     margins: true,
     paddings: true,

--- a/src/incubator/Slider/index.tsx
+++ b/src/incubator/Slider/index.tsx
@@ -15,7 +15,7 @@ import {
 } from './SliderPresenter';
 import Thumb from './Thumb';
 import Track from './Track';
-import {ComponentStatics} from 'src/typings/common';
+import {ComponentStatics} from '../../typings/common';
 export interface SliderProps extends AccessibilityProps {
   /**
    * Initial value

--- a/src/incubator/Slider/index.tsx
+++ b/src/incubator/Slider/index.tsx
@@ -15,7 +15,7 @@ import {
 } from './SliderPresenter';
 import Thumb from './Thumb';
 import Track from './Track';
-
+import {ComponentStatics} from 'src/typings/common';
 export interface SliderProps extends AccessibilityProps {
   /**
    * Initial value
@@ -131,8 +131,8 @@ export interface SliderProps extends AccessibilityProps {
   migrate?: boolean;
 }
 
-type Props = SliderProps & ForwardRefInjectedProps;
-interface Statics {
+type Props = SliderProps & ForwardRefInjectedProps<SliderRef>;
+export interface SliderRef {
   reset: () => void;
 }
 
@@ -398,8 +398,7 @@ const Slider = React.memo((props: Props) => {
   );
 });
 
-// @ts-expect-error
-export default forwardRef<SliderProps, Statics>(Slider);
+export default forwardRef<SliderProps, ComponentStatics<typeof Slider>, SliderRef>(Slider);
 
 const styles = StyleSheet.create({
   container: {

--- a/src/incubator/index.ts
+++ b/src/incubator/index.ts
@@ -13,7 +13,7 @@ export {
 export {default as Toast, ToastProps, ToastPresets} from './toast';
 export {default as TouchableOpacity, TouchableOpacityProps} from './TouchableOpacity';
 export {default as PanView, PanViewProps, PanViewDirections, PanViewDismissThreshold} from './panView';
-export {default as Slider} from './Slider';
+export {default as Slider, SliderRef} from './Slider';
 export {default as Dialog, DialogProps, DialogHeaderProps, DialogStatics, DialogImperativeMethods} from './Dialog';
 // TODO: delete exports after fully removing from private
 export {default as ChipsInput, ChipsInputProps, ChipsInputChangeReason, ChipsInputChipProps} from '../components/chipsInput';

--- a/src/incubator/toast/index.tsx
+++ b/src/incubator/toast/index.tsx
@@ -164,7 +164,6 @@ const Toast = (props: PropsWithChildren<ToastProps>) => {
       <View accessible={Constants.isIOS} style={styles.messageContainer}>
         <Text
           testID={`${testID}-message`}
-          // @ts-expect-error
           ref={viewRef}
           style={[styles.message, {textAlign}, messageStyle]}
           accessibilityLabel={toastPreset.accessibilityMessage}

--- a/src/typings/common.d.ts
+++ b/src/typings/common.d.ts
@@ -8,3 +8,5 @@ export type ExtendTypeWith<T extends Constructor<any>, OtherObject extends objec
   ConstructorParameters<T>
 >;
 export type Dictionary<TYPE> = {[key: string]: TYPE};
+
+export type ComponentStatics<T> = {[Key in keyof T]: T[Key]}


### PR DESCRIPTION
## Description
Added RefInterface to the our forwardRef function. Adding this generic sets the type of the ref to the specific interface so when passing ref to a one of our components it will show a ts error when passing an incompatible interface ref.

## Changelog
Added generic typings to the forwardRef and in the asBaseComponent usage.

## Additional info
None
