### PR TITLE
bugfix: remove TabController.TabBar defaultProps, use JavaScript default parameters instead

### DIFF
--- a/src/components/tabController/TabBar.tsx
+++ b/src/components/tabController/TabBar.tsx
@@ -142,8 +142,8 @@ const TabBar = (props: Props) => {
     enableShadow,
     shadowStyle: propsShadowStyle,
     indicatorStyle,
-    labelStyle,
-    selectedLabelStyle,
+    labelStyle = DEFAULT_LABEL_STYLE,
+    selectedLabelStyle = DEFAULT_SELECTED_LABEL_STYLE,
     labelColor,
     selectedLabelColor,
     uppercase,
@@ -151,10 +151,10 @@ const TabBar = (props: Props) => {
     selectedIconColor,
     activeBackgroundColor,
     backgroundColor = Colors.$backgroundElevated,
-    faderProps,
+    faderProps = DEFAULT_FADER_PROPS,
     containerWidth: propsContainerWidth,
     centerSelected,
-    spreadItems,
+    spreadItems = true,
     indicatorInsets = Spacings.s4,
     indicatorWidth,
     containerStyle,
@@ -319,12 +319,6 @@ const TabBar = (props: Props) => {
 };
 
 TabBar.displayName = 'TabController.TabBar';
-TabBar.defaultProps = {
-  labelStyle: DEFAULT_LABEL_STYLE,
-  selectedLabelStyle: DEFAULT_SELECTED_LABEL_STYLE,
-  faderProps: DEFAULT_FADER_PROPS,
-  spreadItems: true
-};
 
 const styles = StyleSheet.create({
   container: {


### PR DESCRIPTION
bugfix: remove TabController.TabBar defaultProps, use JavaScript default parameters instead.

## Description

```
remove code:
TabBar.defaultProps = {
  labelStyle: DEFAULT_LABEL_STYLE,
  selectedLabelStyle: DEFAULT_SELECTED_LABEL_STYLE,
  faderProps: DEFAULT_FADER_PROPS,
  spreadItems: true
};
use parameters instead: 
  const {
    items: propsItems,
    height,
    enableShadow,
    shadowStyle: propsShadowStyle,
    indicatorStyle,
    labelStyle = DEFAULT_LABEL_STYLE,
    selectedLabelStyle = DEFAULT_SELECTED_LABEL_STYLE,
    labelColor,
    selectedLabelColor,
    uppercase,
    iconColor,
    selectedIconColor,
    activeBackgroundColor,
    backgroundColor = Colors.$backgroundElevated,
    faderProps = DEFAULT_FADER_PROPS,
    containerWidth: propsContainerWidth,
    centerSelected,
    spreadItems = true,
    indicatorInsets = Spacings.s4,
    indicatorWidth,
    containerStyle,
    testID
  } = props;
```

## Changelog

components: TabBar
code: remove TabBar.defaultProps


## Additional info

issue: #3154 

