### PR TITLE
changed collapsing to be false on android

### DIFF
--- a/src/components/checkbox/index.tsx
+++ b/src/components/checkbox/index.tsx
@@ -17,6 +17,7 @@ import TouchableOpacity from '../touchableOpacity';
 import Text, {TextProps} from '../text';
 import View from '../view';
 import Icon from '../icon';
+import Constants from '../../commons/Constants';
 
 const DEFAULT_SIZE = 24;
 const DEFAULT_COLOR = Colors.$backgroundPrimaryHeavy;
@@ -287,7 +288,7 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
     const {label, labelStyle, containerStyle, labelProps, testID} = this.props;
     
     return label ? (
-      <View row centerV style={containerStyle}>
+      <View row centerV style={containerStyle} collapsable={!Constants.isAndroid}>
         {this.renderCheckbox()}
         <Text flexS style={[this.styles.checkboxLabel, this.getLabelStyle(), labelStyle]} recorderTag={'unmask'} {...labelProps} onPress={this.onPress} testID={`${testID}.label`}>
           {label}


### PR DESCRIPTION
## Description
Fixes error on android when using the Checkbox with a hint. I think the problem comes from measureInWindow on android or something in that are. Not sure what causes this error. Issue: https://github.com/facebook/react-native/issues/29638 not 100% related but this seems to solve the issue here also.

## Changelog
Checkbox - Fixed crash when using hint on android.

## Additional info
MADS-4310
