### PR TITLE
deprecate children prop

### DIFF
--- a/src/components/picker/helpers/usePickerMigrationWarnings.tsx
+++ b/src/components/picker/helpers/usePickerMigrationWarnings.tsx
@@ -4,10 +4,10 @@ import {LogService} from '../../../services';
 import {PickerProps, PickerModes} from '../types';
 
 // @ts-expect-error TODO: Remove this whole file when migration is completed
-type UsePickerMigrationWarnings = Pick<PickerProps, 'value' | 'mode' | 'useNativePicker' | 'children'>;
+type UsePickerMigrationWarnings = Pick<PickerProps, 'value' | 'mode' | 'useNativePicker'>;
 
 const usePickerMigrationWarnings = (props: UsePickerMigrationWarnings) => {
-  const {value, mode, useNativePicker, children} = props;
+  const {value, mode, useNativePicker} = props;
   useEffect(() => {
     if (mode === PickerModes.SINGLE && Array.isArray(value)) {
       LogService.warn('Picker in SINGLE mode cannot accept an array for value');
@@ -22,10 +22,6 @@ const usePickerMigrationWarnings = (props: UsePickerMigrationWarnings) => {
 
     if (useNativePicker) {
       LogService.warn(`UILib Picker will stop supporting the 'useNativePicker' prop soon, please pass instead the 'useWheelPicker' prop and handle relevant TextField migration if required to`);
-    }
-
-    if (children) {
-      LogService.warn(`UILib Picker will stop supporting the 'children' prop soon, please pass 'items' prop instead`);
     }
   }, []);
 };

--- a/src/components/picker/helpers/usePickerMigrationWarnings.tsx
+++ b/src/components/picker/helpers/usePickerMigrationWarnings.tsx
@@ -4,10 +4,10 @@ import {LogService} from '../../../services';
 import {PickerProps, PickerModes} from '../types';
 
 // @ts-expect-error TODO: Remove this whole file when migration is completed
-type UsePickerMigrationWarnings = Pick<PickerProps, 'value' | 'mode' | 'useNativePicker'>;
+type UsePickerMigrationWarnings = Pick<PickerProps, 'value' | 'mode' | 'useNativePicker' | 'children'>;
 
 const usePickerMigrationWarnings = (props: UsePickerMigrationWarnings) => {
-  const {value, mode, useNativePicker} = props;
+  const {value, mode, useNativePicker, children} = props;
   useEffect(() => {
     if (mode === PickerModes.SINGLE && Array.isArray(value)) {
       LogService.warn('Picker in SINGLE mode cannot accept an array for value');
@@ -22,6 +22,10 @@ const usePickerMigrationWarnings = (props: UsePickerMigrationWarnings) => {
 
     if (useNativePicker) {
       LogService.warn(`UILib Picker will stop supporting the 'useNativePicker' prop soon, please pass instead the 'useWheelPicker' prop and handle relevant TextField migration if required to`);
+    }
+
+    if (children) {
+      LogService.warn(`UILib Picker will stop supporting the 'children' prop soon, please pass 'items' prop instead`);
     }
   }, []);
 };

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -102,7 +102,7 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
 
   useEffect(() => {
     if (children) {
-      LogService.warn(`UILib Picker will stop supporting the 'children' prop in the next major version., please pass 'items' prop instead`);
+      LogService.warn(`UILib Picker will stop supporting the 'children' prop in the next major version, please pass 'items' prop instead`);
     }
   }, []);
 

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -15,6 +15,7 @@ import TextField from '../textField';
 import Icon from '../icon';
 import View from '../view';
 import Text from '../text';
+import {LogService} from '../../services';
 // import NativePicker from './NativePicker';
 import PickerItemsList from './PickerItemsList';
 import PickerItem from './PickerItem';
@@ -98,6 +99,12 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
 
   const [selectedItemPosition, setSelectedItemPosition] = useState(0);
   const [items, setItems] = useState(propItems || extractPickerItems(themeProps));
+
+  useEffect(() => {
+    if (children) {
+      LogService.warn(`UILib Picker will stop supporting the 'children' prop in the next major version., please pass 'items' prop instead`);
+    }
+  }, []);
 
   useEffect(() => {
     if (propItems) {

--- a/src/components/picker/types.tsx
+++ b/src/components/picker/types.tsx
@@ -149,7 +149,7 @@ export type PickerBaseProps = Omit<NewTextFieldProps, 'value' | 'onChange'> & {
   /**
    * Render a custom header for Picker's dialog
    */
-  renderCustomDialogHeader?: (callbacks: {onDone?: () => void, onCancel?: ()=> void}) => React.ReactElement;
+  renderCustomDialogHeader?: (callbacks: {onDone?: () => void; onCancel?: () => void}) => React.ReactElement;
   // /**
   //  * @deprecated pass useWheelPicker prop instead
   //  * Allow to use the native picker solution (different style for iOS and Android)
@@ -187,6 +187,9 @@ export type PickerBaseProps = Omit<NewTextFieldProps, 'value' | 'onChange'> & {
    * Component test id
    */
   testID?: string;
+  /**
+   * @deprecated
+   */
   children?: ReactNode | undefined;
 };
 


### PR DESCRIPTION
## Description
Picker children prop deprecation.
As part of the Picker refactor we are deprecating the children prop and moving to use the items prop.
Children cleanup from Picker internal code will be done after merging this [PR](https://github.com/wix/react-native-ui-lib/pull/3070/files).

## Changelog
Picker children prop deprecation.

## Additional info
MADS-4180
