### PR TITLE
[interface] Allow array in HintProps.message

### DIFF
--- a/src/components/hint/index.tsx
+++ b/src/components/hint/index.tsx
@@ -67,7 +67,7 @@ export interface HintProps {
   /**
    * The hint message
    */
-  message?: string | ReactElement;
+  message?: string | ReactElement | (string | ReactElement)[];
   /**
    * The hint message custom style
    */

--- a/src/components/hint/index.tsx
+++ b/src/components/hint/index.tsx
@@ -67,7 +67,7 @@ export interface HintProps {
   /**
    * The hint message
    */
-  message?: string | ReactElement | (string | ReactElement)[];
+  message?: string | ReactElement | (string | ReactElement | null)[];
   /**
    * The hint message custom style
    */

--- a/src/components/hint/index.tsx
+++ b/src/components/hint/index.tsx
@@ -67,7 +67,7 @@ export interface HintProps {
   /**
    * The hint message
    */
-  message?: string | ReactElement | (string | ReactElement | null)[];
+  message?: ReactNode | ReactNode[];
   /**
    * The hint message custom style
    */

--- a/src/components/hint/index.tsx
+++ b/src/components/hint/index.tsx
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import React, {Component, ReactElement, isValidElement, ElementRef} from 'react';
+import React, {Component, ReactNode, isValidElement, ElementRef} from 'react';
 import {
   Animated,
   StyleSheet,


### PR DESCRIPTION
## Description
Allow passing `(string | ReactElement)[]` in HintProps.message. This is handy when we want to pass a string with formatting (array of strings / <Text /> elements) 

## Changelog
Improved HintProps typing

## Additional info
N/A