### PR TITLE
Bug fixed TextField style error: right operand of 'in' is not an object

### DIFF
--- a/src/components/textField/Input.tsx
+++ b/src/components/textField/Input.tsx
@@ -62,7 +62,7 @@ const Input = ({
   return (
     <TextInput
       fsTagName={recorderTag}
-      style={[styles.input, !!inputColor && {color: inputColor}, style, Constants.isWeb && styles.webStyle]}
+      style={[styles.input, !!inputColor && {color: inputColor}, style, Constants.isWeb ? styles.webStyle : undefined]}
       {...props}
       editable={!disabled}
       value={value}

--- a/src/components/textField/index.tsx
+++ b/src/components/textField/index.tsx
@@ -120,8 +120,9 @@ const TextField = (props: InternalTextFieldProps) => {
     return centered ? [validationMessageStyle, styles.centeredValidationMessage] : validationMessageStyle;
   }, [validationMessageStyle, centered]);
   const hasValue = fieldState.value !== undefined;
+  const hasCenteredValue = fieldState.value ? (centered && styles.centeredInput) : undefined
   const inputStyle = useMemo(() => {
-    return [typographyStyle, colorStyle, others.style, hasValue && centered && styles.centeredInput];
+    return [typographyStyle, colorStyle, others.style, hasCenteredValue];
   }, [typographyStyle, colorStyle, others.style, centered, hasValue]);
   const dummyPlaceholderStyle = useMemo(() => {
     return [inputStyle, styles.dummyPlaceholder];


### PR DESCRIPTION
## Description
If you use rn-ui-lib with NativeWind (Tailwind CSS), TextField not work with error:
```
ERROR  TypeError: right operand of 'in' is not an object

This error is located at:
    in CssInteropComponent (created by Incubator.TextField)
    in Incubator.TextField (created by TextField)
    in RCTView (created by View)
    in View
    in View (created by TextField)
```

I found and fixed 2 bugs.
1. Problem with style Platform.OS === 'web 
2. Problem with style hasValue and centred.

## Changelog
Fixed TextField + NativeWind style error

## Additional info
<!--
If applicable, add additional info such as link to the bug being fixed by this PR etc
-->
