### PR TITLE
Infra/fix to assets typings

### DIFF
--- a/demo/src/assets/Assets.ts
+++ b/demo/src/assets/Assets.ts
@@ -1,4 +1,5 @@
-import {Assets} from 'react-native-ui-lib';
+import {Assets as UIAssets} from 'react-native-ui-lib';
+const Assets: typeof UIAssets = UIAssets;
 Assets.loadAssetsGroup('icons.demo', {
   chevronDown: require('./icons/chevronDown.png'),
   chevronRight: require('./icons/chevronRight.png'),

--- a/demo/src/screens/PlaygroundScreen.tsx
+++ b/demo/src/screens/PlaygroundScreen.tsx
@@ -1,7 +1,6 @@
 import React, {Component} from 'react';
 import {View, Text, Card, TextField, Button} from 'react-native-ui-lib';
 
-
 export default class PlaygroundScreen extends Component {
   render() {
     return (

--- a/demo/src/screens/PlaygroundScreen.tsx
+++ b/demo/src/screens/PlaygroundScreen.tsx
@@ -1,6 +1,7 @@
 import React, {Component} from 'react';
 import {View, Text, Card, TextField, Button} from 'react-native-ui-lib';
 
+
 export default class PlaygroundScreen extends Component {
   render() {
     return (

--- a/src/assets/Assets.ts
+++ b/src/assets/Assets.ts
@@ -40,7 +40,6 @@ function ensurePath(obj: CustomObject, path: string) {
 }
 
 export class Assets {
-  [key: string]: any;
 
   loadAssetsGroup<T extends string, K extends object>(groupName: T, assets: K): asserts this is AssetRecord<typeof this, T, K> {
     if (!_.isString(groupName)) {

--- a/src/assets/index.ts
+++ b/src/assets/index.ts
@@ -3,7 +3,9 @@ import type {icons} from './icons';
 import type {emojis} from './emojis';
 import type {images} from './images';
 
-const assetsStructure = {
+
+const assets: Assets = new Assets();
+assets.loadAssetsGroup('', {
   get icons(): typeof icons {
     return require('./icons').icons;
   },
@@ -13,8 +15,6 @@ const assetsStructure = {
   get images(): typeof images {
     return require('./images').images;
   }
-};
-
-const assets: Assets = new Assets();
-assets.loadAssetsGroup('', assetsStructure);
-export default assets as typeof assets;
+});
+const ExportedAssets: typeof assets = assets;
+export default ExportedAssets;

--- a/src/assets/index.ts
+++ b/src/assets/index.ts
@@ -3,9 +3,7 @@ import type {icons} from './icons';
 import type {emojis} from './emojis';
 import type {images} from './images';
 
-
-const assets: Assets = new Assets();
-assets.loadAssetsGroup('', {
+const assetsStructure = {
   get icons(): typeof icons {
     return require('./icons').icons;
   },
@@ -15,6 +13,8 @@ assets.loadAssetsGroup('', {
   get images(): typeof images {
     return require('./images').images;
   }
-});
-const ExportedAssets: typeof assets = assets;
-export default ExportedAssets;
+};
+
+const assets: Assets = new Assets();
+assets.loadAssetsGroup('', assetsStructure);
+export default assets as typeof assets;

--- a/src/assets/index.ts
+++ b/src/assets/index.ts
@@ -16,5 +16,4 @@ assets.loadAssetsGroup('', {
     return require('./images').images;
   }
 });
-const ExportedAssets: typeof assets = assets;
-export default ExportedAssets;
+export default assets as typeof assets;

--- a/src/typings/assets.d.ts
+++ b/src/typings/assets.d.ts
@@ -48,5 +48,5 @@ type PathRecord<T extends string, K extends object> = NestedRecord<PathToStrings
  */
 export type AssetRecord<This extends object, Path extends string, Asset extends object = {}> = PathRecord<
   Path,
-  DeepGet<This, Path> extends never ? Asset : (DeepGet<This, Path> & Asset & Record<string, any>)
+  DeepGet<This, Path> extends never ? Asset : (DeepGet<This, Path> & Asset)
 >;

--- a/src/typings/assets.d.ts
+++ b/src/typings/assets.d.ts
@@ -10,8 +10,8 @@ type DotExtendedString<T extends string> = `${T}.`;
  *
  * Example: PathArray<'path1.path2.path3'> --> ['path1', 'path2', 'path3']
  */
-type PathArray<S extends string> =
-  DotExtendedString<S> extends `${infer A}.${infer B}` ? (A extends '' ? [] : [A, ...PathArray<B>]) : [];
+type PathToStringsArray<S extends string> =
+  DotExtendedString<S> extends `${infer A}.${infer B}` ? (A extends '' ? [] : [A, ...PathToStringsArray<B>]) : [];
 
 /**
  * Creates a nested record with the nesting of path of the strings in the array that ends with object K.
@@ -19,17 +19,17 @@ type PathArray<S extends string> =
  * Example: NestedRecord<'path1.path2', {last: number}> --> {path1: { path2: {last: number}}}
  */
 type NestedRecord<Path extends string[], K extends object = {}> = Path extends [infer Next, ...infer Rest]
-  ? {[P in Next]: NestedRecord<Rest, K>}
+  ? Next extends string ? Rest extends string[] ? {[P in Next]: NestedRecord<Rest, K>} : never : never
   : K;
 
 /**
  * Gets type of K at Path.
  */
-type DeepGet<K extends object, Path extends string> = _DeepGet<K, PathArray<Path>>;
+type DeepGet<K extends object, Path extends string> = _DeepGet<K, PathToStringsArray<Path>>;
 
-type _DeepGet<K extends object, T extends Array<string>> = T extends [infer First, ...infer Rest]
-  ? First extends keyof K
-    ? _DeepGet<K[First], Rest>
+type _DeepGet<K extends {} | unknown, T extends Array<string>> = T extends [infer First, ...infer Rest]
+  ? First extends keyof K ? Rest extends string[]
+    ? _DeepGet<K[First], Rest> : never
     : never
   : K;
 
@@ -38,7 +38,7 @@ type _DeepGet<K extends object, T extends Array<string>> = T extends [infer Firs
  *
  * Example: PathRecord<'path1.path2', {last: number}> --> {path1: { path2: {last: number}}}
  */
-type PathRecord<T extends string, K = {}> = NestedRecord<PathArray<T>, K>;
+type PathRecord<T extends string, K extends object> = NestedRecord<PathToStringsArray<T>, K>;
 
 
 /**

--- a/src/typings/assets.d.ts
+++ b/src/typings/assets.d.ts
@@ -48,5 +48,5 @@ type PathRecord<T extends string, K extends object> = NestedRecord<PathToStrings
  */
 export type AssetRecord<This extends object, Path extends string, Asset extends object = {}> = PathRecord<
   Path,
-  DeepGet<This, Path> extends never ? Asset : (DeepGet<This, Path> & Asset)
+  DeepGet<This, Path> extends never ? Asset : (DeepGet<This, Path> & Asset & Record<string, any>)
 >;

--- a/src/utils/imageUtils.ts
+++ b/src/utils/imageUtils.ts
@@ -17,7 +17,7 @@ export function isBase64ImageContent(data: string) {
   return base64regex.test(base64Content);
 }
 
-export function getAsset(assetName = '', assetGroup = '') {
+export function getAsset(assetName = '', assetGroup = ''): any {
   return get(Assets, `${assetGroup}.${assetName}`);
 }
 


### PR DESCRIPTION
## Description
`[key: string] :any` was causing everything to be any even after the type guard.

## Changelog
Assets - Fixed typings

## Additional info
N/A
