### PR TITLE
TextField - only use leadingAccessoryRef when needed (i.e. floatingPlaceholder={true})

### DIFF
--- a/src/components/textField/index.tsx
+++ b/src/components/textField/index.tsx
@@ -70,7 +70,7 @@ const TextField = (props: InternalTextFieldProps) => {
     labelStyle,
     labelProps,
     // Accessory Buttons
-    leadingAccessory,
+    leadingAccessory: propsLeadingAccessory,
     trailingAccessory,
     topTrailingAccessory,
     bottomAccessory,
@@ -107,12 +107,16 @@ const TextField = (props: InternalTextFieldProps) => {
   }, [fieldState, others.editable, readonly, validateField, checkValidity]);
 
   const leadingAccessoryClone = useMemo(() => {
-    if (leadingAccessory) {
-      return React.cloneElement(leadingAccessory, {
+    if (propsLeadingAccessory) {
+      return React.cloneElement(propsLeadingAccessory, {
         ref: leadingAccessoryRef
       });
     }
-  }, [leadingAccessory]);
+  }, [propsLeadingAccessory]);
+
+  const leadingAccessory = useMemo(() => {
+    return floatingPlaceholder ? leadingAccessoryClone : propsLeadingAccessory;
+  }, [floatingPlaceholder, leadingAccessoryClone, propsLeadingAccessory]);
 
   const {margins, paddings, typography, positionStyle, color} = modifiers;
   const typographyStyle = useMemo(() => omit(typography, 'lineHeight'), [typography]);
@@ -161,7 +165,7 @@ const TextField = (props: InternalTextFieldProps) => {
         </View>
         <View style={[paddings, fieldStyle]} row centerV centerH={centered}>
           {/* <View row centerV> */}
-          {leadingAccessoryClone}
+          {leadingAccessory}
 
           {/* Note: We're passing flexG to the View to support properly inline behavior - so the input will be rendered correctly in a row container.
             Known Issue: This slightly push the trailing accessory and clear button when entering a long text


### PR DESCRIPTION
## Description
TextField - only use leadingAccessoryRef when needed (i.e. floatingPlaceholder={true})

If the user has a function component for `leadingAccessory`:
```
export const LeadingAccessory = () => {
  return <Text marginR-2>leading accessory</Text>;
};
```
They will get an error since we require a ref for the `leadingAccessory` and in a function component it needs to be forwarded.
One solution is to use `React.forwardRef`, however this can be avoided in cases where `floatingPlaceholder={false}` because that's the only reason to have the `ref`.

## Changelog
TextField - only require `leadingAccessory` to have a ref when needed (i.e. floatingPlaceholder={true})

## Additional info
Channel (Aug. 4th)
