### PR TITLE
refactor components to use Shadows presets

### DIFF
--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import React, {PureComponent} from 'react';
 import {Platform, StyleSheet, LayoutAnimation, LayoutChangeEvent, ImageStyle, TextStyle} from 'react-native';
 import {asBaseComponent, forwardRef, Constants} from '../../commons/new';
-import {Colors, Typography, BorderRadiuses} from 'style';
+import {Colors, Typography, BorderRadiuses, Shadows} from 'style';
 import TouchableOpacity from '../touchableOpacity';
 import type {Dictionary, ComponentStatics} from '../../typings/common';
 import Text from '../text';
@@ -409,10 +409,7 @@ function createStyles() {
       backgroundColor: undefined
     },
     shadowStyle: {
-      shadowOffset: {height: 5, width: 0},
-      shadowOpacity: 0.35,
-      shadowRadius: 9.5,
-      elevation: 2
+      ...Shadows.sh20.bottom
     },
     text: {
       backgroundColor: 'transparent',

--- a/src/components/card/index.tsx
+++ b/src/components/card/index.tsx
@@ -1,9 +1,16 @@
 import _ from 'lodash';
 import React, {PureComponent} from 'react';
 import {StyleSheet, Animated, StyleProp, ViewStyle} from 'react-native';
-import {Colors, BorderRadiuses} from '../../style';
+import {Colors, BorderRadiuses, Shadows} from '../../style';
 // import {PureBaseComponent} from '../../commons';
-import {Constants, asBaseComponent, forwardRef, BaseComponentInjectedProps, ForwardRefInjectedProps, MarginModifiers} from '../../commons/new';
+import {
+  Constants,
+  asBaseComponent,
+  forwardRef,
+  BaseComponentInjectedProps,
+  ForwardRefInjectedProps,
+  MarginModifiers
+} from '../../commons/new';
 import View, {ViewProps} from '../view';
 import TouchableOpacity, {TouchableOpacityProps} from '../touchableOpacity';
 import Icon from '../icon';
@@ -38,7 +45,8 @@ export interface CardSelectionOptions {
 
 export {CardSectionProps};
 export type CardProps = ViewProps &
-  TouchableOpacityProps & MarginModifiers & {
+  TouchableOpacityProps &
+  MarginModifiers & {
     /**
      * card custom width
      */
@@ -308,10 +316,7 @@ function createStyles({width, height, borderRadius, selectionOptions}: CardProps
     },
     containerShadow: {
       // sh30 bottom
-      shadowColor: Colors.$backgroundNeutralIdle,
-      shadowOpacity: 0.25,
-      shadowRadius: 12,
-      shadowOffset: {height: 5, width: 0}
+      ...Shadows.sh20.bottom
     },
     blurView: {
       ...StyleSheet.absoluteFillObject,

--- a/src/components/floatingButton/index.tsx
+++ b/src/components/floatingButton/index.tsx
@@ -1,7 +1,7 @@
 import React, {PropsWithChildren, PureComponent} from 'react';
 import {StyleSheet, Animated} from 'react-native';
 import {Constants, asBaseComponent} from '../../commons/new';
-import {Colors, Spacings} from '../../style';
+import {Colors, Spacings, Shadows} from '../../style';
 import View from '../view';
 import Image from '../image';
 import Button, {ButtonProps} from '../button';
@@ -222,11 +222,7 @@ const styles = StyleSheet.create({
     height: '100%'
   },
   shadow: {
-    shadowColor: Colors.$backgroundNeutralIdle,
-    shadowOffset: {height: 5, width: 0},
-    shadowOpacity: 0.35,
-    shadowRadius: 12,
-    elevation: 2
+    ...Shadows.sh20.bottom
   },
   secondaryMargin: {
     marginTop: Spacings.s4,

--- a/src/components/stackAggregator/index.tsx
+++ b/src/components/stackAggregator/index.tsx
@@ -1,6 +1,6 @@
 import React, {useState, useMemo, useCallback, useEffect} from 'react';
 import {StyleSheet, Animated, Easing, LayoutAnimation, StyleProp, ViewStyle, LayoutChangeEvent} from 'react-native';
-import {Colors} from '../../style';
+import {Colors, Shadows} from '../../style';
 import View, {ViewProps} from '../view';
 import TouchableOpacity from '../touchableOpacity';
 import Button, {ButtonSize, ButtonProps} from '../button';
@@ -327,10 +327,7 @@ const styles = StyleSheet.create({
   },
   containerShadow: {
     backgroundColor: Colors.white,
-    shadowColor: Colors.grey40,
-    shadowOpacity: 0.25,
-    shadowRadius: 12,
-    shadowOffset: {height: 5, width: 0}
+    ...Shadows.sh20.bottom
   },
   card: {
     overflow: 'hidden',

--- a/src/components/tabController/TabBar.tsx
+++ b/src/components/tabController/TabBar.tsx
@@ -12,7 +12,7 @@ import {
   ForwardRefInjectedProps
 } from '../../commons/new';
 import View from '../view';
-import {Colors, Spacings, Typography} from '../../style';
+import {Colors, Spacings, Typography, Shadows} from '../../style';
 import FadedScrollView, {FadedScrollViewRef} from '../fadedScrollView';
 import {FaderProps} from '../fader';
 import useScrollToItem from './useScrollToItem';
@@ -351,13 +351,10 @@ const styles = StyleSheet.create({
   containerShadow: {
     ...Platform.select({
       ios: {
-        shadowColor: Colors.black,
-        shadowOpacity: 0.05,
-        shadowRadius: 2,
-        shadowOffset: {height: 6, width: 0}
+        ...Shadows.sh10.bottom
       },
       android: {
-        elevation: 5,
+        ...Shadows.sh10.bottom,
         backgroundColor: Colors.$backgroundElevated
       }
     })

--- a/src/incubator/Slider/Thumb.tsx
+++ b/src/incubator/Slider/Thumb.tsx
@@ -2,7 +2,7 @@ import React, {useCallback} from 'react';
 import {StyleSheet, ViewProps, ViewStyle, LayoutChangeEvent} from 'react-native';
 import {SharedValue, useAnimatedStyle, useSharedValue, withSpring} from 'react-native-reanimated';
 import {GestureDetector, Gesture} from 'react-native-gesture-handler';
-import {Colors} from '../../style';
+import {Shadows} from '../../style';
 import View from '../../components/view';
 import {Constants} from '../../commons/new';
 
@@ -26,7 +26,6 @@ interface ThumbProps extends ViewProps {
   enableShadow?: boolean;
 }
 
-const SHADOW_RADIUS = 4;
 const THUMB_SIZE = 24;
 
 const Thumb = (props: ThumbProps) => {
@@ -70,9 +69,11 @@ const Thumb = (props: ThumbProps) => {
         // adjust end edge
         newX = end.value;
       }
-      if (!secondary && newX <= gap || 
-        secondary && newX >= end.value - gap || 
-        newX < end.value - gap && newX > start.value + gap) {
+      if (
+        (!secondary && newX <= gap) ||
+        (secondary && newX >= end.value - gap) ||
+        (newX < end.value - gap && newX > start.value + gap)
+      ) {
         offset.value = newX;
       }
     })
@@ -124,11 +125,7 @@ const styles = StyleSheet.create({
     position: 'absolute'
   },
   thumbShadow: {
-    shadowColor: Colors.rgba(Colors.black, 0.3),
-    shadowOffset: {width: 0, height: 0},
-    shadowOpacity: 0.9,
-    shadowRadius: SHADOW_RADIUS,
-    elevation: 2
+    ...Shadows.sh10.bottom
   }
 });
 


### PR DESCRIPTION
## Description
Refactor `Button, Card, FloatingButton, Slider, StackAggregator  and TabBar` to use shadows presets

## Changelog
Refactor `Button, Card, FloatingButton, Slider, StackAggregator  and TabBar` to use shadows presets

## Additional info
ticker 3077
