### PR TITLE
getItemLabel type changed since it's not deprecated

### DIFF
--- a/src/components/picker/types.tsx
+++ b/src/components/picker/types.tsx
@@ -220,7 +220,7 @@ export interface PickerItemProps extends Pick<TouchableOpacityProps, 'customValu
   /**
    * Custom function for the item label (e.g (value) => customLabel)
    */
-  getItemLabel?: PickerProps['getItemLabel'];
+  getItemLabel?: (value: PickerValue) => string;
   /**
    * @deprecated Function to return the value out of the item value prop when value is custom shaped.
    */


### PR DESCRIPTION
## Description
getItemLabel type changed since it's not deprecated

## Changelog
getItemLabel type changed since it's not deprecated

## Additional info
MADS-4191
