### PR TITLE
Separate icon color passed in Button from icon style

### DIFF
--- a/demo/src/screens/__tests__/__snapshots__/TextFieldScreen.spec.js.snap
+++ b/demo/src/screens/__tests__/__snapshots__/TextFieldScreen.spec.js.snap
@@ -3002,9 +3002,7 @@ exports[`TextField Screen renders screen 1`] = `
                       "tintColor": "#5A48F5",
                     },
                     [
-                      {
-                        "tintColor": "#5A48F5",
-                      },
+                      {},
                       {
                         "tintColor": "#A6ACB1",
                       },
@@ -3738,9 +3736,7 @@ exports[`TextField Screen renders screen 1`] = `
                     "tintColor": "#20303C",
                   },
                   [
-                    {
-                      "tintColor": "#20303C",
-                    },
+                    {},
                     undefined,
                   ],
                 ]

--- a/demo/src/screens/componentScreens/ButtonsScreen.tsx
+++ b/demo/src/screens/componentScreens/ButtonsScreen.tsx
@@ -234,15 +234,16 @@ export default class ButtonsScreen extends Component {
               style={{marginBottom: ButtonSpace}}
               iconSource={iconStyle => (
                 <View
-                  style={{
-                    width: 20,
-                    height: 20,
-                    // @ts-expect-error
-                    backgroundColor: iconStyle[0]?.tintColor,
-                    borderRadius: 10,
-                    // @ts-expect-error
-                    marginRight: iconStyle[0]?.marginRight
-                  }}
+                  style={[
+                    iconStyle,
+                    {
+                      width: 20,
+                      height: 20,
+                      // @ts-expect-error
+                      backgroundColor: iconStyle[0]?.tintColor,
+                      borderRadius: 10
+                    }
+                  ]}
                 />
               )}
             />

--- a/demo/src/screens/componentScreens/ButtonsScreen.tsx
+++ b/demo/src/screens/componentScreens/ButtonsScreen.tsx
@@ -215,6 +215,10 @@ export default class ButtonsScreen extends Component {
             </View>
 
             <Button style={{marginBottom: ButtonSpace}} size={Button.sizes.small} iconSource={plusIcon} label="Icon"/>
+            
+            <Button marginB-s5 iconSource={plusIcon} iconProps={{tintColor: 'red'}} label="Custom icon color"/>
+
+            <Button marginB-s5 iconSource={plusIcon} iconStyle={{tintColor: 'pink'}} label="Custom icon style"/>
 
             <Button style={{marginBottom: ButtonSpace}} outline iconSource={plusIcon} label="Icon"/>
 

--- a/src/components/button/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/button/__tests__/__snapshots__/index.spec.js.snap
@@ -2334,6 +2334,214 @@ exports[`Button icon should apply color on icon 2`] = `
 </View>
 `;
 
+exports[`Button icon should apply the right icon color 1`] = `
+<View
+  accessibilityRole="button"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onClick={[Function]}
+  onLayout={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    {
+      "alignItems": "center",
+      "backgroundColor": "#5A48F5",
+      "borderRadius": 999,
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "minWidth": undefined,
+      "opacity": 1,
+      "paddingHorizontal": undefined,
+      "paddingVertical": undefined,
+    }
+  }
+>
+  <Image
+    accessibilityRole="image"
+    accessible={false}
+    source={12}
+    style={
+      [
+        undefined,
+        undefined,
+        undefined,
+        {
+          "tintColor": "red",
+        },
+        [
+          {},
+          undefined,
+        ],
+      ]
+    }
+    testID="undefined.icon"
+  />
+</View>
+`;
+
+exports[`Button icon should apply the right icon color 2`] = `
+<View
+  accessibilityRole="button"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onClick={[Function]}
+  onLayout={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    {
+      "alignItems": "center",
+      "backgroundColor": "#5A48F5",
+      "borderRadius": 999,
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "minWidth": undefined,
+      "opacity": 1,
+      "paddingHorizontal": undefined,
+      "paddingVertical": undefined,
+    }
+  }
+>
+  <Image
+    accessibilityRole="image"
+    accessible={false}
+    source={12}
+    style={
+      [
+        undefined,
+        undefined,
+        undefined,
+        {
+          "tintColor": "#FFFFFF",
+        },
+        [
+          {},
+          {
+            "tintColor": "#ffee22",
+          },
+        ],
+      ]
+    }
+    testID="undefined.icon"
+  />
+</View>
+`;
+
+exports[`Button icon should apply the right icon color 3`] = `
+<View
+  accessibilityRole="button"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onClick={[Function]}
+  onLayout={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    {
+      "alignItems": "center",
+      "backgroundColor": "#5A48F5",
+      "borderRadius": 999,
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "minWidth": undefined,
+      "opacity": 1,
+      "paddingHorizontal": undefined,
+      "paddingVertical": undefined,
+    }
+  }
+>
+  <Image
+    accessibilityRole="image"
+    accessible={false}
+    source={12}
+    style={
+      [
+        undefined,
+        undefined,
+        undefined,
+        {
+          "tintColor": "red",
+        },
+        [
+          {},
+          {
+            "tintColor": "#ffee22",
+          },
+        ],
+      ]
+    }
+    testID="undefined.icon"
+  />
+</View>
+`;
+
 exports[`Button icon should include custom iconStyle provided as a prop 1`] = `
 <View
   accessibilityRole="button"

--- a/src/components/button/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/button/__tests__/__snapshots__/index.spec.js.snap
@@ -1133,7 +1133,6 @@ exports[`Button container size should have no padding of button is an icon butto
         [
           {
             "marginRight": 8,
-            "tintColor": "#FFFFFF",
           },
           undefined,
         ],
@@ -2257,9 +2256,7 @@ exports[`Button icon should apply color on icon 1`] = `
           "tintColor": "green",
         },
         [
-          {
-            "tintColor": "green",
-          },
+          {},
           undefined,
         ],
       ]
@@ -2327,9 +2324,7 @@ exports[`Button icon should apply color on icon 2`] = `
           "tintColor": "#FC3D2F",
         },
         [
-          {
-            "tintColor": "#FC3D2F",
-          },
+          {},
           undefined,
         ],
       ]
@@ -2397,9 +2392,7 @@ exports[`Button icon should include custom iconStyle provided as a prop 1`] = `
           "tintColor": "#FFFFFF",
         },
         [
-          {
-            "tintColor": "#FFFFFF",
-          },
+          {},
           {
             "marginRight": 9,
             "tintColor": "red",
@@ -2472,9 +2465,7 @@ exports[`Button icon should return icon style according to different variations 
           "tintColor": "#5A48F5",
         },
         [
-          {
-            "tintColor": "#5A48F5",
-          },
+          {},
           undefined,
         ],
       ]
@@ -2542,9 +2533,7 @@ exports[`Button icon should return icon style according to different variations 
           "tintColor": "#5A48F5",
         },
         [
-          {
-            "tintColor": "#5A48F5",
-          },
+          {},
           undefined,
         ],
       ]
@@ -2612,9 +2601,7 @@ exports[`Button icon should return icon style according to different variations 
           "tintColor": "#FFFFFF",
         },
         [
-          {
-            "tintColor": "#FFFFFF",
-          },
+          {},
           undefined,
         ],
       ]
@@ -3856,9 +3843,7 @@ exports[`Button labelColor should return undefined color if this is an icon butt
           "tintColor": "#FFFFFF",
         },
         [
-          {
-            "tintColor": "#FFFFFF",
-          },
+          {},
           undefined,
         ],
       ]

--- a/src/components/button/__tests__/index.spec.js
+++ b/src/components/button/__tests__/index.spec.js
@@ -253,6 +253,14 @@ describe('Button', () => {
     it('should include custom iconStyle provided as a prop', () => {
       expect(renderer.create(<Button iconSource={12} iconStyle={{marginRight: 9, tintColor: 'red'}}/>).toJSON()).toMatchSnapshot();
     });
+
+    it('should apply the right icon color', () => {
+      expect(renderer.create(<Button iconSource={12} iconProps={{tintColor: 'red'}}/>).toJSON()).toMatchSnapshot();
+      expect(renderer.create(<Button iconSource={12} iconStyle={{tintColor: '#ffee22'}}/>).toJSON()).toMatchSnapshot();
+      expect(renderer
+        .create(<Button iconSource={12} iconProps={{tintColor: 'red'}} iconStyle={{tintColor: '#ffee22'}}/>)
+        .toJSON()).toMatchSnapshot();
+    });
   });
 });
 

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -124,6 +124,17 @@ class Button extends PureComponent<Props, ButtonState> {
     return color;
   }
 
+  getIconColor(): string | undefined {
+    const {disabled} = this.props;
+    let tintColor = this.getLabelColor();
+
+    if (disabled && !this.isFilled) {
+      tintColor = Colors.$iconDisabled;
+    }
+
+    return tintColor;
+  }
+
   getLabelSizeStyle() {
     const size = this.props.size || DEFAULT_SIZE;
 
@@ -249,11 +260,9 @@ class Button extends PureComponent<Props, ButtonState> {
   }
 
   getIconStyle(): [ImageStyle, StyleProp<ImageStyle>] {
-    const {disabled, iconStyle: propsIconStyle, iconOnRight, size: propsSize, link} = this.props;
+    const {iconStyle: propsIconStyle, iconOnRight, size: propsSize, link} = this.props;
     const size = propsSize || DEFAULT_SIZE;
-    const iconStyle: ImageStyle = {
-      tintColor: this.getLabelColor()
-    };
+    const iconStyle: ImageStyle = {};
     const marginSide = link
       ? 4
       : ([Button.sizes.large, Button.sizes.medium] as ButtonSizeProp[]).includes(size)
@@ -266,10 +275,6 @@ class Button extends PureComponent<Props, ButtonState> {
       } else {
         iconStyle.marginRight = marginSide;
       }
-    }
-
-    if (disabled && !this.isFilled) {
-      iconStyle.tintColor = Colors.$iconDisabled;
     }
 
     return [iconStyle, propsIconStyle];
@@ -297,10 +302,11 @@ class Button extends PureComponent<Props, ButtonState> {
     const {iconSource, supportRTL, testID, iconProps} = this.props;
 
     if (iconSource) {
+      const iconColor = this.getIconColor();
       const iconStyle = this.getIconStyle();
 
       if (typeof iconSource === 'function') {
-        return iconSource(iconStyle);
+        return iconSource([{tintColor: iconColor}, this.getIconStyle()]);
       } else {
         // if (Constants.isWeb) {
         return (
@@ -309,9 +315,8 @@ class Button extends PureComponent<Props, ButtonState> {
             source={iconSource}
             supportRTL={supportRTL}
             testID={`${testID}.icon`}
-            // Note Passing tintColor as prop is required for Web
-            // @ts-expect-error RN ImageStyle conflicts with ImageProps in tintColor type
-            tintColor={iconStyle[0]?.tintColor}
+            // Note: Passing tintColor as prop is required for Web
+            tintColor={iconColor}
             {...iconProps}
           />
         );


### PR DESCRIPTION
## Description
Separate the icon color we pass in Button from the icon style object. 
This allows up to pass iconColor to the `tintColor` prop and allow the user to override it color properly 

## Changelog
Fix issue with Button's icon color not being overridden when passing `iconProps`/`iconStyle`

## Additional info
