### PR TITLE
TextField - fix extra margin at the bottom

### DIFF
--- a/src/components/textField/index.tsx
+++ b/src/components/textField/index.tsx
@@ -223,7 +223,7 @@ const TextField = (props: InternalTextFieldProps) => {
             />
           )}
         </View>
-        <Text $textNeutralHeavy subtext marginT-s1>{helperText}</Text>
+        {helperText && <Text $textNeutralHeavy subtext marginT-s1>{helperText}</Text>}
       </View>
     </FieldContext.Provider>
   );


### PR DESCRIPTION
## Description
TextField - fix extra margin at the bottom - don't render Text component if no helperText

## Changelog
TextField - fix extra margin at the bottom - don't render Text component if no helperText


## Additional info
hot fix
