### PR TITLE
Fix/carousel initial page on android

### DIFF
--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -163,6 +163,7 @@ class Carousel extends Component<CarouselProps, CarouselState> {
 
   updateOffset = (animated = false) => {
     const {x, y} = presenter.calcOffset(this.props, this.state);
+    
     if (this.carousel?.current) {
       this.carousel.current.scrollTo({x, y, animated});
 

--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -163,7 +163,6 @@ class Carousel extends Component<CarouselProps, CarouselState> {
 
   updateOffset = (animated = false) => {
     const {x, y} = presenter.calcOffset(this.props, this.state);
-
     if (this.carousel?.current) {
       this.carousel.current.scrollTo({x, y, animated});
 
@@ -520,7 +519,7 @@ class Carousel extends Component<CarouselProps, CarouselState> {
           pagingEnabled={this.shouldEnablePagination()}
           snapToOffsets={snapToOffsets}
           contentOffset={contentOffset}
-          // onContentSizeChange={this.onContentSizeChange}
+          onContentSizeChange={this.onContentSizeChange}
           onMomentumScrollEnd={this.onMomentumScrollEnd}
           style={_style}
         >

--- a/src/components/carousel/index.tsx
+++ b/src/components/carousel/index.tsx
@@ -163,7 +163,7 @@ class Carousel extends Component<CarouselProps, CarouselState> {
 
   updateOffset = (animated = false) => {
     const {x, y} = presenter.calcOffset(this.props, this.state);
-    
+
     if (this.carousel?.current) {
       this.carousel.current.scrollTo({x, y, animated});
 


### PR DESCRIPTION
## Description
Fix for the carousel initial page rendering. Android had a bug where on RTL with initialPage 0 it would start with a different initial page.

## Changelog
Carousel - Fix initial page on android rtl.

## Additional info
MADS-3895
