### PR TITLE
ColorPicker - fix - hue changes to red after move lightness to white

### DIFF
--- a/demo/src/screens/incubatorScreens/IncubatorSliderScreen.tsx
+++ b/demo/src/screens/incubatorScreens/IncubatorSliderScreen.tsx
@@ -58,7 +58,7 @@ const IncubatorSliderScreen = () => {
     setAlpha(alpha);
   }, []);
 
-  const onGroupValueChange = (value: string) => {
+  const onGroupValueChange = (value: any) => {
     setGroupColor(value);
   };
 

--- a/src/components/colorPicker/ColorPickerDialog.tsx
+++ b/src/components/colorPicker/ColorPickerDialog.tsx
@@ -1,17 +1,17 @@
 import _ from 'lodash';
 import React, {useCallback, useEffect, useState} from 'react';
 import {LayoutAnimation, StyleSheet, Keyboard, StyleProp, ViewStyle} from 'react-native';
-
 import {Constants, asBaseComponent} from '../../commons/new';
 import {Colors} from '../../style';
 import {ModalProps} from '../../components/modal';
 import Dialog, {DialogProps} from '../../incubator/Dialog';
+import type {HSLA} from '../slider/GradientSlider';
 import {getColorValue, getValidColorString, getTextColor, BORDER_RADIUS} from './ColorPickerPresenter';
 import Header from './ColorPickerDialogHeader';
 import Preview from './ColorPickerPreview';
 import Sliders from './ColorPickerDialogSliders';
 
-interface Props extends DialogProps {
+export interface ColorPickerDialogProps extends DialogProps {
   /**
    * The initial color to pass the picker dialog
    */
@@ -45,7 +45,6 @@ interface Props extends DialogProps {
    */
   migrate?: boolean;
 }
-export type ColorPickerDialogProps = Props;
 
 const KEYBOARD_HEIGHT = 216;
 const MODAL_PROPS = {
@@ -57,7 +56,7 @@ const MODAL_PROPS = {
  * @extends: Dialog
  * @example: https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/ColorPickerScreen.tsx
  */
-const ColorPickerDialog = (props: Props) => {
+const ColorPickerDialog = (props: ColorPickerDialogProps) => {
   const {
     initialColor = Colors.$backgroundNeutralLight,
     dialogProps,
@@ -149,11 +148,13 @@ const ColorPickerDialog = (props: Props) => {
     setValid(valid);
   };
 
-  const updateColor = useCallback((hex: string) => {
-    setColor(Colors.getHSL(hex));
+  const updateColor = useCallback((value: string | HSLA) => {
+    setColor(_.isString(value) ? Colors.getHSL(value) : value);
+    const hex = Colors.getHexString(value);
     setText(_.toUpper(getColorValue(hex)));
     setValid(true);
   }, []);
+
   return (
     <Dialog
       visible={visible} //TODO: pass all Dialog props instead
@@ -191,7 +192,7 @@ const ColorPickerDialog = (props: Props) => {
 
 ColorPickerDialog.displayName = 'ColorPicker';
 
-export default asBaseComponent<Props>(ColorPickerDialog);
+export default asBaseComponent<ColorPickerDialogProps>(ColorPickerDialog);
 
 const styles = StyleSheet.create({
   dialog: {

--- a/src/components/colorPicker/ColorPickerDialogSliders.tsx
+++ b/src/components/colorPicker/ColorPickerDialogSliders.tsx
@@ -1,23 +1,23 @@
 import React from 'react';
 import {StyleSheet} from 'react-native';
-
 import {Colors} from '../../style';
-import ColorSliderGroup from '../slider/ColorSliderGroup';
+import ColorSliderGroup, {ColorSliderGroupProps} from '../slider/ColorSliderGroup';
 import {HSLColor} from './ColorPickerPresenter';
 import {ColorPickerDialogProps} from './ColorPickerDialog';
 
 type SlidersProps = Pick<ColorPickerDialogProps, 'migrate'> & {
   keyboardHeight: number;
   color: HSLColor;
-  onSliderValueChange: (value: string) => void;
+  onSliderValueChange: ColorSliderGroupProps['onValueChange'];
 };
 
 const Sliders = (props: SlidersProps) => {
   const {keyboardHeight, color, migrate, onSliderValueChange} = props;
-  const colorValue = color.a === 0 ? Colors.$backgroundInverted : Colors.getHexString(color);
+  const initialColor = color.a === 0 ? Colors.getHSL(Colors.$backgroundInverted) : color;
+  
   return (
     <ColorSliderGroup
-      initialColor={colorValue}
+      initialColor={initialColor}
       containerStyle={[styles.sliderGroup, {height: keyboardHeight}]}
       sliderContainerStyle={styles.slider}
       showLabels

--- a/src/components/slider/ColorSliderGroup.tsx
+++ b/src/components/slider/ColorSliderGroup.tsx
@@ -1,21 +1,22 @@
+import _ from 'lodash';
 import React, {useState, useEffect, useCallback} from 'react';
 import {StyleProp, ViewStyle, TextStyle} from 'react-native';
+import {Colors} from '../../style';
 import {asBaseComponent} from '../../commons/new';
-import GradientSlider, {GradientSliderTypes} from './GradientSlider';
+import GradientSlider, {GradientSliderTypes, HSLA} from './GradientSlider';
 import SliderGroup from './context/SliderGroup';
 import ColorSlider from './ColorSlider';
 
-type SliderOnValueChange = (value: string) => void;
 
 export type ColorSliderGroupProps = {
   /**
    * The gradient color
    */
-  initialColor: string;
+  initialColor: string | HSLA;
   /**
    * Callback for onValueChange returns the new hex color
    */
-  onValueChange?: SliderOnValueChange;
+  onValueChange?: (value: string | HSLA) => void;
   /**
    * Group container style
    */
@@ -54,12 +55,13 @@ export type ColorSliderGroupProps = {
  */
 const ColorSliderGroup = (props: ColorSliderGroupProps) => {
   const {initialColor, containerStyle, ...others} = props;
-  const [color, setColor] = useState(initialColor);
+  const [color, setColor] = useState(_.isString(initialColor) ? Colors.HSLA(initialColor) : initialColor);
+  
   useEffect(() => {
-    setColor(initialColor);
+    setColor(_.isString(initialColor) ? Colors.HSLA(initialColor) : initialColor);
   }, [initialColor]);
 
-  const onValueChange = useCallback((value: string) => {
+  const onValueChange = useCallback((value: string | HSLA) => {
     props?.onValueChange?.(value);
   },
   [props]);

--- a/src/components/slider/GradientSlider.tsx
+++ b/src/components/slider/GradientSlider.tsx
@@ -11,7 +11,7 @@ import {SliderContextProps} from './context/SliderContext';
 import asSliderGroupChild from './context/asSliderGroupChild';
 import Gradient from '../gradient';
 
-type SliderOnValueChange = (value: string, alfa: number) => void;
+export type HSLA = tinycolor.ColorFormats.HSLA;
 
 export enum GradientSliderTypes {
   DEFAULT = 'default',
@@ -27,7 +27,7 @@ export type GradientSliderProps = Omit<
   /**
    * The gradient color
    */
-  color?: string;
+  color?: string | HSLA;
   /**
    * The gradient type (default, hue, lightness, saturation)
    */
@@ -39,7 +39,7 @@ export type GradientSliderProps = Omit<
   /**
    * Callback for onValueChange, returns the updated color
    */
-  onValueChange?: SliderOnValueChange;
+  onValueChange?: (value: string, alfa: number) => void;
   /**
    * If true the component will have accessibility features enabled
    */
@@ -83,12 +83,13 @@ const GradientSlider = (props: Props) => {
     ...others
   } = props;
 
-  const initialColor = useRef(Colors.getHSL(propsColors));
-  const [color, setColor] = useState(Colors.getHSL(propsColors));
+  const colorProp = _.isString(propsColors) ? Colors.getHSL(propsColors) : propsColors;
+  const initialColor = useRef(colorProp);
+  const [color, setColor] = useState(colorProp);
   
   useEffect(() => {
-    setColor(Colors.getHSL(propsColors));
-  }, [propsColors]);
+    setColor(colorProp);
+  }, [colorProp]);
 
   const getColor = useCallback(() => {
     return color || sliderContext.value;
@@ -126,7 +127,7 @@ const GradientSlider = (props: Props) => {
   },
   [_onValueChange]);
 
-  const updateColor = useCallback((color: tinycolor.ColorFormats.HSLA) => {
+  const updateColor = useCallback((color: HSLA) => {
     if (!_.isEmpty(sliderContext)) {
       sliderContext.setValue?.(color);
     } else {

--- a/src/components/slider/context/SliderContext.ts
+++ b/src/components/slider/context/SliderContext.ts
@@ -1,8 +1,8 @@
 import React from 'react';
-
+import {HSLA} from '../GradientSlider';
 export interface SliderContextProps {
-  value?: tinycolor.ColorFormats.HSLA;
-  setValue?: (value: tinycolor.ColorFormats.HSLA) => void;
+  value?: HSLA;
+  setValue?: (value: HSLA) => void;
 }
 
 const SliderContext: React.Context<SliderContextProps> = React.createContext({});

--- a/src/components/slider/context/SliderGroup.tsx
+++ b/src/components/slider/context/SliderGroup.tsx
@@ -1,24 +1,23 @@
 import React, {useCallback, useMemo, useState} from 'react';
 import {StyleProp, ViewStyle} from 'react-native';
-import {Colors} from '../../../style';
 import SliderContext from './SliderContext';
+import type {HSLA} from '../GradientSlider';
 import View from '../../view';
-import tinycolor from 'tinycolor2';
 
 interface SliderGroupProps {
-  color: string;
-  onValueChange: (color: string) => void;
+  color: HSLA;
+  onValueChange: (color: HSLA) => void;
   style?: StyleProp<ViewStyle>;
   children?: React.ReactNode;
 }
 
 const SliderGroup = (props: SliderGroupProps) => {
   const {color, onValueChange, children} = props;
-  const [value, setValue] = useState(Colors.getHSL(color));
+  const [value, setValue] = useState(color);
 
-  const _setValue = useCallback((value: tinycolor.ColorFormats.HSLA) => {
+  const _setValue = useCallback((value: HSLA) => {
     setValue(value);
-    onValueChange?.(Colors.getHexString(value));
+    onValueChange?.(value);
   },
   [onValueChange]);
 


### PR DESCRIPTION
## Description
**The bug:** When moving the lightness slider to white, a #fffff color is set back to the component creating a color of h=0,s=0,l=0 values.
Now when moving the hue slider the color remains grey as the saturation is 0, and when moving the lightness slider the color remains red as the hue is 0.
**The solution:** Passing the color as HSL instead of converting it to hex allows the new color to keep the values of the hue and saturation in the transition so when moving either slider the color changes from the last values and not from the white color values.

## Changelog
ColorPicker - fix - hue changes to red after moving lightness to white

## Additional info

