### PR TITLE
pass the testID to the Text component

### DIFF
--- a/src/components/hint/index.tsx
+++ b/src/components/hint/index.tsx
@@ -480,7 +480,11 @@ class Hint extends Component<HintProps, HintState> {
       >
         {customContent}
         {!customContent && icon && <Image source={icon} style={[styles.icon, iconStyle]}/>}
-        {!customContent && <Text recorderTag={'unmask'} style={[styles.hintMessage, messageStyle]}>{message}</Text>}
+        {!customContent && (
+          <Text recorderTag={'unmask'} style={[styles.hintMessage, messageStyle]} testID={`${testID}.message.text`}>
+            {message}
+          </Text>
+        )}
       </View>
     );
   }


### PR DESCRIPTION
## Description
Hint passing TestID to the Text component.
We should add test for this, waiting for this [PR](https://github.com/wix/react-native-ui-lib/pull/2898) to merge first to use the new driver.

## Changelog
Hint passing TestID to the Text component.

## Additional info
ticket 3682
