### PR TITLE
Hint - Hide mocked children

### DIFF
--- a/src/components/hint/index.tsx
+++ b/src/components/hint/index.tsx
@@ -546,7 +546,7 @@ class Hint extends Component<HintProps, HintState> {
       };
 
       return (
-        <View style={[styles.mockChildrenContainer, layout, !isBackdropColorPassed && {opacity: 0}]}>
+        <View style={[styles.mockChildrenContainer, layout, !isBackdropColorPassed && styles.hidden]}>
           {React.cloneElement<any>(children, {
             collapsable: false,
             key: 'mock',
@@ -610,6 +610,7 @@ const styles = StyleSheet.create({
   container: {
     position: 'absolute'
   },
+  hidden: {opacity: 0},
   overlayContainer: {
     zIndex: 10,
     elevation: 10


### PR DESCRIPTION
## Description
Hint causes mocked component to be shown over other components when there are components with higher zIndex on them.

## Changelog
Hint - Mocked children are hidden when not backdropColor is passed.

## Additional info
MADS-4399
