### PR TITLE
Fixed lib/package.js main

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -3,7 +3,7 @@
   "version": "4.1.3",
   "homepage": "https://github.com/wix/react-native-ui-lib",
   "description": "uilib native components (separated from js components)",
-  "main": "components/index.js",
+  "main": "components/index.ts",
   "scripts": {},
   "author": "Ethan Sharabi <ethan.shar@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Description
Fixed lib/package.js main. It should be done in order to prevent require.resolve("uilib-native") crashed.

## Changelog

## Additional info
