### PR TITLE
new pickerType and headerProps prop

### DIFF
--- a/demo/src/screens/componentScreens/PickerScreen.tsx
+++ b/demo/src/screens/componentScreens/PickerScreen.tsx
@@ -12,13 +12,13 @@ import {
   Assets,
   PanningProvider,
   Typography,
-  PickerProps,
   RenderCustomModalProps,
   PickerMethods,
   Button
 } from 'react-native-ui-lib'; //eslint-disable-line
 import contactsData from '../../data/conversations';
 import {longOptions} from './PickerScreenLongOptions';
+import {PickerPropsDeprecation} from 'src/components/picker/types';
 
 const tagIcon = require('../../assets/icons/tags.png');
 const dropdown = require('../../assets/icons/chevronDown.png');
@@ -99,7 +99,7 @@ export default class PickerScreen extends Component {
     contact: 0
   };
 
-  renderDialog: PickerProps['renderCustomModal'] = (modalProps: RenderCustomModalProps) => {
+  renderDialog: PickerPropsDeprecation['renderCustomModal'] = (modalProps: RenderCustomModalProps) => {
     const {visible, children, toggleModal, onDone} = modalProps;
     return (
       <Incubator.Dialog
@@ -134,7 +134,8 @@ export default class PickerScreen extends Component {
             value={this.state.language}
             enableModalBlur={false}
             onChange={item => this.setState({language: item})}
-            topBarProps={{title: 'Languages'}}
+            // topBarProps={{title: 'Languages'}}
+            headerProps={{title: 'Languages'}}
             // style={{color: Colors.red20}}
             showSearch
             searchPlaceholder={'Search a language'}
@@ -147,6 +148,7 @@ export default class PickerScreen extends Component {
             placeholder="Favorite Languages (up to 3)"
             value={this.state.languages}
             onChange={items => this.setState({languages: items})}
+            headerProps={{title: 'Multi Languages'}}
             mode={Picker.modes.MULTI}
             selectionLimit={3}
             trailingAccessory={dropdownIcon}
@@ -156,7 +158,9 @@ export default class PickerScreen extends Component {
           <Picker
             label="Wheel Picker"
             placeholder="Pick a Language"
-            useWheelPicker
+            // useWheelPicker
+            pickerType="wheelPicker"
+            customPickerProps={{migrateDialog: true, dialogProps: {bottom: true, width: '100%', height: '45%'}}}
             value={this.state.wheelPickerValue}
             onChange={wheelPickerValue => this.setState({wheelPickerValue})}
             trailingAccessory={<Icon source={dropdown}/>}
@@ -170,6 +174,7 @@ export default class PickerScreen extends Component {
             onChange={items => this.setState({customModalValues: items})}
             mode={Picker.modes.MULTI}
             trailingAccessory={dropdownIcon}
+            pickerType="custom"
             renderCustomModal={this.renderDialog}
             items={options}
           />
@@ -181,8 +186,10 @@ export default class PickerScreen extends Component {
             value={this.state.option}
             enableModalBlur={false}
             onChange={item => this.setState({option: item})}
-            topBarProps={{title: 'Languages'}}
-            useDialog
+            // topBarProps={{title: 'Languages'}}
+            // useDialog
+            headerProps={{title: 'Languages'}}
+            pickerType="dialog"
             renderCustomDialogHeader={({onDone, onCancel}) => (
               <View padding-s5 row spread>
                 <Button link label="Cancel" onPress={onCancel}/>

--- a/src/components/picker/PickerItemsList.tsx
+++ b/src/components/picker/PickerItemsList.tsx
@@ -42,7 +42,10 @@ const PickerItemsList = (props: PickerItemsListProps) => {
     const shouldFlex = true;
     const style = {flex: shouldFlex ? 1 : 0, maxHeight: Constants.isWeb ? Constants.windowHeight * 0.75 : undefined};
     return style;
-  }, [/* useDialog */]);
+  },
+  [
+    /* useDialog */
+  ]);
 
   const renderSearchInput = () => {
     if (showSearch) {

--- a/src/components/picker/PickerPresenter.ts
+++ b/src/components/picker/PickerPresenter.ts
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 import React from 'react';
-import {PickerProps, PickerSingleValue, PickerValue} from './types';
+import {PickerProps, PickerSingleValue, PickerValue, PickerPropsDeprecation} from './types';
 
-export function extractPickerItems(props: PickerProps) {
+export function extractPickerItems(props: PickerProps & PickerPropsDeprecation) {
   const {children} = props;
   const items = React.Children.map(children, child => ({
     // @ts-expect-error handle use PickerItemProps once exist
@@ -37,7 +37,7 @@ export function isItemSelected(childValue: PickerSingleValue, selectedValue?: Pi
 //   return _.invoke(props, 'getItemValue', props.value) || _.get(props.value, 'value');
 // }
 
-export function getItemLabel(label: string, value: PickerValue, getItemLabel: PickerProps['getItemLabel']) {
+export function getItemLabel(label: string, value: PickerValue, getItemLabel: PickerPropsDeprecation['getItemLabel']) {
   if (_.isObject(value)) {
     if (getItemLabel) {
       return getItemLabel(value);

--- a/src/components/picker/helpers/usePickerLabel.tsx
+++ b/src/components/picker/helpers/usePickerLabel.tsx
@@ -1,14 +1,14 @@
 import {useCallback, useMemo} from 'react';
 import _ from 'lodash';
-import {PickerProps, PickerValue} from '../types';
+import {PickerProps, PickerValue, PickerPropsDeprecation} from '../types';
 
-interface UsePickerLabelProps
-  extends Pick<
-    PickerProps,
-    'value' | 'getLabel' | 'getItemLabel' | 'placeholder' | 'accessibilityLabel' | 'accessibilityHint'
-  > {
-  items: {value: string | number; label: string}[] | null | undefined;
-}
+type UsePickerLabelProps = Pick<
+  PickerProps,
+  'value' | 'getLabel' | 'placeholder' | 'accessibilityLabel' | 'accessibilityHint'
+> &
+  Pick<PickerPropsDeprecation, 'getItemLabel'> & {
+    items: {value: string | number; label: string}[] | null | undefined;
+  };
 
 const usePickerLabel = (props: UsePickerLabelProps) => {
   const {value, items, getLabel, getItemLabel, placeholder, accessibilityLabel, accessibilityHint} = props;

--- a/src/components/picker/helpers/usePickerMigrationWarnings.tsx
+++ b/src/components/picker/helpers/usePickerMigrationWarnings.tsx
@@ -1,10 +1,10 @@
 import {useEffect} from 'react';
 import {LogService} from '../../../services';
-import {PickerProps} from '../types';
+import {PickerPropsDeprecation} from '../types';
 
 // TODO: Remove this whole file when migration is completed
 type UsePickerMigrationWarnings = Pick<
-  PickerProps,
+  PickerPropsDeprecation,
   'children' | 'migrate' | 'getItemLabel' | 'getItemValue' | 'onShow'
 >;
 

--- a/src/components/picker/helpers/usePickerMode.tsx
+++ b/src/components/picker/helpers/usePickerMode.tsx
@@ -1,0 +1,45 @@
+import {ExpandableOverlayProps} from 'src/incubator';
+import {PickerProps, PickerModeTypes} from '../index';
+import {CustomPickerProps} from '../types';
+
+type PickerType = {
+  dialog?: boolean;
+  wheelPicker?: boolean;
+  modal?: boolean;
+  custom?: boolean;
+};
+
+const usePickerMode = (props: PickerProps) => {
+  let type: PickerType = {dialog: false, wheelPicker: false, modal: false, custom: false};
+  let headerProps: any;
+  let renderCustomModal: CustomPickerProps['renderCustomModal'];
+  let dialogProps: ExpandableOverlayProps['dialogProps'];
+  if ('pickerType' in props) {
+    const {pickerType} = props;
+    if (pickerType) {
+      type[pickerType] = true;
+    }
+    switch (pickerType) {
+      case PickerModeTypes.Modal:
+        headerProps = props.headerProps;
+        break;
+      case PickerModeTypes.Dialog:
+      case PickerModeTypes.WheelPicker:
+        headerProps = props.headerProps;
+        // {"bottom": true, "height": "45%", "width": "100%"}
+        dialogProps = headerProps && {...props?.customPickerProps?.dialogProps, headerProps: props.headerProps};
+        break;
+      case PickerModeTypes.Custom:
+        renderCustomModal = props.renderCustomModal;
+        break;
+    }
+    return {type, headerProps, renderCustomModal, dialogProps};
+  } else {
+    const {useDialog, useWheelPicker} = props;
+    type = {dialog: !!useDialog, wheelPicker: !!useWheelPicker, modal: !useDialog && !useWheelPicker, custom: false};
+  }
+
+  return {type};
+};
+
+export default usePickerMode;

--- a/src/components/picker/helpers/usePickerMode.tsx
+++ b/src/components/picker/helpers/usePickerMode.tsx
@@ -14,6 +14,7 @@ const usePickerMode = (props: PickerProps) => {
   let headerProps: any;
   let renderCustomModal: CustomPickerProps['renderCustomModal'];
   let dialogProps: ExpandableOverlayProps['dialogProps'];
+  let pickerModalProps: ExpandableOverlayProps['modalProps'];
   if ('pickerType' in props) {
     const {pickerType} = props;
     if (pickerType) {
@@ -22,18 +23,19 @@ const usePickerMode = (props: PickerProps) => {
     switch (pickerType) {
       case PickerModeTypes.Modal:
         headerProps = props.headerProps;
+        //@ts-ignore
+        pickerModalProps = props.pickerModalProps || props.modalProps;
         break;
       case PickerModeTypes.Dialog:
       case PickerModeTypes.WheelPicker:
         headerProps = props.headerProps;
-        // {"bottom": true, "height": "45%", "width": "100%"}
         dialogProps = headerProps && {...props?.customPickerProps?.dialogProps, headerProps: props.headerProps};
         break;
       case PickerModeTypes.Custom:
         renderCustomModal = props.renderCustomModal;
         break;
     }
-    return {type, headerProps, renderCustomModal, dialogProps};
+    return {type, headerProps, renderCustomModal, dialogProps, pickerModalProps};
   } else {
     const {useDialog, useWheelPicker} = props;
     type = {dialog: !!useDialog, wheelPicker: !!useWheelPicker, modal: !useDialog && !useWheelPicker, custom: false};

--- a/src/components/picker/helpers/usePickerSearch.tsx
+++ b/src/components/picker/helpers/usePickerSearch.tsx
@@ -1,9 +1,10 @@
 import {useCallback, useState, useMemo} from 'react';
 import _ from 'lodash';
-import {PickerProps} from '../types';
+import {PickerProps, PickerPropsDeprecation} from '../types';
 import {getItemLabel as getItemLabelPresenter, shouldFilterOut} from '../PickerPresenter';
 
-type UsePickerSearchProps = Pick<PickerProps, 'showSearch' | 'onSearchChange' | 'children' | 'getItemLabel'>;
+type UsePickerSearchProps = Pick<PickerProps, 'showSearch' | 'onSearchChange'> &
+  Pick<PickerPropsDeprecation, 'children' | 'getItemLabel'>;
 
 const usePickerSearch = (props: UsePickerSearchProps) => {
   const {showSearch, onSearchChange, children, getItemLabel} = props;

--- a/src/components/picker/helpers/usePickerSelection.tsx
+++ b/src/components/picker/helpers/usePickerSelection.tsx
@@ -1,15 +1,25 @@
 import {RefObject, useCallback, useState, useEffect} from 'react';
 import _ from 'lodash';
-import {PickerProps, PickerValue, PickerSingleValue, PickerMultiValue, PickerModes} from '../types';
+import {
+  PickerProps,
+  PickerValue,
+  PickerSingleValue,
+  PickerMultiValue,
+  PickerModes,
+  PickerPropsDeprecation
+} from '../types';
+import {ModalTopBarProps} from 'src/components/modal';
 
-interface UsePickerSelectionProps
-  extends Pick<PickerProps, 'migrate' | 'value' | 'onChange' | 'getItemValue' | 'topBarProps' | 'mode'> {
-  pickerExpandableRef: RefObject<any>;
-  setSearchValue: (searchValue: string) => void;
-}
+type UsePickerSelectionProps = Pick<PickerProps, 'value' | 'onChange' | 'mode'> &
+  Pick<PickerPropsDeprecation, 'migrate' | 'getItemValue' | 'topBarProps'> & {
+    headerProps?: ModalTopBarProps;
+    pickerExpandableRef: RefObject<any>;
+    setSearchValue: (searchValue: string) => void;
+  };
 
 const usePickerSelection = (props: UsePickerSelectionProps) => {
-  const {migrate, value, onChange, topBarProps, pickerExpandableRef, getItemValue, setSearchValue, mode} = props;
+  const {migrate, value, onChange, topBarProps, headerProps, pickerExpandableRef, getItemValue, setSearchValue, mode} =
+    props;
   const [multiDraftValue, setMultiDraftValue] = useState(value as PickerMultiValue);
   const [multiFinalValue, setMultiFinalValue] = useState(value as PickerMultiValue);
 
@@ -46,6 +56,7 @@ const usePickerSelection = (props: UsePickerSelectionProps) => {
     setMultiDraftValue(multiFinalValue);
     pickerExpandableRef.current?.closeExpandable?.();
     topBarProps?.onCancel?.();
+    headerProps?.onCancel?.();
   }, [multiFinalValue, topBarProps]);
 
   return {

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -187,7 +187,7 @@ const Picker = React.forwardRef((props: PickerProps & PickerPropsDeprecation, re
     animationType: 'slide',
     transparent: Constants.isIOS && enableModalBlur,
     enableModalBlur: Constants.isIOS && enableModalBlur,
-    onRequestClose: topBarProps?.onCancel,
+    onRequestClose: topBarProps?.onCancel || headerProps?.onCancel,
     onShow,
     ...pickerModalProps
   };
@@ -240,6 +240,7 @@ const Picker = React.forwardRef((props: PickerProps & PickerPropsDeprecation, re
 
   const expandableModalContent = useMemo(() => {
     const useItems = isWheelPicker || propItems;
+    const listTopBarProps = type.modal ? headerProps : topBarProps;
     return (
       <PickerItemsList
         testID={`${testID}.modal`}
@@ -248,8 +249,7 @@ const Picker = React.forwardRef((props: PickerProps & PickerPropsDeprecation, re
         useDialog={isDialog}
         items={useItems ? items : undefined}
         topBarProps={{
-          ...topBarProps,
-          ...headerProps,
+          ...listTopBarProps,
           onCancel: cancelSelect,
           onDone: mode === PickerModes.MULTI ? () => onDoneSelecting(multiDraftValue) : undefined
         }}

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -79,7 +79,6 @@ const Picker = React.forwardRef((props: PickerProps & PickerPropsDeprecation, re
     renderCustomModal,
     enableModalBlur,
     topBarProps,
-    pickerModalProps,
     listProps,
     value,
     getLabel,
@@ -101,7 +100,8 @@ const Picker = React.forwardRef((props: PickerProps & PickerPropsDeprecation, re
     type,
     headerProps,
     renderCustomModal: typeRenderCustomModal,
-    dialogProps
+    dialogProps,
+    pickerModalProps
   } = usePickerMode({
     pickerType: PickerModeTypes.Modal,
     ...themeProps

--- a/src/components/picker/types.tsx
+++ b/src/components/picker/types.tsx
@@ -90,6 +90,7 @@ export interface ModalPickerProps {
    */
   pickerType: PickerModeTypes.Modal | `${PickerModeTypes.Modal}`;
   headerProps?: ModalTopBarProps;
+  modalProps?: ExpandableOverlayProps['modalProps'];
 }
 
 export interface CustomPickerProps {
@@ -144,9 +145,15 @@ export type PickerPropsDeprecation = {
    */
   children?: ReactNode | undefined;
   /**
+   * @deprecated
    * Render custom picker modal (e.g ({visible, children, toggleModal}) => {...})
    */
   renderCustomModal?: (modalProps: RenderCustomModalProps) => React.ReactElement;
+  /**
+   * @deprecated
+   * Pass props to the picker modal
+   */
+  pickerModalProps?: object;
 };
 
 export type PickerTypes = PickerModeProps | PickerPropsDeprecation;
@@ -235,10 +242,6 @@ export type PickerBaseProps = Omit<NewTextFieldProps, 'value' | 'onChange'> & {
    * Pass props to the list component that wraps the picker options (allows to control FlatList behavior)
    */
   listProps?: Partial<FlatListProps<any>>;
-  /**
-   * Pass props to the picker modal
-   */
-  pickerModalProps?: object;
   /**
    * Custom container style
    */

--- a/src/components/picker/types.tsx
+++ b/src/components/picker/types.tsx
@@ -100,6 +100,7 @@ export interface CustomPickerProps {
   renderCustomModal?: PickerPropsDeprecation['renderCustomModal'];
 }
 
+type PickerHeaderProps = ModalTopBarProps | DialogPropsOld['pannableHeaderProps'] | DialogPropsNew['headerProps'];
 export type PickerModeProps = ModalPickerProps | DialogPickerProps | WheelPickerProps | CustomPickerProps;
 
 export type PickerPropsDeprecation = {
@@ -348,8 +349,9 @@ export type PickerItemsListProps = Pick<
   | 'mode'
   | 'testID'
 > &
-  Pick<PickerPropsDeprecation, 'topBarProps' | 'useWheelPicker' | 'useDialog'> & {
+  Pick<PickerPropsDeprecation, 'useWheelPicker' | 'useDialog'> & {
     items?: {value: any; label: any}[];
+    topBarProps: PickerHeaderProps;
   };
 
 export type PickerMethods = TextFieldMethods & ExpandableOverlayMethods;

--- a/src/components/picker/types.tsx
+++ b/src/components/picker/types.tsx
@@ -98,7 +98,7 @@ export interface CustomPickerProps {
    * Type of picker to render
    */
   pickerType: PickerModeTypes.Custom | `${PickerModeTypes.Custom}`;
-  renderCustomModal?: PickerPropsDeprecation['renderCustomModal'];
+  renderCustomModal?: (modalProps: RenderCustomModalProps) => React.ReactElement;
 }
 
 type PickerHeaderProps = ModalTopBarProps | DialogPropsOld['pannableHeaderProps'] | DialogPropsNew['headerProps'];
@@ -297,7 +297,7 @@ export interface PickerItemProps extends Pick<TouchableOpacityProps, 'customValu
   /**
    * Custom function for the item label (e.g (value) => customLabel)
    */
-  getItemLabel?: PickerPropsDeprecation['getItemLabel'];
+  getItemLabel?: (value: PickerValue) => string;
   /**
    * @deprecated Function to return the value out of the item value prop when value is custom shaped.
    */


### PR DESCRIPTION
## Description
New Picker prop `pickerType` to choose the "render" mode of the picker - 'modal, dialog, wheelPicker, custom" and according to that to pass the right type of header props.
Default value 'Modal'.
Deprecation of `useDialog, useWheelPicker, pickerModalProps, renderCustomModal`.

Note: I moved the Picker prop that are deprecated to `PickerDeprecationsProps` type so in `v8` removing the props from `PickerBaseProps` will be much easier. 

## Changelog
New Picker prop `pickerType` and 'headerProps' props to choose the "render" mode of the picker.

## Additional info
MADS-4187