### PR TITLE
Fix/button icon

### DIFF
--- a/demo/src/screens/__tests__/__snapshots__/TextFieldScreen.spec.js.snap
+++ b/demo/src/screens/__tests__/__snapshots__/TextFieldScreen.spec.js.snap
@@ -1899,6 +1899,8 @@ exports[`TextField Screen renders screen 1`] = `
               }
             >
               <Image
+                accessibilityRole="image"
+                accessible={false}
                 source={
                   {
                     "testUri": "../../../demo/src/assets/icons/info.png",
@@ -2695,6 +2697,7 @@ exports[`TextField Screen renders screen 1`] = `
                 ],
               ]
             }
+            testID="undefined.clearButton.container"
           >
             <View
               accessibilityLabel="clear"
@@ -2753,8 +2756,6 @@ exports[`TextField Screen renders screen 1`] = `
               <Image
                 accessibilityRole="image"
                 accessible={false}
-                assetGroup="icons"
-                onError={[Function]}
                 source={
                   {
                     "testUri": "../../../src/assets/icons/xFlat.png",
@@ -2762,16 +2763,6 @@ exports[`TextField Screen renders screen 1`] = `
                 }
                 style={
                   [
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    false,
                     [
                       {
                         "tintColor": "#5A48F5",
@@ -2780,7 +2771,12 @@ exports[`TextField Screen renders screen 1`] = `
                         "tintColor": "#A6ACB1",
                       },
                     ],
-                    false,
+                    undefined,
+                    undefined,
+                    undefined,
+                    {
+                      "tintColor": "#5A48F5",
+                    },
                   ]
                 }
                 testID="undefined.clearButton.icon"
@@ -2788,6 +2784,8 @@ exports[`TextField Screen renders screen 1`] = `
             </View>
           </View>
           <Image
+            accessibilityRole="image"
+            accessible={false}
             source={
               {
                 "testUri": "../../../demo/src/assets/icons/search.png",
@@ -3427,8 +3425,6 @@ exports[`TextField Screen renders screen 1`] = `
             <Image
               accessibilityRole="image"
               accessible={false}
-              assetGroup="icons"
-              onError={[Function]}
               source={
                 {
                   "testUri": "../../../demo/src/assets/icons/search.png",
@@ -3436,23 +3432,18 @@ exports[`TextField Screen renders screen 1`] = `
               }
               style={
                 [
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  undefined,
-                  false,
                   [
                     {
                       "tintColor": "#20303C",
                     },
                     undefined,
                   ],
-                  false,
+                  undefined,
+                  undefined,
+                  undefined,
+                  {
+                    "tintColor": "#20303C",
+                  },
                 ]
               }
               testID="undefined.icon"
@@ -5398,6 +5389,8 @@ exports[`TextField Screen renders screen 1`] = `
             }
           >
             <Image
+              accessibilityRole="image"
+              accessible={false}
               marginL-s1={true}
               source={
                 {

--- a/src/components/button/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/button/__tests__/__snapshots__/index.spec.js.snap
@@ -1121,21 +1121,9 @@ exports[`Button container size should have no padding of button is an icon butto
   <Image
     accessibilityRole="image"
     accessible={false}
-    assetGroup="icons"
-    onError={[Function]}
     source={14}
     style={
       [
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        false,
         [
           {
             "marginRight": 8,
@@ -1143,7 +1131,12 @@ exports[`Button container size should have no padding of button is an icon butto
           },
           undefined,
         ],
-        false,
+        undefined,
+        undefined,
+        undefined,
+        {
+          "tintColor": "#FFFFFF",
+        },
       ]
     }
     testID="undefined.icon"
@@ -2254,28 +2247,21 @@ exports[`Button icon should apply color on icon 1`] = `
   <Image
     accessibilityRole="image"
     accessible={false}
-    assetGroup="icons"
-    onError={[Function]}
     source={12}
     style={
       [
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        false,
         [
           {
             "tintColor": "green",
           },
           undefined,
         ],
-        false,
+        undefined,
+        undefined,
+        undefined,
+        {
+          "tintColor": "green",
+        },
       ]
     }
     testID="undefined.icon"
@@ -2331,28 +2317,21 @@ exports[`Button icon should apply color on icon 2`] = `
   <Image
     accessibilityRole="image"
     accessible={false}
-    assetGroup="icons"
-    onError={[Function]}
     source={12}
     style={
       [
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        false,
         [
           {
             "tintColor": "#FC3D2F",
           },
           undefined,
         ],
-        false,
+        undefined,
+        undefined,
+        undefined,
+        {
+          "tintColor": "#FC3D2F",
+        },
       ]
     }
     testID="undefined.icon"
@@ -2408,21 +2387,9 @@ exports[`Button icon should include custom iconStyle provided as a prop 1`] = `
   <Image
     accessibilityRole="image"
     accessible={false}
-    assetGroup="icons"
-    onError={[Function]}
     source={12}
     style={
       [
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        false,
         [
           {
             "tintColor": "#FFFFFF",
@@ -2432,7 +2399,12 @@ exports[`Button icon should include custom iconStyle provided as a prop 1`] = `
             "tintColor": "red",
           },
         ],
-        false,
+        undefined,
+        undefined,
+        undefined,
+        {
+          "tintColor": "#FFFFFF",
+        },
       ]
     }
     testID="undefined.icon"
@@ -2490,28 +2462,21 @@ exports[`Button icon should return icon style according to different variations 
   <Image
     accessibilityRole="image"
     accessible={false}
-    assetGroup="icons"
-    onError={[Function]}
     source={12}
     style={
       [
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        false,
         [
           {
             "tintColor": "#5A48F5",
           },
           undefined,
         ],
-        false,
+        undefined,
+        undefined,
+        undefined,
+        {
+          "tintColor": "#5A48F5",
+        },
       ]
     }
     testID="undefined.icon"
@@ -2567,28 +2532,21 @@ exports[`Button icon should return icon style according to different variations 
   <Image
     accessibilityRole="image"
     accessible={false}
-    assetGroup="icons"
-    onError={[Function]}
     source={12}
     style={
       [
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        false,
         [
           {
             "tintColor": "#5A48F5",
           },
           undefined,
         ],
-        false,
+        undefined,
+        undefined,
+        undefined,
+        {
+          "tintColor": "#5A48F5",
+        },
       ]
     }
     testID="undefined.icon"
@@ -2644,28 +2602,21 @@ exports[`Button icon should return icon style according to different variations 
   <Image
     accessibilityRole="image"
     accessible={false}
-    assetGroup="icons"
-    onError={[Function]}
     source={12}
     style={
       [
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        false,
         [
           {
             "tintColor": "#FFFFFF",
           },
           undefined,
         ],
-        false,
+        undefined,
+        undefined,
+        undefined,
+        {
+          "tintColor": "#FFFFFF",
+        },
       ]
     }
     testID="undefined.icon"
@@ -3895,28 +3846,21 @@ exports[`Button labelColor should return undefined color if this is an icon butt
   <Image
     accessibilityRole="image"
     accessible={false}
-    assetGroup="icons"
-    onError={[Function]}
     source={12}
     style={
       [
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        false,
         [
           {
             "tintColor": "#FFFFFF",
           },
           undefined,
         ],
-        false,
+        undefined,
+        undefined,
+        undefined,
+        {
+          "tintColor": "#FFFFFF",
+        },
       ]
     }
     testID="undefined.icon"

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -1,12 +1,11 @@
 import _ from 'lodash';
 import React, {PureComponent} from 'react';
-import {Platform, StyleSheet, LayoutAnimation, LayoutChangeEvent, ImageStyle, TextStyle} from 'react-native';
+import {Platform, StyleSheet, LayoutAnimation, LayoutChangeEvent, ImageStyle, TextStyle, StyleProp} from 'react-native';
 import {asBaseComponent, forwardRef, Constants} from '../../commons/new';
 import {Colors, Typography, BorderRadiuses} from 'style';
 import TouchableOpacity from '../touchableOpacity';
 import type {Dictionary, ComponentStatics} from '../../typings/common';
 import Text from '../text';
-import Image from '../image';
 import Icon from '../icon';
 import {
   ButtonSize,
@@ -249,7 +248,7 @@ class Button extends PureComponent<Props, ButtonState> {
     }
   }
 
-  getIconStyle() {
+  getIconStyle(): [ImageStyle, StyleProp<ImageStyle>] {
     const {disabled, iconStyle: propsIconStyle, iconOnRight, size: propsSize, link} = this.props;
     const size = propsSize || DEFAULT_SIZE;
     const iconStyle: ImageStyle = {
@@ -303,26 +302,28 @@ class Button extends PureComponent<Props, ButtonState> {
       if (typeof iconSource === 'function') {
         return iconSource(iconStyle);
       } else {
-        if (Constants.isWeb) {
-          return (
-            <Icon
-              style={iconStyle}
-              tintColor={Colors.$iconDefault}
-              source={iconSource}
-              testID={`${testID}.icon`}
-              {...iconProps}
-            />
-          );
-        }
+        // if (Constants.isWeb) {
         return (
-          <Image
+          <Icon
+            style={iconStyle}
             source={iconSource}
             supportRTL={supportRTL}
-            style={iconStyle}
             testID={`${testID}.icon`}
+            // @ts-expect-error RN ImageStyle conflicts with ImageProps in tintColor type
+            tintColor={iconStyle[0]?.tintColor}
             {...iconProps}
           />
         );
+        // }
+        // return (
+        //   <Image
+        //     source={iconSource}
+        //     supportRTL={supportRTL}
+        //     style={iconStyle}
+        //     testID={`${testID}.icon`}
+        //     {...iconProps}
+        //   />
+        // );
       }
     }
     return null;

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -309,6 +309,7 @@ class Button extends PureComponent<Props, ButtonState> {
             source={iconSource}
             supportRTL={supportRTL}
             testID={`${testID}.icon`}
+            // Note Passing tintColor as prop is required for Web
             // @ts-expect-error RN ImageStyle conflicts with ImageProps in tintColor type
             tintColor={iconStyle[0]?.tintColor}
             {...iconProps}

--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -88,6 +88,8 @@ const Icon = forwardRef((props: Props, ref: any) => {
 
   const renderImage = () => (
     <Image
+      accessible={false}
+      accessibilityRole={'image'}
       fsTagName={recorderTag}
       {...others}
       ref={ref}


### PR DESCRIPTION
## Description
Fix icon coloring issue on Web 
It appear passing `tintColor` in style does not work on Web while passing it as prop works

Also remove our usage of Image component for icon in Button and unify the code for web and mobile

(I kept previous code in a comment cause we weren't sure before about using Icon on mobile, so In case an issue will arise we'll quickly know where it comes from) 

## Changelog
Fix button's icon coloring issue on Web

## Additional info
