### PR TITLE
Fix/wheel picker initial value on change

### DIFF
--- a/src/components/WheelPicker/WheelPicker.driver.tsx
+++ b/src/components/WheelPicker/WheelPicker.driver.tsx
@@ -14,6 +14,7 @@ export const WheelPickerDriver = (props: ComponentProps) => {
   const itemsLength = listDriver.getElement().props.data?.length ?? 0;
 
   const moveToItem = (index: number, itemHeight: number = ITEM_HEIGHT, numberOfRows: number = itemsLength) => {
+    listDriver.triggerEvent('onScrollBeginDrag');
     listDriver.triggerEvent('onMomentumScrollEnd', {
       contentOffset: {x: 0, y: itemHeight * index},
       contentSize: {height: numberOfRows * itemHeight, width: 400},

--- a/src/components/WheelPicker/index.tsx
+++ b/src/components/WheelPicker/index.tsx
@@ -170,11 +170,12 @@ const WheelPicker = <T extends WheelPickerItemValue>(props: WheelPickerProps<T>)
     !isUndefined(initialValue) && scrollToIndex(currentIndex, true);
   }, [currentIndex]);
 
+  useEffect(() => {
+    prevInitialValue.current = initialValue;
+  }, [initialValue]);
+
   const _onChange = useCallback((value: T, index: number) => {
-    if (prevInitialValue.current !== initialValue) {
-      // don't invoke 'onChange' if 'initialValue' changed
-      prevInitialValue.current = initialValue;
-    } else {
+    if (prevInitialValue.current === initialValue) {
       onChange?.(value, index);
     }
   },

--- a/src/components/WheelPicker/index.tsx
+++ b/src/components/WheelPicker/index.tsx
@@ -180,7 +180,7 @@ const WheelPicker = <T extends WheelPickerItemValue>(props: WheelPickerProps<T>)
   },
   [onChange]);
 
-  const invokeNextOnChange = useCallback(() => {
+  const disableOnChangeSkip = useCallback(() => {
     shouldSkipNextOnChange.current = false;
   }, []);
 
@@ -363,7 +363,7 @@ const WheelPicker = <T extends WheelPickerItemValue>(props: WheelPickerProps<T>)
             onScroll={scrollHandler}
             onMomentumScrollEnd={onValueChange}
             showsVerticalScrollIndicator={false}
-            onScrollBeginDrag={invokeNextOnChange} // user dragged wheel.
+            onScrollBeginDrag={disableOnChangeSkip} // user dragged wheel.
             // @ts-ignore
             ref={scrollView}
             // @ts-expect-error

--- a/src/components/WheelPicker/index.tsx
+++ b/src/components/WheelPicker/index.tsx
@@ -148,7 +148,7 @@ const WheelPicker = <T extends WheelPickerItemValue>(props: WheelPickerProps<T>)
     preferredNumVisibleRows: numberOfVisibleRows
   });
 
-  const shouldSkipNextOnChange = useRef(true);
+  const shouldSkipNextOnChange = useRef(false);
   const prevIndex = useRef(currentIndex);
   const [flatListWidth, setFlatListWidth] = useState(0);
   const keyExtractor = useCallback((item: WheelPickerItemProps<T>, index: number) => `${item}.${index}`, []);

--- a/src/components/WheelPicker/index.tsx
+++ b/src/components/WheelPicker/index.tsx
@@ -170,12 +170,11 @@ const WheelPicker = <T extends WheelPickerItemValue>(props: WheelPickerProps<T>)
     !isUndefined(initialValue) && scrollToIndex(currentIndex, true);
   }, [currentIndex]);
 
-  useEffect(() => {
-    prevInitialValue.current = initialValue;
-  }, [initialValue]);
-
   const _onChange = useCallback((value: T, index: number) => {
-    if (prevInitialValue.current === initialValue) {
+    if (prevInitialValue.current !== initialValue) {
+      // don't invoke 'onChange' if 'initialValue' changed
+      prevInitialValue.current = initialValue;
+    } else {
       onChange?.(value, index);
     }
   },

--- a/src/components/WheelPicker/index.tsx
+++ b/src/components/WheelPicker/index.tsx
@@ -148,7 +148,7 @@ const WheelPicker = <T extends WheelPickerItemValue>(props: WheelPickerProps<T>)
     preferredNumVisibleRows: numberOfVisibleRows
   });
 
-  const shouldInvokeOnChange = useRef(false);
+  const shouldSkipNextOnChange = useRef(true);
   const prevIndex = useRef(currentIndex);
   const [flatListWidth, setFlatListWidth] = useState(0);
   const keyExtractor = useCallback((item: WheelPickerItemProps<T>, index: number) => `${item}.${index}`, []);
@@ -168,20 +168,20 @@ const WheelPicker = <T extends WheelPickerItemValue>(props: WheelPickerProps<T>)
   useEffect(() => {
     // This effect making sure to reset index if initialValue has changed
     if (!isUndefined(initialValue)) {
-      shouldInvokeOnChange.current = false;
+      shouldSkipNextOnChange.current = true;
       scrollToIndex(currentIndex, true);
     }
   }, [currentIndex]);
 
   const _onChange = useCallback((value: T, index: number) => {
-    if (shouldInvokeOnChange.current) {
+    if (!shouldSkipNextOnChange.current) {
       onChange?.(value, index);
     }
   },
   [onChange]);
 
-  const enableOnChangeInvocation = useCallback(() => {
-    shouldInvokeOnChange.current = true;
+  const invokeNextOnChange = useCallback(() => {
+    shouldSkipNextOnChange.current = false;
   }, []);
 
   const onValueChange = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
@@ -363,7 +363,7 @@ const WheelPicker = <T extends WheelPickerItemValue>(props: WheelPickerProps<T>)
             onScroll={scrollHandler}
             onMomentumScrollEnd={onValueChange}
             showsVerticalScrollIndicator={false}
-            onScrollBeginDrag={enableOnChangeInvocation} // user dragged wheel.
+            onScrollBeginDrag={invokeNextOnChange} // user dragged wheel.
             // @ts-ignore
             ref={scrollView}
             // @ts-expect-error


### PR DESCRIPTION
## Description
The WheelPicker was not invoking `onChange` if the `initialValue` was changed right after `onChange` was called. I added a handling for wether the drag is a user or a programatic scroll.

## Changelog
WheelPicker - Fix onChange not called when initial value is changed.

## Additional info
MADS-4145