### PR TITLE
Add flex to SortableList's GestureHandlerRootView

### DIFF
--- a/src/components/sortableList/index.tsx
+++ b/src/components/sortableList/index.tsx
@@ -76,7 +76,7 @@ const SortableList = <ItemT extends SortableListItemProps>(props: SortableListPr
     };
   }, [data]);
   return (
-    <GestureHandlerRootView>
+    <GestureHandlerRootView style={{flex: 1}}>
       <SortableListContext.Provider value={context}>
         <FlatList
           {...others}


### PR DESCRIPTION
## Description

Add flex to SortableList's GestureHandlerRootView to fix issue described in this [JIRA](https://jira.wixpress.com/browse/MADS-4163) ticket.

## Changelog

Add `{flex: 1}` to GestureHandlerRootView.

