### PR TITLE
Support passing imageStyle when rendering internally ImageBackground

### DIFF
--- a/src/components/animatedImage/index.tsx
+++ b/src/components/animatedImage/index.tsx
@@ -70,7 +70,14 @@ const AnimatedImage = (props: AnimatedImageProps) => {
 
   return (
     <View style={containerStyle}>
-      <UIAnimatedImage {...others} style={_style} source={source} onLoad={onLoad} testID={testID}/>
+      <UIAnimatedImage
+        {...others}
+        style={_style}
+        source={source}
+        onLoad={onLoad}
+        testID={testID}
+        imageStyle={undefined}
+      />
       {isLoading && loader && <View style={styles.loader}>{loader}</View>}
     </View>
   );

--- a/src/components/image/index.tsx
+++ b/src/components/image/index.tsx
@@ -6,6 +6,7 @@ import {
   Image as RNImage,
   ImageProps as RNImageProps,
   ImageBackground,
+  ImageBackgroundProps,
   NativeSyntheticEvent,
   ImageErrorEventData
 } from 'react-native';
@@ -27,6 +28,7 @@ import {ComponentStatics} from 'src/typings/common';
 export type ImageSourceType = string | RNImageProps['source'];
 
 export type ImageProps = Omit<RNImageProps, 'source'> &
+  Pick<ImageBackgroundProps, 'imageStyle'> &
   MarginModifiers &
   RecorderProps & {
     /**
@@ -183,6 +185,13 @@ class Image extends PureComponent<Props, State> {
     return this.getVerifiedSource(source);
   }
 
+  getImageStyle = () => {
+    const {imageStyle, borderRadius} = this.props;
+    if (this.shouldUseImageBackground()) {
+      return borderRadius ? [{borderRadius}, imageStyle] : imageStyle;
+    }
+  };
+
   onError = (event: NativeSyntheticEvent<ImageErrorEventData>) => {
     if (event.nativeEvent.error) {
       this.setState({error: true});
@@ -250,6 +259,8 @@ class Image extends PureComponent<Props, State> {
         accessibilityRole={'image'}
         fsTagName={recorderTag}
         {...others}
+        // NOTE: imageStyle prop is only relevant for when rendering ImageBackground component
+        imageStyle={this.getImageStyle()}
         onError={this.onError}
         source={source}
       >


### PR DESCRIPTION
## Description
Pass `imageStyle` to Image component when internally it renders ImageBackground (whenever we render children inside the Image) 
This fix some issues where image styling is not being passed to the Image that rendered by ImageBackground component 

See reference in [React Native docs](https://reactnative.dev/docs/imagebackground#imagestyle)

## Changelog
Fix nesting image style props in Image component with children (overlay, content).. 

## Additional info
ticket 4290