### PR TITLE
remove migrate prop, finish deprecation

### DIFF
--- a/demo/src/screens/realExamples/ProductPage/index.tsx
+++ b/demo/src/screens/realExamples/ProductPage/index.tsx
@@ -75,7 +75,6 @@ class Product extends Component {
 
           <View marginT-s2>
             <Picker
-              migrate
               value={selectedColor}
               onChange={(value: PickerValue) => this.setState({selectedColor: value})}
               trailingAccessory={
@@ -94,7 +93,6 @@ class Product extends Component {
               })}
             </Picker>
             <Picker
-              migrate
               value={selectedSize}
               onChange={(value: PickerValue) => this.setState({selectedSize: value})}
             >

--- a/eslint-rules/tests/component_prop_deprecation.json
+++ b/eslint-rules/tests/component_prop_deprecation.json
@@ -78,16 +78,5 @@
         "fix": {"propName": "subtitle"}
       }
     ]
-  }, 
-  {
-    "component": "Picker",
-    "source": "module-with-deprecations",
-    "props": [
-      {
-        "prop": "migrate",
-        "message": "Please make sure to pass the 'migrate' prop.",
-        "isRequired": true
-      }
-    ]
   }
 ]

--- a/src/components/picker/PickerItem.tsx
+++ b/src/components/picker/PickerItem.tsx
@@ -11,7 +11,7 @@ import Image from '../image';
 import Text from '../text';
 import {getItemLabel, isItemSelected} from './PickerPresenter';
 import PickerContext from './PickerContext';
-import {PickerItemProps, PickerSingleValue} from './types';
+import {PickerItemProps} from './types';
 
 /**
  * @description: Picker.Item, for configuring the Picker's selectable options
@@ -29,10 +29,8 @@ const PickerItem = (props: PickerItemProps) => {
     testID
   } = props;
   const context = useContext(PickerContext);
-  const {migrate} = context;
   const customRenderItem = context.renderItem || props.renderItem;
-  // @ts-expect-error TODO: fix after removing migrate prop completely
-  const itemValue = !migrate && typeof value === 'object' ? value?.value : value;
+  const itemValue = value;
   const isSelected = isItemSelected(itemValue, context.value);
   const itemLabel = getItemLabel(label, value, props.getItemLabel || context.getItemLabel);
   const selectedCounter = context.selectionLimit && _.isArray(context.value) && context.value?.length;
@@ -65,16 +63,12 @@ const PickerItem = (props: PickerItemProps) => {
   const _onPress = useCallback(async (props: any) => {
     // Using !(await onPress?.(item)) does not work properly when onPress is not sent
     // We have to explicitly state `false` so a synchronous void (undefined) will still work as expected
-    if (onPress && await onPress(context.isMultiMode ? !isSelected : undefined, props) === false) {
+    if (onPress && (await onPress(context.isMultiMode ? !isSelected : undefined, props)) === false) {
       return;
     }
-    if (migrate) {
-      context.onPress(value);
-    } else {
-      // @ts-expect-error TODO: fix after removing migrate prop completely
-      context.onPress(typeof value === 'object' || context.isMultiMode ? value : ({value, label: itemLabel}) as PickerSingleValue);
-    }
-  }, [migrate, value, context.onPress, onPress]);
+    context.onPress(value);
+  },
+  [value, context.onPress, onPress]);
 
   const onSelectedLayout = useCallback((...args: any[]) => {
     _.invoke(context, 'onSelectedLayout', ...args);

--- a/src/components/picker/PickerPresenter.ts
+++ b/src/components/picker/PickerPresenter.ts
@@ -19,8 +19,7 @@ export function isItemSelected(childValue: PickerSingleValue, selectedValue?: Pi
   if (Array.isArray(selectedValue)) {
     isSelected =
       _.find(selectedValue, v => {
-        // @ts-expect-error TODO: fix after removing migrate prop completely
-        return v === childValue || (typeof v === 'object' && v?.value === childValue);
+        return v === childValue;
       }) !== undefined;
   } else {
     isSelected = childValue === selectedValue;

--- a/src/components/picker/helpers/usePickerSelection.tsx
+++ b/src/components/picker/helpers/usePickerSelection.tsx
@@ -3,13 +3,13 @@ import _ from 'lodash';
 import {PickerProps, PickerValue, PickerSingleValue, PickerMultiValue, PickerModes} from '../types';
 
 interface UsePickerSelectionProps
-  extends Pick<PickerProps, 'migrate' | 'value' | 'onChange' | 'getItemValue' | 'topBarProps' | 'mode'> {
+  extends Pick<PickerProps, 'value' | 'onChange' | 'getItemValue' | 'topBarProps' | 'mode'> {
   pickerExpandableRef: RefObject<any>;
   setSearchValue: (searchValue: string) => void;
 }
 
 const usePickerSelection = (props: UsePickerSelectionProps) => {
-  const {migrate, value, onChange, topBarProps, pickerExpandableRef, getItemValue, setSearchValue, mode} = props;
+  const {value, onChange, topBarProps, pickerExpandableRef, getItemValue, setSearchValue, mode} = props;
   const [multiDraftValue, setMultiDraftValue] = useState(value as PickerMultiValue);
   const [multiFinalValue, setMultiFinalValue] = useState(value as PickerMultiValue);
 
@@ -29,14 +29,8 @@ const usePickerSelection = (props: UsePickerSelectionProps) => {
   [onChange]);
 
   const toggleItemSelection = useCallback((item: PickerSingleValue) => {
-    let newValue;
     const itemAsArray = [item];
-    if (!migrate) {
-      newValue = _.xorBy(multiDraftValue, itemAsArray, getItemValue || 'value');
-    } else {
-      newValue = _.xor(multiDraftValue, itemAsArray);
-    }
-
+    const newValue = _.xor(multiDraftValue, itemAsArray);
     setMultiDraftValue(newValue);
   },
   [multiDraftValue, getItemValue]);

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -88,7 +88,6 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
     children,
     useSafeArea,
     // TODO: Remove migrate props and migrate code
-    migrate = true,
     accessibilityLabel,
     accessibilityHint,
     items: propItems,
@@ -117,7 +116,6 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
     onSearchChange: _onSearchChange
   } = usePickerSearch({showSearch, onSearchChange, getItemLabel, children});
   const {multiDraftValue, onDoneSelecting, toggleItemSelection, cancelSelect} = usePickerSelection({
-    migrate,
     value,
     onChange,
     pickerExpandableRef: pickerExpandable,
@@ -143,10 +141,8 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
   }, []);
 
   const contextValue = useMemo(() => {
-    // @ts-expect-error cleanup after removing migrate prop
-    const pickerValue = !migrate && typeof value === 'object' && !_.isArray(value) ? value?.value : value;
+    const pickerValue = value;
     return {
-      migrate,
       value: mode === PickerModes.MULTI ? multiDraftValue : pickerValue,
       onPress: mode === PickerModes.MULTI ? toggleItemSelection : onDoneSelecting,
       isMultiMode: mode === PickerModes.MULTI,
@@ -157,7 +153,6 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
       selectionLimit
     };
   }, [
-    migrate,
     mode,
     value,
     multiDraftValue,

--- a/src/components/picker/types.tsx
+++ b/src/components/picker/types.tsx
@@ -55,10 +55,6 @@ export type PickerBaseProps = Omit<NewTextFieldProps, 'value' | 'onChange'> & {
    */
   useDialog?: boolean;
   /**
-   * Temporary prop required for migration to Picker's new API
-   */
-  migrate?: boolean;
-  /**
    * Pass for different field type UI (form, filter or settings)
    */
   fieldType?: PickerFieldTypes | `${PickerFieldTypes}`;
@@ -149,7 +145,7 @@ export type PickerBaseProps = Omit<NewTextFieldProps, 'value' | 'onChange'> & {
   /**
    * Render a custom header for Picker's dialog
    */
-  renderCustomDialogHeader?: (callbacks: {onDone?: () => void, onCancel?: ()=> void}) => React.ReactElement;
+  renderCustomDialogHeader?: (callbacks: {onDone?: () => void; onCancel?: () => void}) => React.ReactElement;
   // /**
   //  * @deprecated pass useWheelPicker prop instead
   //  * Allow to use the native picker solution (different style for iOS and Android)
@@ -252,7 +248,7 @@ export interface PickerItemProps extends Pick<TouchableOpacityProps, 'customValu
 }
 
 export interface PickerContextProps
-  extends Pick<PickerProps, 'migrate' | 'value' | 'getItemValue' | 'getItemLabel' | 'renderItem' | 'selectionLimit'> {
+  extends Pick<PickerProps, 'value' | 'getItemValue' | 'getItemLabel' | 'renderItem' | 'selectionLimit'> {
   onPress: (value: PickerSingleValue) => void;
   isMultiMode: boolean;
   onSelectedLayout: (event: any) => any;


### PR DESCRIPTION
## Description
Picker refactor - finish prop deprecation.
Finish `migrate` prop deprecation, the `migrate` prop was in prop deprecation error phase.
**Note**: take a look at this [PR](https://github.com/wix/react-native-ui-lib/pull/2815), I checked that `0` value works.

## Changelog
Picker finish `migrate` prop deprecation.

## Additional info
MDAS - 4195