### PR TITLE
Revert to #3012

### DIFF
--- a/src/components/textField/index.tsx
+++ b/src/components/textField/index.tsx
@@ -198,7 +198,7 @@ const TextField = (props: InternalTextFieldProps) => {
           {/* </View> */}
         </View>
         <View row spread>
-          {others.validationMessage && validationMessagePosition === ValidationMessagePosition.BOTTOM && (
+          {validationMessagePosition === ValidationMessagePosition.BOTTOM && (
             <ValidationMessage
               enableErrors={enableErrors}
               validate={others.validate}


### PR DESCRIPTION
## Description
Revert to #3012 . It was causing layouting problems with modules.

## Changelog
TextField - Reverted validation message block not rendered by default.

## Additional info
MADS-4147, MADS-4143
