### PR TITLE
Infra/test renderer find style

### DIFF
--- a/src/uilib-test-renderer/helper.ts
+++ b/src/uilib-test-renderer/helper.ts
@@ -9,10 +9,11 @@ interface Component {
 }
 
 const findStyle = <T>(key: string, component: Component): T => {
-  const style = component.props.style;
+  const style = component?.props?.style;
   if (style) {
     return StyleSheet.flatten(style)[key];
   }
+  return style;
 };
 
 export {findStyle};

--- a/src/uilib-test-renderer/helper.ts
+++ b/src/uilib-test-renderer/helper.ts
@@ -1,7 +1,7 @@
 import {StyleSheet} from 'react-native';
 
 interface Props {
-  style: any;
+  style?: any;
 }
 
 interface Component {
@@ -9,7 +9,10 @@ interface Component {
 }
 
 const findStyle = <T>(key: string, component: Component): T => {
-  return StyleSheet.flatten(component.props.style)[key];
+  const style = component.props.style;
+  if (style) {
+    return StyleSheet.flatten(style)[key];
+  }
 };
 
 export {findStyle};


### PR DESCRIPTION
## Description
uilib-test-renderer - findStyle - fix TS error: Argument of type 'ReactTestInstance' is not assignable to parameter of type 'Component'

## Changelog
uilib-test-renderer - findStyle - fix TS error: Argument of type 'ReactTestInstance' is not assignable to parameter of type 'Component'


## Additional info

