### PR TITLE
Picker settings field flex changed to flexGrow

### DIFF
--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -273,7 +273,7 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
       );
     } else if (fieldType === PickerFieldTypes.settings) {
       return (
-        <View flex row spread>
+        <View flexG row spread>
           <Text text70 style={labelStyle}>
             {others.label}
           </Text>


### PR DESCRIPTION
## Description
`Picker` - `fieldType - settings` changed the `View` wrapper `flex` to be `flexGrow` as passing `position: relative` to shrink and grow according to the parent.

## Changelog
`Picker` - `fieldType - settings` changed the wrapper `flex` to `flexGrow` to solve flex issues according to the parent style.

## Additional info
ticket 4018
