### PR TITLE
fix onChange not invoked when used with initial value

### DIFF
--- a/src/components/WheelPicker/index.tsx
+++ b/src/components/WheelPicker/index.tsx
@@ -216,6 +216,7 @@ const WheelPicker = <T extends WheelPickerItemValue>(props: WheelPickerProps<T>)
   };
 
   const selectItem = useCallback((index: number) => {
+    shouldSkipNextOnChange.current = false;
     scrollToIndex(index, true);
   },
   [itemHeight]);


### PR DESCRIPTION
## Description
Another fix for the wheel picker. When selecting an Item (if the `WheelPicker` has an initialValue, It was skipping the onChange).

## Changelog
WheelPicker - Fix onChange not called when selecting an item.

## Additional info
MADS-4145
