### PR TITLE
Picker - fix usePickerLabel

### DIFF
--- a/demo/src/screens/componentScreens/PickerScreen.tsx
+++ b/demo/src/screens/componentScreens/PickerScreen.tsx
@@ -82,6 +82,7 @@ const dialogOptions = [
   {label: 'Option 7', value: 6},
   {label: 'Option 8', value: 6}
 ];
+
 export default class PickerScreen extends Component {
   picker = React.createRef<PickerMethods>();
   state = {
@@ -128,6 +129,7 @@ export default class PickerScreen extends Component {
           <Text text40 $textDefault>
             Picker
           </Text>
+          
           <Picker
             placeholder="Favorite Language"
             floatingPlaceholder
@@ -194,6 +196,7 @@ export default class PickerScreen extends Component {
             searchPlaceholder={'Search a language'}
             items={dialogOptions}
           />
+          
           <Text marginB-10 text70 $textDefault>
             Custom Picker:
           </Text>
@@ -216,6 +219,7 @@ export default class PickerScreen extends Component {
             }}
             items={filters}
           />
+
           <Text marginT-20 marginB-10 text70 $textDefault>
             Custom Picker Items:
           </Text>
@@ -252,6 +256,7 @@ export default class PickerScreen extends Component {
             style={{alignSelf: 'flex-start'}}
             onPress={() => this.picker.current?.openExpandable?.()}
           />
+          
           <Text text60 marginT-s5>
             Different Field Types
           </Text>

--- a/src/components/picker/helpers/__tests__/usePickerLabel.spec.ts
+++ b/src/components/picker/helpers/__tests__/usePickerLabel.spec.ts
@@ -1,0 +1,75 @@
+import {renderHook} from '@testing-library/react-hooks';
+import usePickerLabel from '../usePickerLabel';
+
+const colors = [
+  {value: 'red', label: 'Red'},
+  {
+    value: 'green',
+    label: 'Green',
+    listItemProps: {subtitle: 'Subtitle'}
+  },
+  {
+    value: 'blue',
+    label: 'Blue',
+    listItemProps: {
+      subtitleLines: 2,
+      subtitle: 'Subtitle with\n2 lines of text'
+    }
+  },
+  {value: 'purple', label: 'Purple', disabled: true},
+  {value: 'yellow', label: 'Yellow'},
+  {value: 'grey', label: 'Grey'}
+];
+
+describe('usePickerLabel hook tests', () => {
+  const makeSUT = ({
+    value,
+    items,
+    getLabel
+    // getItemLabel,
+    // accessibilityLabel,
+    // accessibilityHint,
+    // placeholder
+  }) => {
+    return renderHook(() =>
+      usePickerLabel({
+        value,
+        items,
+        getLabel
+        // getItemLabel,
+        // accessibilityLabel,
+        // accessibilityHint,
+        // placeholder
+      }));
+  };
+
+  it('expect label to equal an empty string when value is undefined', () => {
+    const sut = makeSUT({items: colors, value: undefined, getLabel: undefined});
+    expect(sut.result.current.label).toEqual('');
+  });
+
+  it('expect label to equal an empty string when value is null', () => {
+    const sut = makeSUT({items: colors, value: null, getLabel: undefined});
+    expect(sut.result.current.label).toEqual('');
+  });
+
+  it('expect label to equal returned string when getLabel passed', () => {
+    const sut = makeSUT({items: colors, value: null, getLabel: () => 'Some label'});
+    expect(sut.result.current.label).toEqual('Some label');
+  });
+
+  it('expect label to equal array of values when value is array', () => {
+    const sut = makeSUT({items: colors, value: ['red', 'green'], getLabel: undefined});
+    expect(sut.result.current.label).toEqual('Red, Green');
+  });
+
+  it('expect label to equal selected item label when value equals item value', () => {
+    const sut = makeSUT({items: colors, value: 'red', getLabel: undefined});
+    expect(sut.result.current.label).toEqual('Red');
+  });
+
+  it('expect label to equal value when no items passed', () => {
+    const sut = makeSUT({items: undefined, value: 'Some string', getLabel: undefined});
+    expect(sut.result.current.label).toEqual('Some string');
+  });
+});

--- a/src/components/picker/helpers/usePickerLabel.tsx
+++ b/src/components/picker/helpers/usePickerLabel.tsx
@@ -21,10 +21,6 @@ const usePickerLabel = (props: UsePickerLabelProps) => {
   }, [getItemLabel, items]);
 
   const _getLabel = useCallback((value: PickerValue) => {
-    if (_.isUndefined(value) || typeof value === 'string') {
-      return value;
-    }
-
     if (_.isFunction(getLabel) && !_.isUndefined(getLabel(value))) {
       return getLabel(value);
     }
@@ -36,6 +32,10 @@ const usePickerLabel = (props: UsePickerLabelProps) => {
     if (!_.isEmpty(items)) {
       const selectedItem = _.find(items, {value});
       return _.get(selectedItem, 'label');
+    }
+
+    if (_.isUndefined(value) || typeof value === 'string') {
+      return value;
     }
   }, [getLabel, getLabelsFromArray, items]);
 

--- a/src/components/picker/helpers/usePickerLabel.tsx
+++ b/src/components/picker/helpers/usePickerLabel.tsx
@@ -34,7 +34,7 @@ const usePickerLabel = (props: UsePickerLabelProps) => {
       return _.get(selectedItem, 'label');
     }
 
-    if (_.isUndefined(value) || typeof value === 'string') {
+    if (typeof value === 'string') {
       return value;
     }
   }, [getLabel, getLabelsFromArray, items]);

--- a/src/components/picker/helpers/usePickerLabel.tsx
+++ b/src/components/picker/helpers/usePickerLabel.tsx
@@ -1,5 +1,5 @@
-import {useCallback, useMemo} from 'react';
 import _ from 'lodash';
+import {useCallback, useMemo} from 'react';
 import {PickerProps, PickerValue} from '../types';
 
 interface UsePickerLabelProps
@@ -15,12 +15,10 @@ const usePickerLabel = (props: UsePickerLabelProps) => {
 
   const getLabelsFromArray = useCallback((value: PickerValue) => {
     const itemsByValue = _.keyBy(items, 'value');
-
     return _.flow(arr =>
       _.map(arr, item => (_.isPlainObject(item) ? getItemLabel?.(item) || item?.label : itemsByValue[item]?.label)),
     arr => _.join(arr, ', '))(value);
-  },
-  [getItemLabel, items]);
+  }, [getItemLabel, items]);
 
   const _getLabel = useCallback((value: PickerValue) => {
     if (_.isFunction(getLabel) && !_.isUndefined(getLabel(value))) {
@@ -31,19 +29,13 @@ const usePickerLabel = (props: UsePickerLabelProps) => {
       return getLabelsFromArray(value);
     }
 
-    // TODO: Remove
-    // if (typeof value === 'object') {
-    //   return value?.label;
-    // }
-
     if (!_.isEmpty(items)) {
       const selectedItem = _.find(items, {value});
       return _.get(selectedItem, 'label');
     }
 
     return value;
-  },
-  [getLabel, getLabelsFromArray, items]);
+  }, [getLabel, getLabelsFromArray, items]);
 
   const accessibilityInfo = useMemo(() => {
     const label = _getLabel(value);

--- a/src/components/picker/helpers/usePickerLabel.tsx
+++ b/src/components/picker/helpers/usePickerLabel.tsx
@@ -21,6 +21,10 @@ const usePickerLabel = (props: UsePickerLabelProps) => {
   }, [getItemLabel, items]);
 
   const _getLabel = useCallback((value: PickerValue) => {
+    if (_.isUndefined(value) || typeof value === 'string') {
+      return value;
+    }
+
     if (_.isFunction(getLabel) && !_.isUndefined(getLabel(value))) {
       return getLabel(value);
     }
@@ -33,8 +37,6 @@ const usePickerLabel = (props: UsePickerLabelProps) => {
       const selectedItem = _.find(items, {value});
       return _.get(selectedItem, 'label');
     }
-
-    return value;
   }, [getLabel, getLabelsFromArray, items]);
 
   const accessibilityInfo = useMemo(() => {

--- a/src/components/picker/helpers/usePickerLabel.tsx
+++ b/src/components/picker/helpers/usePickerLabel.tsx
@@ -36,12 +36,14 @@ const usePickerLabel = (props: UsePickerLabelProps) => {
     //   return value?.label;
     // }
 
-    // otherwise, extract from picker items
-    const selectedItem = _.find(items, {value});
+    if (!_.isEmpty(items)) {
+      const selectedItem = _.find(items, {value});
+      return _.get(selectedItem, 'label');
+    }
 
-    return _.get(selectedItem, 'label');
+    return value;
   },
-  [getLabelsFromArray, items]);
+  [getLabel, getLabelsFromArray, items]);
 
   const accessibilityInfo = useMemo(() => {
     const label = _getLabel(value);
@@ -51,7 +53,7 @@ const usePickerLabel = (props: UsePickerLabelProps) => {
       accessibilityHint:
         accessibilityHint ?? (label ? 'Double tap to edit' : `Goes to ${placeholder}. Suggestions will be provided`)
     };
-  }, [value, accessibilityLabel, accessibilityHint]);
+  }, [value, placeholder, accessibilityLabel, accessibilityHint, _getLabel]);
 
   return {
     getLabelsFromArray,


### PR DESCRIPTION
## Description
Picker - usePickerLabel - fix picker label is empty if the 'value' prop is a string and no 'items' passed.

usacase: `<Picker value={'Picker Value'}/>`

## Changelog
⚠️ Picker - usePickerLabel - fix picker label is empty if the 'value' prop is a string and no 'items' passed.

## Additional info

