### PR TITLE
Fix Toast not swipable when rendered with children.

### DIFF
--- a/src/incubator/toast/index.tsx
+++ b/src/incubator/toast/index.tsx
@@ -184,16 +184,6 @@ const Toast = (props: PropsWithChildren<ToastProps>) => {
   };
 
   const renderToastContent = () => {
-    const content = !_.isUndefined(children) ? (
-      children
-    ) : (
-      <View style={[styles.toastContent, style, backgroundColor ? {backgroundColor} : undefined]}>
-        {renderIcon()}
-        {renderMessage()}
-        {renderRightElement()}
-      </View>
-    );
-
     return (
       <PanView
         directions={swipeable ? directions.current : []}
@@ -203,7 +193,13 @@ const Toast = (props: PropsWithChildren<ToastProps>) => {
         onDismiss={handleDismiss}
         threshold={THRESHOLD}
       >
-        {content}
+        {children ?? (
+          <View style={[styles.toastContent, style, backgroundColor ? {backgroundColor} : undefined]}>
+            {renderIcon()}
+            {renderMessage()}
+            {renderRightElement()}
+          </View>
+        )}
       </PanView>
     );
   };

--- a/src/incubator/toast/index.tsx
+++ b/src/incubator/toast/index.tsx
@@ -184,9 +184,15 @@ const Toast = (props: PropsWithChildren<ToastProps>) => {
   };
 
   const renderToastContent = () => {
-    if (!_.isUndefined(children)) {
-      return children;
-    }
+    const content = !_.isUndefined(children) ? (
+      children
+    ) : (
+      <View style={[styles.toastContent, style, backgroundColor ? {backgroundColor} : undefined]}>
+        {renderIcon()}
+        {renderMessage()}
+        {renderRightElement()}
+      </View>
+    );
 
     return (
       <PanView
@@ -197,11 +203,7 @@ const Toast = (props: PropsWithChildren<ToastProps>) => {
         onDismiss={handleDismiss}
         threshold={THRESHOLD}
       >
-        <View style={[styles.toastContent, style, backgroundColor ? {backgroundColor} : undefined]}>
-          {renderIcon()}
-          {renderMessage()}
-          {renderRightElement()}
-        </View>
+        {content}
       </PanView>
     );
   };

--- a/src/incubator/toast/index.tsx
+++ b/src/incubator/toast/index.tsx
@@ -7,7 +7,6 @@ import {
   ViewStyle,
   LayoutChangeEvent
 } from 'react-native';
-import _ from 'lodash';
 import {Constants, asBaseComponent} from '../../commons/new';
 import {useDidUpdate} from '../../hooks';
 import {Colors, BorderRadiuses, Spacings, Typography, Shadows} from 'style';


### PR DESCRIPTION
## Description
This fixes an issue where the pan view in not rendered when the toast is rendered with children making in unswipable

## Changelog
Toast - fix PanView not rendered with children.

## Additional info
MADS-4134
