### PR TITLE
SectionsWheelPickerDriver - Fixed handling of custom testID.

### DIFF
--- a/src/components/sectionsWheelPicker/SectionsWheelPicker.driver.tsx
+++ b/src/components/sectionsWheelPicker/SectionsWheelPicker.driver.tsx
@@ -1,16 +1,17 @@
 import _ from 'lodash';
+import type {ReactTestInstance} from 'react-test-renderer';
 import {useComponentDriver, ComponentProps} from '../../testkit/new/Component.driver';
 import {WheelPickerDriver} from '../WheelPicker/WheelPicker.driver';
-import {SectionsWheelPickerProps} from './index';
+import type {SectionsWheelPickerProps} from './index';
 
 export const SectionsWheelPickerDriver = (props: ComponentProps) => {
   const driver = useComponentDriver(props);
-  const sections = driver.getElement().children as SectionsWheelPickerProps['sections'];
+  const sections = _.map(driver.getElement().children as ReactTestInstance[], (child) => child.props) as SectionsWheelPickerProps['sections'];
   const sectionsDrivers = _.map(sections, (section, index) => {
     const sectionTestID = `${props.testID}.${index}`;
     return WheelPickerDriver({
       renderTree: props.renderTree,
-      testID: section?.testID || sectionTestID
+      testID: section.testID || sectionTestID
     });
   });
   return {...driver, sections, sectionsDrivers};


### PR DESCRIPTION
## Description
Added handling for custom testID in the `SectionsWheelPicker` driver. Taking just the element isn't enough to get the testID we need to go one level down (taking the props from the instance).

## Changelog
SectionsWheelPicker - Fixed driver custom testID capture.

## Additional info
MADS-4398
