### PR TITLE
passing label from usePickerLabel when using filter filedtype

### DIFF
--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -114,6 +114,8 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
     mode
   });
 
+  const {placeholder, style, trailingAccessory, label: propsLabel} = themeProps;
+
   const {label, accessibilityInfo} = usePickerLabel({
     value,
     items,
@@ -121,10 +123,9 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
     getLabel,
     accessibilityLabel,
     accessibilityHint,
-    placeholder: themeProps.placeholder
+    placeholder
   });
 
-  const {placeholder, style, trailingAccessory, label: propsLabel} = themeProps;
   const {propsByFieldType, pickerInnerInput} = useFieldType({
     fieldType,
     preset,
@@ -132,7 +133,7 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
     style,
     placeholder,
     labelStyle,
-    label: propsLabel,
+    label: label || propsLabel,
     testID
   });
 


### PR DESCRIPTION
## Description
Picker with field type is using `label and placeholder` props to render the text filed inner input.
The `useFieldType` hook was using the label from the props instead from the `usePickerLabel` hook, now it uses the value from the label hook and as fallback the label prop value.
related [PR](https://github.com/wix/react-native-ui-lib/pull/3130)

## Changelog
Fix Picker with field type not showing the selected value.

## Additional info
None
