### PR TITLE
Image\Overlay - support borderRadius

### DIFF
--- a/src/components/image/index.tsx
+++ b/src/components/image/index.tsx
@@ -259,6 +259,7 @@ class Image extends PureComponent<Props, State> {
             intensity={overlayIntensity}
             color={overlayColor}
             customContent={customOverlayContent}
+            borderRadius={others?.borderRadius}
           />
         )}
       </ImageView>

--- a/src/components/overlay/index.tsx
+++ b/src/components/overlay/index.tsx
@@ -1,6 +1,6 @@
 import {isUndefined} from 'lodash';
 import React, {PureComponent} from 'react';
-import {StyleSheet, Image, ImageSourcePropType} from 'react-native';
+import {StyleSheet, Image, ImageProps, ImageSourcePropType} from 'react-native';
 import {Colors} from '../../style';
 import View from '../view';
 
@@ -23,7 +23,7 @@ export enum OverlayIntensityType {
 
 export type OverlayTypeType = typeof OVERLY_TYPES[keyof typeof OVERLY_TYPES];
 
-export type OverlayTypes = {
+export type OverlayTypes = Pick<ImageProps, 'borderRadius'> & {
   /**
    * The type of overlay to set on top of the image
    */
@@ -88,7 +88,8 @@ class Overlay extends PureComponent<OverlayTypes> {
   };
 
   renderImage = (style: any, source: ImageSourcePropType) => {
-    return <Image style={[styles.container, style]} resizeMode={'stretch'} source={source}/>;
+    const {borderRadius} = this.props;
+    return <Image style={[styles.container, style]} resizeMode={'stretch'} source={source} borderRadius={borderRadius}/>;
   };
 
   getImageSource = (type?: OverlayTypeType, intensity?: OverlayTypes['intensity']) => {


### PR DESCRIPTION
## Description
Image\Overlay - support borderRadius (only via the prop, not via style)

## Changelog
Image\Overlay - support borderRadius (only via the prop, not via style)

## Additional info
Ticket 4074
