### PR TITLE
Type safe access to ref to avoid breaking tests

### DIFF
--- a/src/components/hint/index.tsx
+++ b/src/components/hint/index.tsx
@@ -227,7 +227,7 @@ class Hint extends Component<HintProps, HintState> {
 
     if (!this.state.targetLayoutInWindow || this.props.onBackgroundPress) {
       setTimeout(() => {
-        this.targetRef?.measureInWindow((x: number, y: number, width: number, height: number) => {
+        this.targetRef?.measureInWindow?.((x: number, y: number, width: number, height: number) => {
           const targetLayoutInWindow = {x, y, width, height};
           this.setState({targetLayoutInWindow});
         });


### PR DESCRIPTION
## Description
<!--
Enter description to help the reviewer understand what's the change about...
-->
Currently, headless tests are breaking with another module transitively most likely because of incomplete mocking in infra.

## Changelog
<!--
Add a quick message for our users about this change (include Component name, relevant props and general purpose of the PR)
-->
Adding type safe way to access refs. In general, it would be best to treat ref types as partial.

## Additional info
<!--
If applicable, add additional info such as link to the bug being fixed by this PR etc
-->
