### PR TITLE
passing display undefined to svgs

### DIFF
--- a/src/components/svgImage/index.tsx
+++ b/src/components/svgImage/index.tsx
@@ -26,12 +26,12 @@ function SvgImage(props: SvgImageProps) {
   }
 
   if (isSvgUri(data)) {
-    return <SvgCssUri {...others} uri={data.uri}/>;
+    return <SvgCssUri {...others} uri={data.uri} display={undefined}/>;
   } else if (typeof data === 'string') {
-    return <SvgXml xml={data} {...others}/>;
+    return <SvgXml xml={data} {...others} display={undefined}/>;
   } else if (data) {
     const File = data; // Must be with capital letter
-    return <File {...others}/>;
+    return <File {...others} display={undefined}/>;
   }
 
   return null;


### PR DESCRIPTION
## Description
Passing undefined to display prop of Svg in order to handle svgs with `display="block"` which causes any error.
**Not sure if this should be in the change log**

## Changelog
SvgImage - Fix svgs with `display="block"` causes crashes.

## Additional info
MADS-4017
