### PR TITLE
Picker render custom modal support items

### DIFF
--- a/demo/src/screens/componentScreens/PickerScreen.tsx
+++ b/demo/src/screens/componentScreens/PickerScreen.tsx
@@ -27,11 +27,11 @@ const dropdownIcon = <Icon source={dropdown} tintColor={Colors.$iconDefault}/>;
 const contacts = _.map(contactsData, (c, index) => ({...c, value: index, label: c.name}));
 
 const options = [
-  {label: 'JavaScript', value: 'js'},
-  {label: 'Java', value: 'java'},
-  {label: 'Python', value: 'python'},
-  {label: 'C++', value: 'c++', disabled: true},
-  {label: 'Perl', value: 'perl'}
+  {label: 'JavaScript', value: 'js', labelStyle: Typography.text65},
+  {label: 'Java', value: 'java', labelStyle: Typography.text65},
+  {label: 'Python', value: 'python', labelStyle: Typography.text65},
+  {label: 'C++', value: 'c++', disabled: true, labelStyle: Typography.text65},
+  {label: 'Perl', value: 'perl', labelStyle: Typography.text65}
 ];
 
 const filters = [
@@ -165,17 +165,8 @@ export default class PickerScreen extends Component {
             mode={Picker.modes.MULTI}
             trailingAccessory={dropdownIcon}
             renderCustomModal={this.renderDialog}
-          >
-            {_.map(options, option => (
-              <Picker.Item
-                key={option.value}
-                value={option.value}
-                label={option.label}
-                labelStyle={Typography.text65}
-                disabled={option.disabled}
-              />
-            ))}
-          </Picker>
+            items={options}
+          />
 
           <Picker
             label="Dialog Picker"

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -96,8 +96,8 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
   } = themeProps;
   const {preset} = others;
 
-  const [selectedItemPosition, setSelectedItemPosition] = useState(0);
-  const [items, setItems] = useState(propItems || extractPickerItems(themeProps));
+  const [selectedItemPosition, setSelectedItemPosition] = useState<number>(0);
+  const [items, setItems] = useState<PickerItemProps[]>(propItems || extractPickerItems(themeProps));
 
   useEffect(() => {
     if (propItems) {
@@ -195,6 +195,10 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
     }
   }, [fieldType, preset, themeProps.trailingAccessory]);
 
+  const renderPickerItem = useCallback((item: PickerItemProps): React.ReactElement => {
+    return <PickerItem {...item}/>;
+  }, []);
+
   const _renderCustomModal: ExpandableOverlayProps['renderCustomOverlay'] = ({
     visible,
     closeExpandable,
@@ -206,7 +210,7 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
         closeModal: closeExpandable,
         toggleModal: toggleExpandable,
         onSearchChange: _onSearchChange,
-        children,
+        children: children || (items && _.map(items, item => renderPickerItem(item))),
         // onDone is relevant to multi mode only
         onDone: () => onDoneSelecting(multiDraftValue),
         onCancel: cancelSelect

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -199,6 +199,11 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
     return <PickerItem {...item}/>;
   }, []);
 
+  const renderItems = useCallback((items: PickerProps['items']) => {
+    return items && _.map(items, item => renderPickerItem(item));
+  },
+  [renderPickerItem]);
+
   const _renderCustomModal: ExpandableOverlayProps['renderCustomOverlay'] = ({
     visible,
     closeExpandable,
@@ -210,7 +215,7 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
         closeModal: closeExpandable,
         toggleModal: toggleExpandable,
         onSearchChange: _onSearchChange,
-        children: children || (items && _.map(items, item => renderPickerItem(item))),
+        children: children || renderItems(items),
         // onDone is relevant to multi mode only
         onDone: () => onDoneSelecting(multiDraftValue),
         onCancel: cancelSelect

--- a/src/components/picker/types.tsx
+++ b/src/components/picker/types.tsx
@@ -182,7 +182,7 @@ export type PickerBaseProps = Omit<NewTextFieldProps, 'value' | 'onChange'> & {
   /**
    * Data source for Picker
    */
-  items?: Pick<PickerItemProps, 'label' | 'value' | 'disabled'>[];
+  items?: PickerItemProps[];
   /**
    * Component test id
    */


### PR DESCRIPTION
## Description
Picker support passing items when passing renderCustomModal.
When passing items the Picker index file will return array of PickerItems instead of Children to the modal props.

## Changelog
Picker support passing items when passing renderCustomModal.

## Additional info
MADS-4228
