### PR TITLE
Incubator.Slider - value updates fix flag

### DIFF
--- a/src/incubator/Slider/index.tsx
+++ b/src/incubator/Slider/index.tsx
@@ -273,8 +273,9 @@ const Slider = React.memo((props: Props) => {
   const onValueChangeThrottled = useCallback(_.throttle(value => {
     if (!didValueUpdate.current) { // NOTE: fix for GradientSlider (should be removed after fix in the GradientSlider component): don't invoke onChange when slider's value changes to prevent updates loop
       onValueChange?.(value);
+    } else {
+      didValueUpdate.current = false;
     }
-    didValueUpdate.current = false;
   }, 200), [onValueChange]);
 
   const onRangeChangeThrottled = useCallback(_.throttle((min, max) => {

--- a/src/incubator/Slider/index.tsx
+++ b/src/incubator/Slider/index.tsx
@@ -6,7 +6,7 @@ import {forwardRef, ForwardRefInjectedProps, Constants} from '../../commons/new'
 import {extractAccessibilityProps} from '../../commons/modifiers';
 import {Colors, Spacings} from '../../style';
 import {StyleUtils} from 'utils';
-import {useThemeProps} from '../../hooks';
+import {useThemeProps, useDidUpdate} from '../../hooks';
 import View from '../../components/view';
 import {ComponentStatics} from '../../typings/common';
 import {
@@ -258,7 +258,7 @@ const Slider = React.memo((props: Props) => {
     reset: () => reset()
   }));
   
-  useEffect(() => {
+  useDidUpdate(() => {
     didValueUpdate.current = true;
     setInitialPositions(trackSize.value.width);
   }, [value, setInitialPositions]);
@@ -273,9 +273,8 @@ const Slider = React.memo((props: Props) => {
   const onValueChangeThrottled = useCallback(_.throttle(value => {
     if (!didValueUpdate.current) { // NOTE: fix for GradientSlider (should be removed after fix in the GradientSlider component): don't invoke onChange when slider's value changes to prevent updates loop
       onValueChange?.(value);
-    } else {
-      didValueUpdate.current = false;
     }
+    didValueUpdate.current = false;
   }, 200), [onValueChange]);
 
   const onRangeChangeThrottled = useCallback(_.throttle((min, max) => {


### PR DESCRIPTION
## Description
Incubator.Slider - value updates fix flag

The fix is for GradientSlider which doesn't get updated since the value changes on init thus the flag turns true and onValueChange is not called on the first change.

## Changelog
Incubator.Slider - value updates fix flag

## Additional info
Fix for PR https://github.com/wix/react-native-ui-lib/pull/2994
