### PR TITLE
Changed ComponentProps typing for amino

### DIFF
--- a/src/testkit/new/Component.driver.ts
+++ b/src/testkit/new/Component.driver.ts
@@ -3,7 +3,7 @@ import {within} from '@testing-library/react-native';
 
 export interface ComponentProps {
   renderTree: ReturnType<typeof within>; // Note: This changed was asked for integration with amino. This still gives all querying functionality.
-  testID: string;
+  testID: string | RegExp;
 }
 
 export interface ComponentDriverResult {


### PR DESCRIPTION
## Description
Added type to `testID` in the drivers typings

## Changelog
ComponentDriver - Added extra type to testID.

## Additional info
MADS-4062
