### PR TITLE
bottom validation message should render only if validation message sent

### DIFF
--- a/src/components/textField/index.tsx
+++ b/src/components/textField/index.tsx
@@ -198,7 +198,7 @@ const TextField = (props: InternalTextFieldProps) => {
           {/* </View> */}
         </View>
         <View row spread>
-          {validationMessagePosition === ValidationMessagePosition.BOTTOM && (
+          {others.validationMessage && validationMessagePosition === ValidationMessagePosition.BOTTOM && (
             <ValidationMessage
               enableErrors={enableErrors}
               validate={others.validate}


### PR DESCRIPTION
## Description
`TextField` bottom view should render the `validationMessage` only if the user passed `validationMessage`.
Currently the `validationMessage` renders most of the times because the default value for `validationMessagePosition` is `bottom` and break the alignment when the user passes `bottomAccessory` by it self.

## Changelog
`TextField` bottom view should render the `validationMessage` only if the user passed `validationMessage`.

## Additional info
