### PR TITLE
Removed getProps/getElementProps entirely

### DIFF
--- a/src/components/WheelPicker/WheelPicker.driver.tsx
+++ b/src/components/WheelPicker/WheelPicker.driver.tsx
@@ -11,7 +11,7 @@ export const WheelPickerDriver = (props: ComponentProps) => {
     testID: `${props.testID}.list`
   }));
 
-  const itemsLength = listDriver.getElementProps().data?.length ?? 0;
+  const itemsLength = listDriver.getElement().props.data?.length ?? 0;
 
   const moveToItem = (index: number, itemHeight: number = ITEM_HEIGHT, numberOfRows: number = itemsLength) => {
     listDriver.triggerEvent('onMomentumScrollEnd', {
@@ -22,7 +22,7 @@ export const WheelPickerDriver = (props: ComponentProps) => {
   };
 
   const getListHeight = () => {
-    return listDriver.getElementProps().height;
+    return listDriver.getElement().props.height;
   };
 
   const labelDriver = TextDriver({

--- a/src/components/WheelPicker/WheelPicker.driver.tsx
+++ b/src/components/WheelPicker/WheelPicker.driver.tsx
@@ -1,18 +1,17 @@
-import {FlatListProps} from 'react-native';
-import {WheelPickerProps, WheelPickerItemProps, ITEM_HEIGHT} from './index';
+import {ITEM_HEIGHT} from './index';
 import {useComponentDriver, ComponentProps} from '../../testkit/new/Component.driver';
 import {useScrollableDriver} from '../../testkit/new/useScrollable.driver';
 import {TextDriver} from '../../components/text/Text.driver.new';
 
 export const WheelPickerDriver = (props: ComponentProps) => {
-  const driver = useComponentDriver<WheelPickerProps>(props);
+  const driver = useComponentDriver(props);
 
-  const listDriver = useScrollableDriver<FlatListProps<WheelPickerItemProps>>(useComponentDriver({
+  const listDriver = useScrollableDriver(useComponentDriver({
     renderTree: props.renderTree,
     testID: `${props.testID}.list`
   }));
 
-  const itemsLength = listDriver.getProps().data?.length ?? 0;
+  const itemsLength = listDriver.getElementProps().data?.length ?? 0;
 
   const moveToItem = (index: number, itemHeight: number = ITEM_HEIGHT, numberOfRows: number = itemsLength) => {
     listDriver.triggerEvent('onMomentumScrollEnd', {
@@ -23,8 +22,7 @@ export const WheelPickerDriver = (props: ComponentProps) => {
   };
 
   const getListHeight = () => {
-    //@ts-expect-error
-    return listDriver.getProps().height;
+    return listDriver.getElementProps().height;
   };
 
   const labelDriver = TextDriver({

--- a/src/components/button/Button.driver.new.ts
+++ b/src/components/button/Button.driver.new.ts
@@ -1,8 +1,7 @@
-import {ButtonProps} from './ButtonTypes';
 import {useComponentDriver, ComponentProps, usePressableDriver, TextDriver, ImageDriver} from '../../testkit';
 
 export const ButtonDriver = (props: ComponentProps) => {
-  const driver = usePressableDriver<ButtonProps>(useComponentDriver(props));
+  const driver = usePressableDriver(useComponentDriver(props));
 
   const labelDriver = TextDriver({
     renderTree: props.renderTree,

--- a/src/components/carousel/Carousel.driver.new.ts
+++ b/src/components/carousel/Carousel.driver.new.ts
@@ -1,9 +1,8 @@
-import {CarouselProps} from './types';
 import {useComponentDriver, ComponentProps} from '../../testkit/new/Component.driver';
 import {useScrollableDriver, ScrollProps} from '../../testkit/new/useScrollable.driver';
 
 export const CarouselDriver = (props: ComponentProps) => {
-  const driver = useScrollableDriver<CarouselProps>(useComponentDriver(props));
+  const driver = useScrollableDriver(useComponentDriver(props));
 
   const scroll = (props: ScrollProps) => {
     return driver.scroll(props);

--- a/src/components/checkbox/Checkbox.driver.ts
+++ b/src/components/checkbox/Checkbox.driver.ts
@@ -1,10 +1,9 @@
-import {CheckboxProps} from './index';
 import {useComponentDriver, ComponentProps} from '../../testkit/new/Component.driver';
 import {usePressableDriver} from '../../testkit/new/usePressable.driver';
 import {TextDriver} from '../text/Text.driver.new';
 
 export const CheckboxDriver = (props: ComponentProps) => {
-  const driver = usePressableDriver<CheckboxProps>(useComponentDriver(props));
+  const driver = usePressableDriver(useComponentDriver(props));
 
   const labelDriver = TextDriver({
     renderTree: props.renderTree,

--- a/src/components/modal/Modal.driver.new.ts
+++ b/src/components/modal/Modal.driver.new.ts
@@ -1,14 +1,13 @@
-import {ModalProps} from './index';
 import {useComponentDriver, ComponentProps} from '../../testkit/new/Component.driver';
 import {ButtonDriver} from '../button/Button.driver.new';
 
 export const ModalDriver = (props: ComponentProps) => {
   const {renderTree, testID} = props;
-  const driver = useComponentDriver<ModalProps>(props);
+  const driver = useComponentDriver(props);
   const overlayDriver = ButtonDriver({renderTree, testID: `${testID}.TouchableOverlay`});
 
   const isVisible = () => {
-    return !!driver.getProps().visible;
+    return !!driver.getElementProps().visible;
   };
 
   return {...driver, isVisible, pressOnBackground: overlayDriver.press};

--- a/src/components/modal/Modal.driver.new.ts
+++ b/src/components/modal/Modal.driver.new.ts
@@ -7,7 +7,7 @@ export const ModalDriver = (props: ComponentProps) => {
   const overlayDriver = ButtonDriver({renderTree, testID: `${testID}.TouchableOverlay`});
 
   const isVisible = () => {
-    return !!driver.getElementProps().visible;
+    return !!driver.getElement().props.visible;
   };
 
   return {...driver, isVisible, pressOnBackground: overlayDriver.press};

--- a/src/components/sectionsWheelPicker/SectionsWheelPicker.driver.tsx
+++ b/src/components/sectionsWheelPicker/SectionsWheelPicker.driver.tsx
@@ -4,8 +4,8 @@ import {WheelPickerDriver} from '../WheelPicker/WheelPicker.driver';
 import {SectionsWheelPickerProps} from './index';
 
 export const SectionsWheelPickerDriver = (props: ComponentProps) => {
-  const driver = useComponentDriver<SectionsWheelPickerProps>(props);
-  const sections = driver.getProps().children as SectionsWheelPickerProps;
+  const driver = useComponentDriver(props);
+  const sections = driver.getElementChildren() as SectionsWheelPickerProps;
   const sectionsDrivers = _.map(sections, (_, index) => {
     const sectionTestID = `${props.testID}.${index}`;
     return WheelPickerDriver({

--- a/src/components/sectionsWheelPicker/SectionsWheelPicker.driver.tsx
+++ b/src/components/sectionsWheelPicker/SectionsWheelPicker.driver.tsx
@@ -5,7 +5,7 @@ import {SectionsWheelPickerProps} from './index';
 
 export const SectionsWheelPickerDriver = (props: ComponentProps) => {
   const driver = useComponentDriver(props);
-  const sections = driver.getElementChildren() as SectionsWheelPickerProps;
+  const sections = driver.getElement().children as SectionsWheelPickerProps;
   const sectionsDrivers = _.map(sections, (_, index) => {
     const sectionTestID = `${props.testID}.${index}`;
     return WheelPickerDriver({

--- a/src/components/sortableList/SortableListItem.driver.new.ts
+++ b/src/components/sortableList/SortableListItem.driver.new.ts
@@ -1,11 +1,10 @@
 import _ from 'lodash';
 import {useComponentDriver, ComponentProps} from '../../testkit/new/Component.driver';
 import {useDraggableDriver} from '../../testkit/new/useDraggable.driver';
-import {SortableListItemProps} from './types';
 import {DEFAULT_LIST_ITEM_SIZE} from './SortableListItem';
 
 export const SortableListItemDriver = (props: ComponentProps) => {
-  const driver = useDraggableDriver<SortableListItemProps>(useComponentDriver(props));
+  const driver = useDraggableDriver(useComponentDriver(props));
 
   const dragUp = async (indices: number) => {
     validateIndices(indices);

--- a/src/components/switch/switch.driver.ts
+++ b/src/components/switch/switch.driver.ts
@@ -1,15 +1,14 @@
 import {ViewStyle} from 'react-native';
-import {SwitchProps} from './index';
 import {useComponentDriver, ComponentProps} from '../../testkit/new/Component.driver';
 import {usePressableDriver} from '../../testkit/new/usePressable.driver';
 
 export const SwitchDriver = (props: ComponentProps) => {
-  const driver = usePressableDriver<SwitchProps>(useComponentDriver(props));
+  const driver = usePressableDriver(useComponentDriver(props));
   
-  const getStyle = () => driver.getProps().style as ViewStyle;
-  const getAccessibilityValue = () => driver.getProps().accessibilityValue?.text === '1';
-  const isDisabled = () => driver.getProps().accessibilityState?.disabled === true;
-  const isChecked = () => driver.getProps().accessibilityValue?.text === '1';
+  const getStyle = () => driver.getElementProps().style as ViewStyle;
+  const getAccessibilityValue = () => driver.getElementProps().accessibilityValue?.text === '1';
+  const isDisabled = () => driver.getElementProps().accessibilityState?.disabled === true;
+  const isChecked = () => driver.getElementProps().accessibilityValue?.text === '1';
   
   return {...driver, getStyle, getAccessibilityValue, isDisabled, isChecked};
 };

--- a/src/components/switch/switch.driver.ts
+++ b/src/components/switch/switch.driver.ts
@@ -5,10 +5,10 @@ import {usePressableDriver} from '../../testkit/new/usePressable.driver';
 export const SwitchDriver = (props: ComponentProps) => {
   const driver = usePressableDriver(useComponentDriver(props));
   
-  const getStyle = () => driver.getElementProps().style as ViewStyle;
-  const getAccessibilityValue = () => driver.getElementProps().accessibilityValue?.text === '1';
-  const isDisabled = () => driver.getElementProps().accessibilityState?.disabled === true;
-  const isChecked = () => driver.getElementProps().accessibilityValue?.text === '1';
+  const getStyle = () => driver.getElement().props.style as ViewStyle;
+  const getAccessibilityValue = () => driver.getElement().props.accessibilityValue?.text === '1';
+  const isDisabled = () => driver.getElement().props.accessibilityState?.disabled === true;
+  const isChecked = () => driver.getElement().props.accessibilityValue?.text === '1';
   
   return {...driver, getStyle, getAccessibilityValue, isDisabled, isChecked};
 };

--- a/src/components/text/Text.driver.new.ts
+++ b/src/components/text/Text.driver.new.ts
@@ -6,7 +6,7 @@ export const TextDriver = (props: ComponentProps) => {
   const driver = usePressableDriver(useComponentDriver(props));
 
   const getText = () => {
-    const textChildren = driver.getElementChildren();
+    const textChildren = driver.getElement().children;
     if (textChildren.length === 0) {
       return '';
     }
@@ -17,7 +17,7 @@ export const TextDriver = (props: ComponentProps) => {
   };
 
   const getStyle = () => {
-    return StyleSheet.flatten(driver.getElementProps().style) as TextStyle;
+    return StyleSheet.flatten(driver.getElement().props.style) as TextStyle;
   };
 
   return {...driver, getText, getStyle};

--- a/src/components/text/Text.driver.new.ts
+++ b/src/components/text/Text.driver.new.ts
@@ -1,17 +1,23 @@
 import {StyleSheet, TextStyle} from 'react-native';
-import {TextProps} from './index';
 import {useComponentDriver, ComponentProps} from '../../testkit/new/Component.driver';
 import {usePressableDriver} from '../../testkit/new/usePressable.driver';
 
 export const TextDriver = (props: ComponentProps) => {
-  const driver = usePressableDriver<TextProps>(useComponentDriver(props));
+  const driver = usePressableDriver(useComponentDriver(props));
 
-  const getText = (): React.ReactNode | string | undefined => {
-    return driver.getProps().children;
+  const getText = () => {
+    const textChildren = driver.getElementChildren();
+    if (textChildren.length === 0) {
+      return '';
+    }
+    if (textChildren.length === 1 && typeof textChildren[0] === 'string') {
+      return textChildren[0];
+    }
+    return textChildren;
   };
 
   const getStyle = () => {
-    return StyleSheet.flatten(driver.getProps().style) as TextStyle;
+    return StyleSheet.flatten(driver.getElementProps().style) as TextStyle;
   };
 
   return {...driver, getText, getStyle};

--- a/src/components/text/__tests__/index.driver.spec.tsx
+++ b/src/components/text/__tests__/index.driver.spec.tsx
@@ -70,13 +70,13 @@ describe('Text', () => {
       jest.isolateModules(() => {
         setConstants(true, true);
         const {textDriver} = getDriver();
-        const textStyle = textDriver.getElementProps().style;
+        const textStyle = textDriver.getElement().props.style;
         expect(StyleSheet.flatten(textStyle).textAlign).toEqual('left');
       });
       jest.isolateModules(() => {
         setConstants(true, false);
         const {textDriver} = getDriver();
-        const textStyle = textDriver.getElementProps().style;
+        const textStyle = textDriver.getElement().props.style;
         expect(StyleSheet.flatten(textStyle).textAlign).toEqual('left');
       });
     });
@@ -85,7 +85,7 @@ describe('Text', () => {
       jest.isolateModules(() => {
         setConstants(false, true);
         const {textDriver} = getDriver();
-        const textStyle = textDriver.getElementProps().style;
+        const textStyle = textDriver.getElement().props.style;
         expect(StyleSheet.flatten(textStyle).writingDirection).toEqual('rtl');
       });
     });
@@ -93,7 +93,7 @@ describe('Text', () => {
       jest.isolateModules(() => {
         setConstants(false, false);
         const {textDriver} = getDriver();
-        const textStyle = textDriver.getElementProps().style;
+        const textStyle = textDriver.getElement().props.style;
         expect(StyleSheet.flatten(textStyle).writingDirection).toEqual('ltr');
       });
     });

--- a/src/components/text/__tests__/index.driver.spec.tsx
+++ b/src/components/text/__tests__/index.driver.spec.tsx
@@ -29,6 +29,21 @@ describe('Text', () => {
     const content = textDriver.getText();
     expect(content).toEqual(TEXT_CONTENT);
   });
+  it('should return empty string', () => {
+    const Text = require('../').default;
+    const renderTree = render(<Text testID={TEXT_ID}/>);
+    const textDriver = TextDriver({renderTree, testID: TEXT_ID});
+    const content = textDriver.getText();
+    expect(content).toEqual('');
+  });
+  it('should not return a string as text', () => {
+    const Text = require('../').default;
+    const renderTree = render(<Text testID={TEXT_ID}><Text>This is a text</Text></Text>);
+    const textDriver = TextDriver({renderTree, testID: TEXT_ID});
+    const content = textDriver.getText();
+    expect(content.length).toBe(1);
+    expect(typeof content[0]).not.toBe('string');
+  });
 
   describe('onPress', () => {
     it('should press the text, and run callback', () => {
@@ -55,13 +70,13 @@ describe('Text', () => {
       jest.isolateModules(() => {
         setConstants(true, true);
         const {textDriver} = getDriver();
-        const textStyle = textDriver.getProps().style;
+        const textStyle = textDriver.getElementProps().style;
         expect(StyleSheet.flatten(textStyle).textAlign).toEqual('left');
       });
       jest.isolateModules(() => {
         setConstants(true, false);
         const {textDriver} = getDriver();
-        const textStyle = textDriver.getProps().style;
+        const textStyle = textDriver.getElementProps().style;
         expect(StyleSheet.flatten(textStyle).textAlign).toEqual('left');
       });
     });
@@ -70,7 +85,7 @@ describe('Text', () => {
       jest.isolateModules(() => {
         setConstants(false, true);
         const {textDriver} = getDriver();
-        const textStyle = textDriver.getProps().style;
+        const textStyle = textDriver.getElementProps().style;
         expect(StyleSheet.flatten(textStyle).writingDirection).toEqual('rtl');
       });
     });
@@ -78,7 +93,7 @@ describe('Text', () => {
       jest.isolateModules(() => {
         setConstants(false, false);
         const {textDriver} = getDriver();
-        const textStyle = textDriver.getProps().style;
+        const textStyle = textDriver.getElementProps().style;
         expect(StyleSheet.flatten(textStyle).writingDirection).toEqual('ltr');
       });
     });

--- a/src/components/textField/TextField.driver.new.ts
+++ b/src/components/textField/TextField.driver.new.ts
@@ -1,12 +1,11 @@
 import _ from 'lodash';
 import {fireEvent} from '@testing-library/react-native';
-import {TextFieldProps} from './types';
 import {useComponentDriver, ComponentProps} from '../../testkit/new/Component.driver';
 import {TextDriver} from '../text/Text.driver.new';
 import {usePressableDriver} from '../../testkit/new/usePressable.driver';
 
 export const TextFieldDriver = (props: ComponentProps) => {
-  const driver = usePressableDriver<TextFieldProps>(useComponentDriver(props));
+  const driver = usePressableDriver(useComponentDriver(props));
 
   const floatingPlaceholderDriver = TextDriver({
     renderTree: props.renderTree,
@@ -26,7 +25,7 @@ export const TextFieldDriver = (props: ComponentProps) => {
   });
 
   const getValue = (): string | undefined => {
-    return driver.getProps().value ?? driver.getProps().defaultValue;
+    return driver.getElementProps().value ?? driver.getElementProps().defaultValue;
   };
 
   const changeText = (text: string): void => {
@@ -42,18 +41,18 @@ export const TextFieldDriver = (props: ComponentProps) => {
   };
 
   const isEnabled = (): boolean => {
-    return !driver.getProps().accessibilityState?.disabled;
+    return !driver.getElementProps().accessibilityState?.disabled;
   };
 
   const getPlaceholder = () => {
     const exists = (): boolean => {
-      const hasPlaceholder = !!driver.getProps().placeholder;
+      const hasPlaceholder = !!driver.getElementProps().placeholder;
       const hasText = !!getValue();
       return hasPlaceholder && (!hasText || (hasText && floatingPlaceholderDriver.exists()));
     };
     const getText = (): string | undefined => {
       if (exists()) {
-        return driver.getProps().placeholder;
+        return driver.getElementProps().placeholder;
       }
     };
 

--- a/src/components/textField/TextField.driver.new.ts
+++ b/src/components/textField/TextField.driver.new.ts
@@ -25,7 +25,7 @@ export const TextFieldDriver = (props: ComponentProps) => {
   });
 
   const getValue = (): string | undefined => {
-    return driver.getElementProps().value ?? driver.getElementProps().defaultValue;
+    return driver.getElement().props.value ?? driver.getElement().props.defaultValue;
   };
 
   const changeText = (text: string): void => {
@@ -41,18 +41,18 @@ export const TextFieldDriver = (props: ComponentProps) => {
   };
 
   const isEnabled = (): boolean => {
-    return !driver.getElementProps().accessibilityState?.disabled;
+    return !driver.getElement().props.accessibilityState?.disabled;
   };
 
   const getPlaceholder = () => {
     const exists = (): boolean => {
-      const hasPlaceholder = !!driver.getElementProps().placeholder;
+      const hasPlaceholder = !!driver.getElement().props.placeholder;
       const hasText = !!getValue();
       return hasPlaceholder && (!hasText || (hasText && floatingPlaceholderDriver.exists()));
     };
     const getText = (): string | undefined => {
       if (exists()) {
-        return driver.getElementProps().placeholder;
+        return driver.getElement().props.placeholder;
       }
     };
 

--- a/src/components/view/View.driver.new.ts
+++ b/src/components/view/View.driver.new.ts
@@ -1,11 +1,10 @@
-import {ViewProps} from './index';
 import {useComponentDriver, ComponentProps} from '../../testkit/new/Component.driver';
 
 export const ViewDriver = (props: ComponentProps) => {
-  const driver = useComponentDriver<ViewProps>(props);
+  const driver = useComponentDriver(props);
 
   const getStyle = () => {
-    return driver.getProps().style;
+    return driver.getElementProps().style;
   };
   return {...driver, getStyle};
 };

--- a/src/components/view/View.driver.new.ts
+++ b/src/components/view/View.driver.new.ts
@@ -4,7 +4,7 @@ export const ViewDriver = (props: ComponentProps) => {
   const driver = useComponentDriver(props);
 
   const getStyle = () => {
-    return driver.getElementProps().style;
+    return driver.getElement().props.style;
   };
   return {...driver, getStyle};
 };

--- a/src/incubator/Dialog/Dialog.driver.new.ts
+++ b/src/incubator/Dialog/Dialog.driver.new.ts
@@ -1,10 +1,9 @@
-import {DialogProps} from './index';
 import {useComponentDriver, ComponentProps} from '../../testkit/new/Component.driver';
 import {ModalDriver} from '../../testkit/';
 
 export const DialogDriver = (props: ComponentProps) => {
   const {renderTree, testID} = props;
-  const driver = useComponentDriver<DialogProps>(props);
+  const driver = useComponentDriver(props);
   const modalDriver = ModalDriver({renderTree, testID: `${testID}.modal`});
   return {...driver, getModal: () => modalDriver};
 };

--- a/src/incubator/toast/Toast.driver.new.ts
+++ b/src/incubator/toast/Toast.driver.new.ts
@@ -1,11 +1,10 @@
-import {ToastProps} from '../index';
 import {useComponentDriver, ComponentProps} from '../../testkit/new/Component.driver';
 import {TextDriver} from '../../components/text/Text.driver.new';
 import {ButtonDriver} from '../../components/button/Button.driver.new';
 
 export const ToastDriver = (props: ComponentProps) => {
   const {renderTree, testID} = props;
-  const driver = useComponentDriver<ToastProps>(props);
+  const driver = useComponentDriver(props);
   const actionButtonDriver = ButtonDriver({renderTree, testID: `${testID}-action`});
   const messageDriver = TextDriver({renderTree, testID: `${testID}-message`});
 

--- a/src/testkit/new/Component.driver.ts
+++ b/src/testkit/new/Component.driver.ts
@@ -9,8 +9,6 @@ export interface ComponentProps {
 export interface ComponentDriverResult {
   getElement: () => ReactTestInstance;
   exists: () => boolean;
-  getElementProps: () => ReactTestInstance['props'];
-  getElementChildren: () => ReactTestInstance['children'];
 }
 
 export const useComponentDriver = (props: ComponentProps): ComponentDriverResult => {
@@ -29,10 +27,6 @@ export const useComponentDriver = (props: ComponentProps): ComponentDriverResult
       throw new Error(`Could not find element with testID: ${testID}`);
     }
   };
-  
-  const getElementChildren = () => {
-    return getElement().children;
-  };
 
   const exists = (): boolean => {
     try {
@@ -43,11 +37,7 @@ export const useComponentDriver = (props: ComponentProps): ComponentDriverResult
     }
   };
 
-  const getElementProps = () => {
-    return getElement().props;
-  };
-
-  return {getElement, getElementChildren, exists, getElementProps};
+  return {getElement, exists};
 };
 
 export const ComponentDriver = (props: ComponentProps): ComponentDriverResult => {

--- a/src/testkit/new/Component.driver.ts
+++ b/src/testkit/new/Component.driver.ts
@@ -6,13 +6,14 @@ export interface ComponentProps {
   testID: string;
 }
 
-export interface ComponentDriverResult<Props> {
+export interface ComponentDriverResult {
   getElement: () => ReactTestInstance;
   exists: () => boolean;
-  getProps: () => Props;
+  getElementProps: () => ReactTestInstance['props'];
+  getElementChildren: () => ReactTestInstance['children'];
 }
 
-export const useComponentDriver = <Props>(props: ComponentProps): ComponentDriverResult<Props> => {
+export const useComponentDriver = (props: ComponentProps): ComponentDriverResult => {
   const {renderTree, testID} = props;
 
   const getElement = (): ReactTestInstance => {
@@ -28,6 +29,10 @@ export const useComponentDriver = <Props>(props: ComponentProps): ComponentDrive
       throw new Error(`Could not find element with testID: ${testID}`);
     }
   };
+  
+  const getElementChildren = () => {
+    return getElement().children;
+  };
 
   const exists = (): boolean => {
     try {
@@ -38,13 +43,13 @@ export const useComponentDriver = <Props>(props: ComponentProps): ComponentDrive
     }
   };
 
-  const getProps = (): Props => {
-    return getElement().props as Props;
+  const getElementProps = () => {
+    return getElement().props;
   };
 
-  return {getElement, exists, getProps};
+  return {getElement, getElementChildren, exists, getElementProps};
 };
 
-export const ComponentDriver = <Props>(props: ComponentProps): ComponentDriverResult<Props> => {
+export const ComponentDriver = (props: ComponentProps): ComponentDriverResult => {
   return useComponentDriver(props);
 };

--- a/src/testkit/new/useDraggable.driver.ts
+++ b/src/testkit/new/useDraggable.driver.ts
@@ -12,16 +12,15 @@ export type DragEvent = {
   y?: number;
 };
 
-export interface DraggableDriverResult<Props> extends ComponentDriverResult<Props> {
+export interface DraggableDriverResult extends ComponentDriverResult {
   drag: (distanceOrEvent: DragEvent | DragEvent[] | number) => void;
 }
 
 export const useDraggableDriver = <
-  Props,
-  DriverProps extends ComponentDriverResult<Props> = ComponentDriverResult<Props> // Allows for chaining multiple drivers
+  DriverProps extends ComponentDriverResult = ComponentDriverResult // Allows for chaining multiple drivers
 >(
     driver: DriverProps
-  ): DraggableDriverResult<Props> & DriverProps => {
+  ): DraggableDriverResult & DriverProps => {
   const drag = (distanceOrEvent: DragEvent | DragEvent[] | number) => {
     let data: DragEvent | DragEvent[];
     if (typeof distanceOrEvent === 'number') {

--- a/src/testkit/new/usePressable.driver.ts
+++ b/src/testkit/new/usePressable.driver.ts
@@ -27,7 +27,7 @@ export const usePressableDriver = <
   };
 
   const hasOnPress = () => {
-    return typeof driver.getElementProps().onPress === 'function';
+    return typeof driver.getElement().props.onPress === 'function';
   };
 
   const onPressIn = () => {
@@ -35,7 +35,7 @@ export const usePressableDriver = <
   };
 
   const hasOnPressIn = () => {
-    return typeof driver.getElementProps().onPressIn === 'function';
+    return typeof driver.getElement().props.onPressIn === 'function';
   };
 
   const onPressOut = () => {
@@ -43,7 +43,7 @@ export const usePressableDriver = <
   };
 
   const hasOnPressOut = () => {
-    return typeof driver.getElementProps().onPressOut === 'function';
+    return typeof driver.getElement().props.onPressOut === 'function';
   };
 
   const onLongPress = () => {
@@ -51,7 +51,7 @@ export const usePressableDriver = <
   };
 
   const hasOnLongPress = () => {
-    return typeof driver.getElementProps().onLongPress === 'function';
+    return typeof driver.getElement().props.onLongPress === 'function';
   };
 
   return {

--- a/src/testkit/new/usePressable.driver.ts
+++ b/src/testkit/new/usePressable.driver.ts
@@ -2,7 +2,7 @@ import {fireEvent} from '@testing-library/react-native';
 import {ComponentDriverResult} from './Component.driver';
 import {PressableProps} from 'react-native';
 
-export interface PressableDriverResult<Props> extends ComponentDriverResult<Props> {
+export interface PressableDriverResult extends ComponentDriverResult {
   press: () => void;
   hasOnPress: () => boolean;
   onPressIn: () => void;
@@ -18,17 +18,16 @@ export type PressableDriverProps = Partial<
 >;
 
 export const usePressableDriver = <
-  Props extends PressableDriverProps,
-  DriverProps extends ComponentDriverResult<Props> = ComponentDriverResult<Props> // Allows for chaining multiple drivers
+  DriverProps extends ComponentDriverResult = ComponentDriverResult // Allows for chaining multiple drivers
 >(
     driver: DriverProps
-  ): PressableDriverResult<Props> & DriverProps => {
+  ): PressableDriverResult & DriverProps => {
   const press = () => {
     fireEvent.press(driver.getElement());
   };
 
   const hasOnPress = () => {
-    return typeof driver.getProps().onPress === 'function';
+    return typeof driver.getElementProps().onPress === 'function';
   };
 
   const onPressIn = () => {
@@ -36,7 +35,7 @@ export const usePressableDriver = <
   };
 
   const hasOnPressIn = () => {
-    return typeof driver.getProps().onPressIn === 'function';
+    return typeof driver.getElementProps().onPressIn === 'function';
   };
 
   const onPressOut = () => {
@@ -44,7 +43,7 @@ export const usePressableDriver = <
   };
 
   const hasOnPressOut = () => {
-    return typeof driver.getProps().onPressOut === 'function';
+    return typeof driver.getElementProps().onPressOut === 'function';
   };
 
   const onLongPress = () => {
@@ -52,7 +51,7 @@ export const usePressableDriver = <
   };
 
   const hasOnLongPress = () => {
-    return typeof driver.getProps().onLongPress === 'function';
+    return typeof driver.getElementProps().onLongPress === 'function';
   };
 
   return {

--- a/src/testkit/new/useScrollable.driver.ts
+++ b/src/testkit/new/useScrollable.driver.ts
@@ -8,14 +8,14 @@ type ContentOffset = Partial<NativeScrollPoint>;
 
 export type ScrollProps = ContentOffset & {options?: ScrollableDriverOptions};
 
-export interface ScrollableDriverResult<Props> extends ComponentDriverResult<Props> {
+export interface ScrollableDriverResult extends ComponentDriverResult {
   scroll: (contentOffset: ContentOffset, options?: ScrollableDriverOptions) => void;
   triggerEvent: (eventName?: string, event?: Partial<NativeScrollEvent>) => void;
 }
 
 export const useScrollableDriver = 
-<Props, DriverProps extends ComponentDriverResult<Props> = ComponentDriverResult<Props>>(driver: DriverProps): 
-ScrollableDriverResult<Props> & DriverProps => {
+<DriverProps extends ComponentDriverResult = ComponentDriverResult>(driver: DriverProps): 
+ScrollableDriverResult & DriverProps => {
 
   const getContentOffset = async () => await driver.getElement().props.contentOffset;
 


### PR DESCRIPTION
## Description
Removed the usage of getProps from the basic component driver. To get the element props we now need to use getElement().props.
Changed Text driver getText to return text if it has only one children.

## Changelog
None.

## Additional info
MADS-4058
