### PR TITLE
passing onRequestClose to Modal

### DIFF
--- a/src/incubator/expandableOverlay/index.tsx
+++ b/src/incubator/expandableOverlay/index.tsx
@@ -94,6 +94,7 @@ const ExpandableOverlay = (props: ExpandableOverlayProps, ref: any) => {
         {...modalProps}
         visible={visible}
         onDismiss={closeExpandable}
+        onRequestClose={closeExpandable}
       >
         {showTopBar && <Modal.TopBar onDone={closeExpandable} {...topBarProps}/>}
         {expandableContent}


### PR DESCRIPTION
## Description
Modal support onRequestClose for Android users close modal on back button press.
Note the `onRequestClose` is in RN AndroidModal types - [link](https://reactnative.dev/docs/modal#onrequestclose)
Related [PR](https://github.com/wix/react-native-ui-lib/pull/3128) that closed

## Changelog
Modal support closing on Android back button press.

## Additional info
MADS-4238
