### PR TITLE
fix: [MADS-4071] clear picker value on web

### DIFF
--- a/src/components/picker/__tests__/index.spec.tsx
+++ b/src/components/picker/__tests__/index.spec.tsx
@@ -78,7 +78,7 @@ describe('Picker', () => {
     describe('Test selection', () => {
       it('Should select a single item', () => {
         const driver = getDriver();
-        expect(driver.getValue()).toEqual(undefined);
+        expect(driver.getValue()).toEqual('');
         expect(driver.isOpen()).toBeFalsy();
         driver.open();
         expect(driver.isOpen()).toBeTruthy();
@@ -89,7 +89,7 @@ describe('Picker', () => {
 
       it('Should select multiple items', () => {
         const driver = getDriver({mode: 'MULTI'});
-        expect(driver.getValue()).toEqual(undefined);
+        expect(driver.getValue()).toEqual('');
         expect(driver.isOpen()).toBeFalsy();
         driver.open();
         expect(driver.isOpen()).toBeTruthy();

--- a/src/components/picker/helpers/usePickerLabel.tsx
+++ b/src/components/picker/helpers/usePickerLabel.tsx
@@ -57,7 +57,7 @@ const usePickerLabel = (props: UsePickerLabelProps) => {
     getLabelsFromArray,
     getLabel: _getLabel,
     accessibilityInfo,
-    label: _getLabel(value)
+    label: _getLabel(value) ?? ''
   };
 };
 


### PR DESCRIPTION
## Description
<!--
Enter description to help the reviewer understand what's the change about...
-->
when passing undefined after a value already selected, it's not being cleared on the UI.

## Changelog
<!--
Add a quick message for our users about this change (include Component name, relevant props and general purpose of the PR)
-->
fix: clearing picker value on web

## Additional info
<!--
If applicable, add additional info such as link to the bug being fixed by this PR etc
-->
MADS-4071