### PR TITLE
removed centerV

### DIFF
--- a/src/components/textField/index.tsx
+++ b/src/components/textField/index.tsx
@@ -135,7 +135,7 @@ const TextField = (props: InternalTextFieldProps) => {
   return (
     <FieldContext.Provider value={context}>
       <View {...containerProps} style={[margins, positionStyle, containerStyle, centeredContainerStyle]}>
-        <View row spread centerV={Constants.isAndroid} style={centeredContainerStyle}>
+        <View row spread style={centeredContainerStyle}>
           <Label
             label={label}
             labelColor={labelColor}


### PR DESCRIPTION
## Description
TextField remove of `centerV` only in Android from the `Label` View wrapper.
The `centerV` caused the value and the label of `Picker` in `filter` type to be unequal in the height.

## Changelog
TextField remove of `centerV` only in Android from the `Label` View wrapper.

## Additional info
MADS-4302
