### PR TITLE
new pickerType prop

### DIFF
--- a/demo/src/screens/componentScreens/PickerScreen.tsx
+++ b/demo/src/screens/componentScreens/PickerScreen.tsx
@@ -156,7 +156,8 @@ export default class PickerScreen extends Component {
           <Picker
             label="Wheel Picker"
             placeholder="Pick a Language"
-            useWheelPicker
+            // useWheelPicker
+            pickerType={Picker.type.WheelPicker}
             value={this.state.wheelPickerValue}
             onChange={wheelPickerValue => this.setState({wheelPickerValue})}
             trailingAccessory={<Icon source={dropdown}/>}
@@ -182,7 +183,8 @@ export default class PickerScreen extends Component {
             enableModalBlur={false}
             onChange={item => this.setState({option: item})}
             topBarProps={{title: 'Languages'}}
-            useDialog
+            // useDialog
+            pickerType={Picker.type.Dialog}
             renderCustomDialogHeader={({onDone, onCancel}) => (
               <View padding-s5 row spread>
                 <Button link label="Cancel" onPress={onCancel}/>

--- a/src/components/picker/api/picker.api.json
+++ b/src/components/picker/api/picker.api.json
@@ -31,7 +31,12 @@
       "default": "Picker.fieldTypes.FORM"
     },
     {"name": "selectionLimit", "type": "number", "description": "Limit the number of selected items"},
-    {"name": "enableModalBlur", "type": "boolean", "description": "Adds blur effect to picker modal", "note": "iOS only"},
+    {
+      "name": "enableModalBlur",
+      "type": "boolean",
+      "description": "Adds blur effect to picker modal",
+      "note": "iOS only"
+    },
     {
       "name": "renderPicker",
       "type": "(selectedItem, itemLabel) => void",
@@ -92,7 +97,13 @@
     },
     {"name": "pickerModalProps", "type": "ModalProps", "description": "Pass props to the picker modal"},
     {"name": "useSafeArea", "type": "boolean", "description": "Add safe area in the Picker modal view"},
-    {"name": "items", "type": "{label: string, value: string | number}[]", "description": "Data source for Picker"}
+    {"name": "items", "type": "{label: string, value: string | number}[]", "description": "Data source for Picker"},
+    {
+      "name": "pickerType",
+      "type": "PickerTypes",
+      "description": "Type of picker to render",
+      "default": "PickerType.Modal"
+    }
   ],
   "snippet": [
     "<Picker",
@@ -106,4 +117,3 @@
     "</Picker>"
   ]
 }
-   

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -33,7 +33,7 @@ import {
   RenderCustomModalProps,
   PickerItemsListProps,
   PickerMethods,
-  PickerTypes
+  PickerModeTypes
 } from './types';
 
 const dropdown = require('./assets/dropdown.png');
@@ -49,7 +49,7 @@ type PickerStatics = {
   modes: typeof PickerModes;
   fieldTypes: typeof PickerFieldTypes;
   extractPickerItems: typeof extractPickerItems;
-  type: typeof PickerTypes;
+  type: typeof PickerModeTypes;
 };
 
 const Picker = React.forwardRef((props: PickerProps, ref) => {
@@ -376,7 +376,7 @@ export {
   RenderCustomModalProps,
   PickerItemsListProps,
   PickerMethods,
-  PickerTypes
+  PickerModeTypes
 };
 export {Picker}; // For tests
 export default Picker as typeof Picker & PickerStatics;

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -93,7 +93,7 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
     items: propItems,
     //TODO: Remove this when migration is completed, starting of v8 (remove of useDialog and useWheelPicker)
     //@ts-expect-error
-    pickerType = PickerTypes.Modal,
+    pickerType = PickerModeTypes.Modal,
     ...others
   } = themeProps;
   const {preset} = others;
@@ -364,7 +364,7 @@ Picker.fieldTypes = PickerFieldTypes;
 // @ts-expect-error
 Picker.extractPickerItems = extractPickerItems;
 // @ts-expect-error
-Picker.type = PickerTypes;
+Picker.type = PickerModeTypes;
 
 export {
   PickerProps,

--- a/src/components/picker/types.tsx
+++ b/src/components/picker/types.tsx
@@ -19,7 +19,7 @@ export enum PickerFieldTypes {
   settings = 'settings'
 }
 
-export enum PickerTypes {
+export enum PickerModeTypes {
   Modal = 'modal',
   Dialog = 'dialog',
   WheelPicker = 'wheelPicker',
@@ -32,7 +32,7 @@ export enum PickerTypes {
 export type PickerSingleValue = string | number;
 export type PickerMultiValue = PickerSingleValue[];
 export type PickerValue = PickerSingleValue | PickerMultiValue | undefined;
-export type PickerType = PickerTypes | `${PickerTypes}`;
+export type PickerType = PickerModeTypes | `${PickerModeTypes}`;
 
 type RenderPickerOverloads<ValueType> = ValueType extends PickerValue
   ? (value?: ValueType, label?: string) => React.ReactElement
@@ -60,7 +60,7 @@ interface PickerDialogProps {
   /**
    * Type of picker to render
    */
-  pickerType: PickerTypes.Dialog;
+  pickerType: PickerModeTypes.Dialog;
   dialogProps?: ExpandableOverlayProps['dialogProps'];
 }
 
@@ -68,7 +68,7 @@ interface WheelPickerProps {
   /**
    * Type of picker to render
    */
-  pickerType: PickerTypes.WheelPicker;
+  pickerType: PickerModeTypes.WheelPicker;
   listProps?: PickerBaseProps['listProps'];
 }
 
@@ -76,11 +76,16 @@ interface CustomPickerProps {
   /**
    * Type of picker to render
    */
-  pickerType: PickerTypes.Custom;
+  pickerType: PickerModeTypes.Custom;
   renderCustomModal?: PickerBaseProps['renderCustomModal'];
 }
 
-type PickerModesPropDeprecation = {
+type PickerModeProps = (PickerDialogProps | WheelPickerProps | CustomPickerProps) & {
+  useDialog: never;
+  useWheelPicker: never;
+};
+
+type PickerPropsDeprecation = {
   /**
    * @deprecated
    * Use wheel picker instead of a modal picker
@@ -91,22 +96,41 @@ type PickerModesPropDeprecation = {
    * Use dialog instead of modal picker
    */
   useDialog?: boolean;
-};
-
-type PickerModeProps = (PickerDialogProps | WheelPickerProps | CustomPickerProps) & {
-  useDialog: never;
-  useWheelPicker: never;
-};
-
-type PickerModesFinally = PickerModesPropDeprecation | PickerModeProps;
-
-export type PickerBaseProps = Omit<NewTextFieldProps, 'value' | 'onChange'> & {
-  /* ...TextField.propTypes, */
   /**
    * @deprecated
    * Temporary prop required for migration to Picker's new API
    */
   migrate?: boolean;
+  /**
+   * @deprecated
+   * A function that extract the unique value out of the value prop in case value has a custom structure (e.g. {myValue, myLabel})
+   */
+  getItemValue?: (value: PickerValue) => any;
+  /**
+   * @deprecated
+   * A function that extract the label out of the value prop in case value has a custom structure (e.g. {myValue, myLabel})
+   */
+  getItemLabel?: (value: PickerValue) => string;
+  /**
+   * @deprecated
+   * The picker modal top bar props
+   */
+  topBarProps?: ModalTopBarProps;
+  /**
+   * @deprecated
+   * Callback for modal onShow event
+   */
+  onShow?: () => void;
+  /**
+   * @deprecated
+   */
+  children?: ReactNode | undefined;
+};
+
+type PickerTypes = Pick<PickerPropsDeprecation, 'useDialog' | 'useWheelPicker'> | PickerModeProps;
+
+export type PickerBaseProps = Omit<NewTextFieldProps, 'value' | 'onChange'> & {
+  /* ...TextField.propTypes, */
   /**
    * Pass for different field type UI (form, filter or settings)
    */
@@ -158,23 +182,9 @@ export type PickerBaseProps = Omit<NewTextFieldProps, 'value' | 'onChange'> & {
    */
   onPress?: () => void;
   /**
-   * @deprecated
-   * A function that extract the unique value out of the value prop in case value has a custom structure (e.g. {myValue, myLabel})
-   */
-  getItemValue?: (value: PickerValue) => any;
-  /**
-   * @deprecated
-   * A function that extract the label out of the value prop in case value has a custom structure (e.g. {myValue, myLabel})
-   */
-  getItemLabel?: (value: PickerValue) => string;
-  /**
    * A function that returns the label to show for the selected Picker value
    */
   getLabel?: (value: PickerValue) => string;
-  /**
-   * The picker modal top bar props
-   */
-  topBarProps?: ModalTopBarProps;
   /**
    * Show search input to filter picker items by label
    */
@@ -212,11 +222,6 @@ export type PickerBaseProps = Omit<NewTextFieldProps, 'value' | 'onChange'> & {
    */
   containerStyle?: StyleProp<ViewStyle>;
   /**
-   * @deprecated
-   * Callback for modal onShow event
-   */
-  onShow?: () => void;
-  /**
    * Add safe area in the Picker modal view
    */
   useSafeArea?: boolean;
@@ -228,10 +233,6 @@ export type PickerBaseProps = Omit<NewTextFieldProps, 'value' | 'onChange'> & {
    * Component test id
    */
   testID?: string;
-  /**
-   * @deprecated
-   */
-  children?: ReactNode | undefined;
 };
 
 export type PickerPropsWithSingle = {
@@ -246,7 +247,10 @@ export type PickerPropsWithMulti = {
   onChange?: (value: PickerMultiValue) => void;
 };
 
-export type PickerProps = (PickerPropsWithSingle | PickerPropsWithMulti) & PickerBaseProps & PickerModesFinally;
+export type PickerProps = (PickerPropsWithSingle | PickerPropsWithMulti) &
+  PickerBaseProps &
+  PickerPropsDeprecation &
+  PickerTypes;
 
 export interface PickerItemProps extends Pick<TouchableOpacityProps, 'customValue'> {
   /**

--- a/src/components/picker/types.tsx
+++ b/src/components/picker/types.tsx
@@ -19,12 +19,20 @@ export enum PickerFieldTypes {
   settings = 'settings'
 }
 
+export enum PickerTypes {
+  Modal = 'modal',
+  Dialog = 'dialog',
+  WheelPicker = 'wheelPicker',
+  Custom = 'custom'
+}
+
 // TODO: Remove type
 // type PickerValueDeprecated = {value: string | number; label: string};
 
 export type PickerSingleValue = string | number;
 export type PickerMultiValue = PickerSingleValue[];
 export type PickerValue = PickerSingleValue | PickerMultiValue | undefined;
+export type PickerType = PickerTypes | `${PickerTypes}`;
 
 type RenderPickerOverloads<ValueType> = ValueType extends PickerValue
   ? (value?: ValueType, label?: string) => React.ReactElement
@@ -48,12 +56,43 @@ export interface PickerSearchStyle {
   selectionColor?: string;
 }
 
-export type PickerBaseProps = Omit<NewTextFieldProps, 'value' | 'onChange'> & {
-  /* ...TextField.propTypes, */
+interface PickerDialogProps {
+  pickerType: PickerTypes.Dialog;
+  dialogProps?: ExpandableOverlayProps['dialogProps'];
+}
+
+interface WheelPickerProps {
+  pickerType: PickerTypes.WheelPicker;
+  listProps?: PickerBaseProps['listProps'];
+}
+
+interface CustomPickerProps {
+  pickerType: PickerTypes.Custom;
+  renderCustomModal?: PickerBaseProps['renderCustomModal'];
+}
+
+type PickerModesPropDeprecation = {
   /**
+   * @deprecated
+   * Use wheel picker instead of a modal picker
+   */
+  useWheelPicker?: boolean;
+  /**
+   * @deprecated
    * Use dialog instead of modal picker
    */
   useDialog?: boolean;
+};
+
+type PickerModeProps = (PickerDialogProps | WheelPickerProps | CustomPickerProps) & {
+  useDialog: never;
+  useWheelPicker: never;
+};
+
+type PickerModesFinally = PickerModesPropDeprecation | PickerModeProps;
+
+export type PickerBaseProps = Omit<NewTextFieldProps, 'value' | 'onChange'> & {
+  /* ...TextField.propTypes, */
   /**
    * @deprecated
    * Temporary prop required for migration to Picker's new API
@@ -150,11 +189,7 @@ export type PickerBaseProps = Omit<NewTextFieldProps, 'value' | 'onChange'> & {
   /**
    * Render a custom header for Picker's dialog
    */
-  renderCustomDialogHeader?: (callbacks: {onDone?: () => void, onCancel?: ()=> void}) => React.ReactElement;
-  /**
-   * Use wheel picker instead of a list picker
-   */
-  useWheelPicker?: boolean;
+  renderCustomDialogHeader?: (callbacks: {onDone?: () => void; onCancel?: () => void}) => React.ReactElement;
   /**
    * Pass props to the list component that wraps the picker options (allows to control FlatList behavior)
    */
@@ -190,19 +225,19 @@ export type PickerBaseProps = Omit<NewTextFieldProps, 'value' | 'onChange'> & {
   children?: ReactNode | undefined;
 };
 
-export type PickerPropsWithSingle = PickerBaseProps & {
+export type PickerPropsWithSingle = {
   mode?: PickerModes.SINGLE;
   value?: PickerSingleValue;
   onChange?: (value: PickerSingleValue) => void;
 };
 
-export type PickerPropsWithMulti = PickerBaseProps & {
+export type PickerPropsWithMulti = {
   mode?: PickerModes.MULTI;
   value?: PickerMultiValue;
   onChange?: (value: PickerMultiValue) => void;
 };
 
-export type PickerProps = PickerPropsWithSingle | PickerPropsWithMulti;
+export type PickerProps = (PickerPropsWithSingle | PickerPropsWithMulti) & PickerBaseProps & PickerModesFinally;
 
 export interface PickerItemProps extends Pick<TouchableOpacityProps, 'customValue'> {
   /**

--- a/src/components/picker/types.tsx
+++ b/src/components/picker/types.tsx
@@ -57,16 +57,25 @@ export interface PickerSearchStyle {
 }
 
 interface PickerDialogProps {
+  /**
+   * Type of picker to render
+   */
   pickerType: PickerTypes.Dialog;
   dialogProps?: ExpandableOverlayProps['dialogProps'];
 }
 
 interface WheelPickerProps {
+  /**
+   * Type of picker to render
+   */
   pickerType: PickerTypes.WheelPicker;
   listProps?: PickerBaseProps['listProps'];
 }
 
 interface CustomPickerProps {
+  /**
+   * Type of picker to render
+   */
   pickerType: PickerTypes.Custom;
   renderCustomModal?: PickerBaseProps['renderCustomModal'];
 }


### PR DESCRIPTION
## Description
New Picker prop `pickerType` to choose the "render" mode of the picker - 'modal, dialog, wheelPicker, custom".
Default value 'Modal'.
Deprecation of `useDialog, useWheelPicker`.

## Changelog
New Picker prop `pickerType` to choose the "render" mode of the picker 

## Additional info
MADS-4187