### PR TITLE
TextInput - keyboardType="number-pad" with external keyboard

### DIFF
--- a/lib/ios/reactnativeuilib/keyboardtrackingview/ObservingInputAccessoryViewTemp.m
+++ b/lib/ios/reactnativeuilib/keyboardtrackingview/ObservingInputAccessoryViewTemp.m
@@ -129,7 +129,9 @@
 {
     _keyboardState = KeyboardStateShown;
     
-    [self invalidateIntrinsicContentSize];
+    if (_keyboardHeight > 0) { //prevent triggering observeValueForKeyPath if an external keyboard is in use
+        [self invalidateIntrinsicContentSize];
+    }
 }
 
 - (void)_keyboardWillHideNotification:(NSNotification*)notification

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uilib-native",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "homepage": "https://github.com/wix/react-native-ui-lib",
   "description": "uilib native components (separated from js components)",
   "main": "components/index.js",


### PR DESCRIPTION
## Description
TextInput - fix application halting when `keyboardType=“number-pad”` with external keyboard (not sure if Apple keyboard reproduces)

Real device only
Example screen:
```
import React, {Component} from 'react';
import {ScrollView, TextInput} from 'react-native';
import {Keyboard, View} from 'react-native-ui-lib';

export default class PlaygroundScreen extends Component {
  render() {
    return (
      <ScrollView contentContainerStyle={{flex: 1}}>
        <View flex centerV>
          <TextInput placeholder={'TextInput'} keyboardType="number-pad"/>
          <Keyboard.KeyboardAwareInsetsView/>
        </View>
      </ScrollView>
    );
  }
}
```

## Changelog
TextInput - fix application halting when `keyboardType=“number-pad”` with external keyboard (not sure if Apple keyboard reproduces)

## Additional info
Ticket 4007
