### PR TITLE
Fix/ Slider - call onSeekStart only on start

### DIFF
--- a/src/incubator/Slider/Thumb.tsx
+++ b/src/incubator/Slider/Thumb.tsx
@@ -56,11 +56,11 @@ const Thumb = (props: ThumbProps) => {
 
   const gesture = Gesture.Pan()
     .onBegin(() => {
+      onSeekStart?.();
       isPressed.value = true;
       lastOffset.value = offset.value;
     })
     .onUpdate(e => {
-      onSeekStart?.();
       let newX = lastOffset.value + e.translationX * (shouldDisableRTL ? 1 : rtlFix);
 
       if (newX < start.value) {


### PR DESCRIPTION
## Description
Fix/ call onSeekStart only on start (today it's triggered on every value change)

## Changelog
Slider - fix call onSeekStart only on start

## Additional info
<!--
If applicable, add additional info such as link to the bug being fixed by this PR etc
-->
