### PR TITLE
types(Picker): correct type for `onChange` in multi mode

### DIFF
--- a/src/components/picker/types.tsx
+++ b/src/components/picker/types.tsx
@@ -193,11 +193,13 @@ export type PickerBaseProps = Omit<NewTextFieldProps, 'value' | 'onChange'> & {
 export type PickerPropsWithSingle = PickerBaseProps & {
   mode?: PickerModes.SINGLE;
   value?: PickerSingleValue;
+  onChange?: (value: PickerSingleValue) => void;
 };
 
 export type PickerPropsWithMulti = PickerBaseProps & {
   mode?: PickerModes.MULTI;
   value?: PickerMultiValue;
+  onChange?: (value: PickerMultiValue) => void;
 };
 
 export type PickerProps = PickerPropsWithSingle | PickerPropsWithMulti;


### PR DESCRIPTION
## Description
`onChange` is invoked with `PickerMultiValue` in multi mode, needs to be reflected in types
