### PR TITLE
Fix/hint message location

### DIFF
--- a/src/components/hint/index.tsx
+++ b/src/components/hint/index.tsx
@@ -314,7 +314,7 @@ class Hint extends Component<HintProps, HintState> {
 
   getHintPosition() {
     const {position} = this.props;
-    const hintPositionStyle: HintPositionStyle = {alignItems: 'center'};
+    const hintPositionStyle: HintPositionStyle = {};
 
     if (this.targetLayout?.x !== undefined) {
       hintPositionStyle.left = -this.targetLayout.x;
@@ -325,14 +325,6 @@ class Hint extends Component<HintProps, HintState> {
     } else if (this.targetLayout?.height) {
       hintPositionStyle.top = this.targetLayout.height;
     }
-
-    const targetPositionOnScreen = this.getTargetPositionOnScreen();
-    if (targetPositionOnScreen === TARGET_POSITIONS.RIGHT) {
-      hintPositionStyle.alignItems = Constants.isRTL ? 'flex-start' : 'flex-end';
-    } else if (targetPositionOnScreen === TARGET_POSITIONS.LEFT) {
-      hintPositionStyle.alignItems = Constants.isRTL ? 'flex-end' : 'flex-start';
-    }
-    delete hintPositionStyle.alignItems;
     return hintPositionStyle;
   }
 

--- a/src/components/hint/index.tsx
+++ b/src/components/hint/index.tsx
@@ -508,11 +508,7 @@ class Hint extends Component<HintProps, HintState> {
       >
         {customContent}
         {!customContent && icon && <Image source={icon} style={[styles.icon, iconStyle]}/>}
-        {!customContent && (
-          <Text recorderTag={'unmask'} style={[styles.hintMessage, messageStyle]}>
-            {message}
-          </Text>
-        )}
+        {!customContent && <Text recorderTag={'unmask'} style={[styles.hintMessage, messageStyle]}>{message}</Text>}
       </View>
     );
   }

--- a/src/components/hint/index.tsx
+++ b/src/components/hint/index.tsx
@@ -51,8 +51,6 @@ interface HintTargetFrame {
 
 type Position = Pick<ViewStyle, 'top' | 'bottom' | 'left' | 'right'>;
 
-type HintPositionStyle = Position & Pick<ViewStyle, 'alignItems'>;
-
 type Paddings = Pick<ViewStyle, 'paddingLeft' | 'paddingRight' | 'paddingVertical' | 'paddingHorizontal'>;
 
 export interface HintProps {

--- a/src/components/hint/index.tsx
+++ b/src/components/hint/index.tsx
@@ -314,7 +314,7 @@ class Hint extends Component<HintProps, HintState> {
 
   getHintPosition() {
     const {position} = this.props;
-    const hintPositionStyle: HintPositionStyle = {};
+    const hintPositionStyle: Position = {};
 
     if (this.targetLayout?.x !== undefined) {
       hintPositionStyle.left = -this.targetLayout.x;
@@ -430,24 +430,34 @@ class Hint extends Component<HintProps, HintState> {
       );
     }
   }
-  getMessagePosition() {
+  getMessagePosition(): Position {
+    const {position} = this.props;
     const tipPosition = this.getTipPosition();
     const locationOnScreen = this.getTargetPositionOnScreen();
     const {messageLayout} = this.state;
+    const messagePositionStyle: Position = {};
+    const {width: tipWidth} = this.tipSize;
     if (
       (typeof tipPosition.left === 'number' || typeof tipPosition.right === 'number') &&
       messageLayout.width &&
-      this.tipSize.width
+      tipWidth
     ) {
       const tipOffset = tipPosition.left || tipPosition.right;
       if (typeof tipOffset === 'number') {
-        return locationOnScreen === TARGET_POSITIONS.CENTER
-          ? {left: tipOffset - messageLayout.width / 2 - this.tipSize.width / 2}
+        locationOnScreen === TARGET_POSITIONS.CENTER
+          ? (messagePositionStyle.left = tipOffset - messageLayout.width / 2 - tipWidth / 2)
           : locationOnScreen === TARGET_POSITIONS.LEFT
-            ? {left: 0}
-            : {right: 0};
+            ? (messagePositionStyle.left = 0)
+            : (messagePositionStyle.right = 0);
       }
     }
+
+    if (position === HintPositions.TOP) {
+      messagePositionStyle.bottom = 0;
+    } else {
+      messagePositionStyle.top = 0;
+    }
+    return messagePositionStyle;
   }
 
   onMessageLayout = ({nativeEvent: {layout}}: LayoutChangeEvent) => {

--- a/src/components/hint/index.tsx
+++ b/src/components/hint/index.tsx
@@ -531,8 +531,7 @@ class Hint extends Component<HintProps, HintState> {
             styles.animatedContainer,
             this.getHintPosition(),
             this.getHintPadding(),
-            this.getHintAnimatedStyle(),
-            {backgroundColor: 'red'}
+            this.getHintAnimatedStyle()
           ]}
           pointerEvents="box-none"
           testID={testID}

--- a/src/components/hint/index.tsx
+++ b/src/components/hint/index.tsx
@@ -442,7 +442,6 @@ class Hint extends Component<HintProps, HintState> {
     const tipPosition = this.getTipPosition();
     const locationOnScreen = this.getTargetPositionOnScreen();
     const {messageLayout} = this.state;
-    console.log(`Nitzan - tip location layout`, tipPosition, locationOnScreen, messageLayout);
     if (
       (typeof tipPosition.left === 'number' || typeof tipPosition.right === 'number') &&
       messageLayout.width &&
@@ -460,7 +459,6 @@ class Hint extends Component<HintProps, HintState> {
   }
 
   onMessageLayout = ({nativeEvent: {layout}}: LayoutChangeEvent) => {
-    console.log(`Nitzan - layout`, layout);
     this.setState({messageLayout: layout});
   };
 
@@ -490,7 +488,6 @@ class Hint extends Component<HintProps, HintState> {
       visible,
       testID
     } = this.props;
-    console.log(`Nitzan - this.getMessagePosition()`, this.getMessagePosition());
     return (
       <View
         testID={`${testID}.message`}


### PR DESCRIPTION
## Description
Fix for Hint tip and message not in same location bug. When the hint is pointing to component that is large the hint and tip are placed at different location (will probably happen when width of component is larger than 1/3 of the screen). Tip location is correct, message is not.
Snippets for reproducing:
Tablet:
```
<View flex paddingT-100>
  <Hint message={'This is a hint'} visible>
    <View width={800}>
      <Button label="Hint me"/>
    </View>
  </Hint>
</View>
```
Phone:
```
<View flex paddingT-100>
  <Hint message={'This is a hint'} visible>
    <View width={300}>
      <Button label="Hint me"/>
    </View>
  </Hint>
</View>
```


## Changelog
Hint - Big fix where tip and message are not at same location.

## Additional info
MADS-3858
