### PR TITLE
borderRadius is passed to image style

### DIFF
--- a/demo/src/screens/__tests__/__snapshots__/AvatarScreen.spec.js.snap
+++ b/demo/src/screens/__tests__/__snapshots__/AvatarScreen.spec.js.snap
@@ -944,6 +944,7 @@ exports[`AvatarScreen renders screen 1`] = `
               undefined,
               undefined,
               undefined,
+              undefined,
               false,
               [
                 {
@@ -1195,6 +1196,7 @@ exports[`AvatarScreen renders screen 1`] = `
               {
                 "height": 40,
               },
+              undefined,
               undefined,
               undefined,
               undefined,
@@ -1467,6 +1469,7 @@ exports[`AvatarScreen renders screen 1`] = `
                 undefined,
                 undefined,
                 undefined,
+                undefined,
                 false,
                 [
                   [
@@ -1655,6 +1658,7 @@ exports[`AvatarScreen renders screen 1`] = `
               {
                 "height": 70,
               },
+              undefined,
               undefined,
               undefined,
               undefined,
@@ -1914,6 +1918,7 @@ exports[`AvatarScreen renders screen 1`] = `
               undefined,
               undefined,
               undefined,
+              undefined,
               false,
               [
                 {
@@ -2032,6 +2037,7 @@ exports[`AvatarScreen renders screen 1`] = `
               style={
                 [
                   null,
+                  undefined,
                   undefined,
                   undefined,
                   undefined,
@@ -2209,6 +2215,7 @@ exports[`AvatarScreen renders screen 1`] = `
               {
                 "height": 48,
               },
+              undefined,
               undefined,
               undefined,
               undefined,
@@ -2441,6 +2448,7 @@ exports[`AvatarScreen renders screen 1`] = `
               undefined,
               undefined,
               undefined,
+              undefined,
               false,
               [
                 {
@@ -2669,6 +2677,7 @@ exports[`AvatarScreen renders screen 1`] = `
               undefined,
               undefined,
               undefined,
+              undefined,
               false,
               [
                 {
@@ -2851,6 +2860,7 @@ exports[`AvatarScreen renders screen 1`] = `
               {
                 "height": 50,
               },
+              undefined,
               undefined,
               undefined,
               undefined,

--- a/demo/src/screens/__tests__/__snapshots__/TextFieldScreen.spec.js.snap
+++ b/demo/src/screens/__tests__/__snapshots__/TextFieldScreen.spec.js.snap
@@ -2770,6 +2770,7 @@ exports[`TextField Screen renders screen 1`] = `
                     undefined,
                     undefined,
                     undefined,
+                    undefined,
                     false,
                     [
                       {
@@ -3435,6 +3436,7 @@ exports[`TextField Screen renders screen 1`] = `
               }
               style={
                 [
+                  undefined,
                   undefined,
                   undefined,
                   undefined,

--- a/src/components/button/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/button/__tests__/__snapshots__/index.spec.js.snap
@@ -1134,6 +1134,7 @@ exports[`Button container size should have no padding of button is an icon butto
         undefined,
         undefined,
         undefined,
+        undefined,
         false,
         [
           {
@@ -2266,6 +2267,7 @@ exports[`Button icon should apply color on icon 1`] = `
         undefined,
         undefined,
         undefined,
+        undefined,
         false,
         [
           {
@@ -2342,6 +2344,7 @@ exports[`Button icon should apply color on icon 2`] = `
         undefined,
         undefined,
         undefined,
+        undefined,
         false,
         [
           {
@@ -2410,6 +2413,7 @@ exports[`Button icon should include custom iconStyle provided as a prop 1`] = `
     source={12}
     style={
       [
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -2499,6 +2503,7 @@ exports[`Button icon should return icon style according to different variations 
         undefined,
         undefined,
         undefined,
+        undefined,
         false,
         [
           {
@@ -2575,6 +2580,7 @@ exports[`Button icon should return icon style according to different variations 
         undefined,
         undefined,
         undefined,
+        undefined,
         false,
         [
           {
@@ -2643,6 +2649,7 @@ exports[`Button icon should return icon style according to different variations 
     source={12}
     style={
       [
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -3893,6 +3900,7 @@ exports[`Button labelColor should return undefined color if this is an icon butt
     source={12}
     style={
       [
+        undefined,
         undefined,
         undefined,
         undefined,

--- a/src/components/image/index.tsx
+++ b/src/components/image/index.tsx
@@ -233,6 +233,7 @@ class Image extends PureComponent<Props, State> {
       customOverlayContent,
       modifiers,
       recorderTag,
+      borderRadius,
       ...others
     } = this.props;
     const shouldFlipRTL = supportRTL && Constants.isRTL;
@@ -247,6 +248,7 @@ class Image extends PureComponent<Props, State> {
           shouldFlipRTL && styles.rtlFlipped,
           width && {width},
           height && {height},
+          borderRadius && {borderRadius},
           cover && styles.coverImage,
           this.isGif() && styles.gifImage,
           aspectRatio && {aspectRatio},
@@ -270,7 +272,7 @@ class Image extends PureComponent<Props, State> {
             intensity={overlayIntensity}
             color={overlayColor}
             customContent={customOverlayContent}
-            borderRadius={others?.borderRadius}
+            borderRadius={borderRadius}
           />
         )}
       </ImageView>


### PR DESCRIPTION
## Description
Until now `borderRadius` was passed to `imageStyle` which is only for `overlayContent` use case.
That caused a bug in the web environment which `image` without `overlayContent` didn't get the `borderRadius` that passed via the `imageProps`.
[related PR](https://github.com/wix/react-native-ui-lib/pull/3131)
[related issue/feature](https://github.com/necolas/react-native-web/issues/2692) request in `react-native-web`

Note:
```
<Image
    source={{uri: 'https://github.com/pedrottimark.png'}}
    style={{width: 200, height: 200, margin: 20}}
    borderRadius={45}
/>
```
This is basic RN Image with `borderRadius`, this is working on mobile but not on web environment. 

## Changelog
Image passing `borderRadius` to style. 

## Additional info
None
