### PR TITLE
avoid passing columnWrapperStyle when numberOfColumns is 1

### DIFF
--- a/src/components/gridList/index.tsx
+++ b/src/components/gridList/index.tsx
@@ -42,7 +42,7 @@ function GridList<T = any>(props: GridListProps<T>) {
       /* NOTE: Using style with contentContainerStyle because of RN issue with a flatlist nested in another flatlist 
       losing their contentContainerStyle */
       style={listStyle}
-      columnWrapperStyle={listColumnWrapperStyle}
+      columnWrapperStyle={numberOfColumns > 1 ? listColumnWrapperStyle : undefined}
       contentContainerStyle={listContentStyle}
       renderItem={_renderItem}
       numColumns={numberOfColumns}


### PR DESCRIPTION
## Description
We had an issue in GridList after recent changes I did
React Native doesn't like it when we pass columnWrapperStyle while number of columns is 1 

## Changelog
Fix issue in GridList when passing numColumns 1 

## Additional info
