### PR TITLE
PickerItem renderItem stronger then Picker renderItem

### DIFF
--- a/src/components/picker/PickerItem.tsx
+++ b/src/components/picker/PickerItem.tsx
@@ -30,7 +30,7 @@ const PickerItem = (props: PickerItemProps) => {
   } = props;
   const context = useContext(PickerContext);
   const {migrate} = context;
-  const customRenderItem = context.renderItem || props.renderItem;
+  const customRenderItem = props.renderItem || context.renderItem;
   // @ts-expect-error TODO: fix after removing migrate prop completely
   const itemValue = !migrate && typeof value === 'object' ? value?.value : value;
   const isSelected = isItemSelected(itemValue, context.value);


### PR DESCRIPTION
## Description
PickerItem renderItem passing to the PickerItem is stronger then renderItem from the contextValue.

## Changelog
None

## Additional info
None
