### PR TITLE
fix(TabBar): Fixing warning from TabBar defaultProps deprecated

### DIFF
--- a/src/components/tabController/TabBar.tsx
+++ b/src/components/tabController/TabBar.tsx
@@ -142,8 +142,8 @@ const TabBar = (props: Props) => {
     enableShadow,
     shadowStyle: propsShadowStyle,
     indicatorStyle,
-    labelStyle,
-    selectedLabelStyle,
+    labelStyle = DEFAULT_LABEL_STYLE,
+    selectedLabelStyle = DEFAULT_SELECTED_LABEL_STYLE,
     labelColor,
     selectedLabelColor,
     uppercase,
@@ -151,10 +151,10 @@ const TabBar = (props: Props) => {
     selectedIconColor,
     activeBackgroundColor,
     backgroundColor = Colors.$backgroundElevated,
-    faderProps,
+    faderProps = DEFAULT_FADER_PROPS,
     containerWidth: propsContainerWidth,
     centerSelected,
-    spreadItems,
+    spreadItems = true,
     indicatorInsets = Spacings.s4,
     indicatorWidth,
     containerStyle,
@@ -319,12 +319,6 @@ const TabBar = (props: Props) => {
 };
 
 TabBar.displayName = 'TabController.TabBar';
-TabBar.defaultProps = {
-  labelStyle: DEFAULT_LABEL_STYLE,
-  selectedLabelStyle: DEFAULT_SELECTED_LABEL_STYLE,
-  faderProps: DEFAULT_FADER_PROPS,
-  spreadItems: true
-};
 
 const styles = StyleSheet.create({
   container: {


### PR DESCRIPTION
## Description

TabBar using deprecated `defaultProps`.
Seeing warning in projects: 

```
Warning: TabController.TabBar: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
```

## Changelog

- Removed usage of defaultProps from TabBar and replaced functionality with JavaScript default parameters.

## Additional info
<!--
If applicable, add additional info such as link to the bug being fixed by this PR etc
-->

https://github.com/wix/react-native-ui-lib/issues/3154
