### PR TITLE
handled case of assets union

### DIFF
--- a/src/assets/Assets.ts
+++ b/src/assets/Assets.ts
@@ -42,8 +42,7 @@ function ensurePath(obj: CustomObject, path: string) {
 export class Assets {
   [key: string]: any;
 
-  loadAssetsGroup<T extends string, K extends object>(groupName: T,
-    assets: K): asserts this is AssetRecord<T, K, typeof this> {
+  loadAssetsGroup<T extends string, K extends object>(groupName: T, assets: K): asserts this is AssetRecord<typeof this, T, K> {
     if (!_.isString(groupName)) {
       throw new Error('group name should be a string');
     }

--- a/src/assets/Assets.ts
+++ b/src/assets/Assets.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {PathRecord} from '..//typings/common';
+import type {AssetRecord} from '../typings/assets';
 
 interface CustomObject {
   [key: string]: any;
@@ -42,7 +42,8 @@ function ensurePath(obj: CustomObject, path: string) {
 export class Assets {
   [key: string]: any;
 
-  loadAssetsGroup<T extends string, K extends object>(groupName: T, assets: K): asserts this is PathRecord<T, K> {
+  loadAssetsGroup<T extends string, K extends object>(groupName: T,
+    assets: K): asserts this is AssetRecord<T, K, typeof this> {
     if (!_.isString(groupName)) {
       throw new Error('group name should be a string');
     }

--- a/src/typings/assets.d.ts
+++ b/src/typings/assets.d.ts
@@ -1,12 +1,31 @@
+
+/**
+ * Adds dot at end of string.
+ */
 type DotExtendedString<T extends string> = `${T}.`;
+
+
+/**
+ * Converts path string to a an array of the path. Acts like split('.')
+ *
+ * Example: PathArray<'path1.path2.path3'> --> ['path1', 'path2', 'path3']
+ */
 type PathArray<S extends string> =
   DotExtendedString<S> extends `${infer A}.${infer B}` ? (A extends '' ? [] : [A, ...PathArray<B>]) : [];
 
-type RecRecord<Path extends string[], K extends object = {}> = Path extends [infer Next, ...infer Rest]
-  ? {[P in Next]: RecRecord<Rest, K>}
+/**
+ * Creates a nested record with the nesting of path of the strings in the array that ends with object K.
+ *
+ * Example: NestedRecord<'path1.path2', {last: number}> --> {path1: { path2: {last: number}}}
+ */
+type NestedRecord<Path extends string[], K extends object = {}> = Path extends [infer Next, ...infer Rest]
+  ? {[P in Next]: NestedRecord<Rest, K>}
   : K;
 
-type DeepGet<K extends object, T extends string> = _DeepGet<K, PathArray<T>>;
+/**
+ * Gets type of K at Path.
+ */
+type DeepGet<K extends object, Path extends string> = _DeepGet<K, PathArray<Path>>;
 
 type _DeepGet<K extends object, T extends Array<string>> = T extends [infer First, ...infer Rest]
   ? First extends keyof K
@@ -14,9 +33,20 @@ type _DeepGet<K extends object, T extends Array<string>> = T extends [infer Firs
     : never
   : K;
 
-type PathRecord<T extends string, K = {}> = RecRecord<PathArray<T>, K>;
+/**
+ * Create nested object from a PathString.
+ *
+ * Example: PathRecord<'path1.path2', {last: number}> --> {path1: { path2: {last: number}}}
+ */
+type PathRecord<T extends string, K = {}> = NestedRecord<PathArray<T>, K>;
 
-export type AssetRecord<T extends string, K extends object = {}, This extends object> = PathRecord<
-  T,
-  DeepGet<This, T> extends never ? K : DeepGet<This, T> & K
+
+/**
+ * Combines a record at Path with existing record of an object or creates it if it doesn't exist.
+ *
+ * Example: AssertRecord<{path1: {path2: {last: number}}}, 'path1.path2', {reallyLast: string}> --> {path1: {path2: {last: number; reallyLast: string}}}
+ */
+export type AssetRecord<This extends object, Path extends string, Asset extends object = {}> = PathRecord<
+  Path,
+  DeepGet<This, T> extends never ? Asset : DeepGet<This, T> & Asset
 >;

--- a/src/typings/assets.d.ts
+++ b/src/typings/assets.d.ts
@@ -1,0 +1,22 @@
+type DotExtendedString<T extends string> = `${T}.`;
+type PathArray<S extends string> =
+  DotExtendedString<S> extends `${infer A}.${infer B}` ? (A extends '' ? [] : [A, ...PathArray<B>]) : [];
+
+type RecRecord<Path extends string[], K extends object = {}> = Path extends [infer Next, ...infer Rest]
+  ? {[P in Next]: RecRecord<Rest, K>}
+  : K;
+
+type DeepGet<K extends object, T extends string> = _DeepGet<K, PathArray<T>>;
+
+type _DeepGet<K extends object, T extends Array<string>> = T extends [infer First, ...infer Rest]
+  ? First extends keyof K
+    ? _DeepGet<K[First], Rest>
+    : never
+  : K;
+
+type PathRecord<T extends string, K = {}> = RecRecord<PathArray<T>, K>;
+
+export type AssetRecord<T extends string, K extends object = {}, This extends object> = PathRecord<
+  T,
+  DeepGet<This, T> extends never ? K : DeepGet<This, T> & K
+>;

--- a/src/typings/assets.d.ts
+++ b/src/typings/assets.d.ts
@@ -48,5 +48,5 @@ type PathRecord<T extends string, K = {}> = NestedRecord<PathArray<T>, K>;
  */
 export type AssetRecord<This extends object, Path extends string, Asset extends object = {}> = PathRecord<
   Path,
-  DeepGet<This, T> extends never ? Asset : DeepGet<This, T> & Asset
+  DeepGet<This, Path> extends never ? Asset : (DeepGet<This, Path> & Asset)
 >;

--- a/src/typings/common.d.ts
+++ b/src/typings/common.d.ts
@@ -10,14 +10,3 @@ export type ExtendTypeWith<T extends Constructor<any>, OtherObject extends objec
 export type Dictionary<TYPE> = {[key: string]: TYPE};
 
 export type ComponentStatics<T> = Pick<T, keyof T>;
-
-type DotExtendedString<T extends string> = `${T}.`;
-export type PathArray<S extends string> = DotExtendedString<S> extends `${infer A}.${infer B}` ?
-  A extends '' ? [] : [A, ...PathArray<B>]
-  : [];
-
-export type RecRecord<Path extends string[], K = {}> = Path extends [infer Next, ...infer Rest] ?
-  {[P in Next] : RecRecord<Rest, K>}
-  : K;
-
-export type PathRecord<T extends string, K = {}> = RecRecord<PathArray<T>, K>;


### PR DESCRIPTION
## Description
Fixed typings when assets where loaded to an already loaded path. When loading to an already loaded path the type was overridden and not combined. 

## Changelog
Assets - Fix loading assets typings to preloaded path.

## Additional info
MADS-4126
