### PR TITLE
Button render Icon if it's web and typeof source is string - base64

### DIFF
--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -303,7 +303,7 @@ class Button extends PureComponent<Props, ButtonState> {
       if (typeof iconSource === 'function') {
         return iconSource(iconStyle);
       } else {
-        if (Constants.isWeb) {
+        if (Constants.isWeb && typeof iconSource === 'string') {
           return (
             <Icon
               style={iconStyle}


### PR DESCRIPTION
## Description
Button render Image as `iconSource`.
Button support image source type for icon in web, if the type isn't string (object and etc) it will render Image.

## Changelog
Button support image source type for icon in web.

## Additional info
ticket 3791
