### PR TITLE
fix: picker items list is error when array is empty

### DIFF
--- a/src/components/picker/PickerItemsList.tsx
+++ b/src/components/picker/PickerItemsList.tsx
@@ -36,7 +36,7 @@ const PickerItemsList = (props: PickerItemsListProps) => {
   } = props;
   const context = useContext(PickerContext);
 
-  const [wheelPickerValue, setWheelPickerValue] = useState<PickerSingleValue>(context.value ?? items?.[0].value);
+  const [wheelPickerValue, setWheelPickerValue] = useState<PickerSingleValue>(context.value ?? items?.[0]?.value);
   // TODO: Might not need this memoized style, instead we can move it to a stylesheet
   const wrapperContainerStyle = useMemo(() => {
     // const shouldFlex = Constants.isWeb ? 1 : useDialog ? 1 : 1;


### PR DESCRIPTION
## Description
When passing items as empty array to the Picker, it will report an error
error message:  Cannot read property 'value' of undefined

<img width="372" alt="image" src="https://github.com/user-attachments/assets/ce3480b6-d093-476e-b34e-fd10a507831b">

## Changelog
When passing items as empty array to the Picker, it will report an error.
