### PR TITLE
Fixed dialog test to actually test for existence

### DIFF
--- a/src/incubator/Dialog/__tests__/index.new.spec.tsx
+++ b/src/incubator/Dialog/__tests__/index.new.spec.tsx
@@ -89,14 +89,14 @@ describe('Incubator.Dialog sanity checks', () => {
     const onDismiss = jest.fn();
     const component = <TestCase2 onDismiss={onDismiss}/>;
     const {dialogDriver, renderTree} = getDriver(component);
-    expect(dialogDriver.getModal().isVisible()).toBeFalsy();
+    expect(dialogDriver.exists()).toBeFalsy();
     const openButtonDriver = ButtonDriver({renderTree, testID: 'openButton'});
     openButtonDriver.press();
-    expect(dialogDriver.getModal().isVisible()).toBeTruthy();
+    expect(dialogDriver.exists()).toBeTruthy();
     expect(onDismiss).toHaveBeenCalledTimes(0);
     const closeButtonDriver = ButtonDriver({renderTree, testID: 'closeButton'});
     closeButtonDriver.press();
-    expect(dialogDriver.getModal().isVisible()).toBeFalsy();
+    expect(dialogDriver.exists()).toBeFalsy();
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Description
I changed the test so it would test for existence of the dialog instead of testing for the visibility of the modal. I thought they're the same thing.

## Changelog
None

## Additional info
None
