### PR TITLE
fix: [MADS-4118] filter and settings picker placeholder on web

### DIFF
--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -268,7 +268,7 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
     if (fieldType === PickerFieldTypes.filter) {
       return (
         <Text text70 numberOfLines={1} style={others.style}>
-          {label ?? others.placeholder}
+          {_.isEmpty(label) ? others.placeholder : label}
         </Text>
       );
     } else if (fieldType === PickerFieldTypes.settings) {
@@ -278,7 +278,7 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
             {others.label}
           </Text>
           <Text text70 $textPrimary style={others.style}>
-            {label ?? others.placeholder}
+            {_.isEmpty(label) ? others.placeholder : label}
           </Text>
         </View>
       );


### PR DESCRIPTION
## Description
<!--
Enter description to help the reviewer understand what's the change about...
-->
because of https://github.com/wix/react-native-ui-lib/pull/2986, the placeholder stopped being rendered for `settings` and `filter` Picker.

## Changelog
<!--
Add a quick message for our users about this change (include Component name, relevant props and general purpose of the PR)
-->
fix: filter and settings picker placeholder on web

## Additional info
<!--
If applicable, add additional info such as link to the bug being fixed by this PR etc
-->
MADS-4118