### PR TITLE
Text - Highlight strings with content as array of string.

### DIFF
--- a/demo/src/screens/PlaygroundScreen.tsx
+++ b/demo/src/screens/PlaygroundScreen.tsx
@@ -5,15 +5,15 @@ export default class PlaygroundScreen extends Component {
   render() {
     return (
       <View bg-grey80 flex padding-20>
-        <View marginT-20>
-          <TextField migrate placeholder="Placeholder"/>
-        </View>
-        <Card height={100} center padding-20>
-          <Text text50>Playground Screen</Text>
-        </Card>
-        <View flex center>
-          <Button marginV-20 label="Button"/>
-        </View>
+        <Text
+          testID="my-test"
+          highlightString={[
+            {string: 'An', style: {color: 'green'}},
+            {string: 'This', style: {color: 'red'}}
+          ]}
+        >
+          {['Is ', 'An ', 'Array ', 'Of ', 'This ', 'Strings']}
+        </Text>
       </View>
     );
   }


### PR DESCRIPTION
## Description
Bug reproduce for 4373. When text is passed an array of strings each iteration of the text highlight checks the first object of the highlight string array. Since it does not find it (if its not the first one in the array) the loop exists thus its not getting the custom styling.

## Changelog
<!--
Add a quick message for our users about this change (include Component name, relevant props and general purpose of the PR)
-->

## Additional info
<!--
If applicable, add additional info such as link to the bug being fixed by this PR etc
-->
