### PR TITLE
button border width grow outside the container

### DIFF
--- a/demo/src/screens/__tests__/__snapshots__/TextFieldScreen.spec.js.snap
+++ b/demo/src/screens/__tests__/__snapshots__/TextFieldScreen.spec.js.snap
@@ -3521,8 +3521,8 @@ exports[`TextField Screen renders screen 1`] = `
               "marginLeft": 20,
               "minWidth": 66,
               "opacity": 1,
-              "paddingHorizontal": 10,
-              "paddingVertical": 2,
+              "paddingHorizontal": 11,
+              "paddingVertical": 3,
             }
           }
         >

--- a/src/components/button/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/button/__tests__/__snapshots__/index.spec.js.snap
@@ -482,8 +482,8 @@ exports[`Button backgroundColor should return undefined if this button is outlin
       "justifyContent": "center",
       "minWidth": 90,
       "opacity": 1,
-      "paddingHorizontal": 19,
-      "paddingVertical": 8.5,
+      "paddingHorizontal": 20,
+      "paddingVertical": 9.5,
     }
   }
 >
@@ -1230,8 +1230,8 @@ exports[`Button container size should reduce padding by outlineWidth in case of 
       "justifyContent": "center",
       "minWidth": 90,
       "opacity": 1,
-      "paddingHorizontal": 18,
-      "paddingVertical": 7.5,
+      "paddingHorizontal": 20,
+      "paddingVertical": 9.5,
     }
   }
 >
@@ -1408,8 +1408,8 @@ exports[`Button container size should return style for large button 2`] = `
       "justifyContent": "center",
       "minWidth": 90,
       "opacity": 1,
-      "paddingHorizontal": 19,
-      "paddingVertical": 8.5,
+      "paddingHorizontal": 20,
+      "paddingVertical": 9.5,
     }
   }
 >
@@ -1591,8 +1591,8 @@ exports[`Button container size should return style for medium button 2`] = `
       "justifyContent": "center",
       "minWidth": 77,
       "opacity": 1,
-      "paddingHorizontal": 15,
-      "paddingVertical": 5.5,
+      "paddingHorizontal": 16,
+      "paddingVertical": 6.5,
     }
   }
 >
@@ -1684,7 +1684,7 @@ exports[`Button container size should return style for round button 1`] = `
       "height": undefined,
       "justifyContent": "center",
       "opacity": 1,
-      "padding": 9.5,
+      "padding": 8.5,
       "width": undefined,
     }
   }
@@ -1867,8 +1867,8 @@ exports[`Button container size should return style for small button 2`] = `
       "justifyContent": "center",
       "minWidth": 70,
       "opacity": 1,
-      "paddingHorizontal": 13,
-      "paddingVertical": 3.5,
+      "paddingHorizontal": 14,
+      "paddingVertical": 4.5,
     }
   }
 >
@@ -2055,8 +2055,8 @@ exports[`Button container size should return style for xSmall button 2`] = `
       "justifyContent": "center",
       "minWidth": 66,
       "opacity": 1,
-      "paddingHorizontal": 10,
-      "paddingVertical": 2,
+      "paddingHorizontal": 11,
+      "paddingVertical": 3,
     }
   }
 >
@@ -4191,8 +4191,8 @@ exports[`Button outline should render button with an outline 1`] = `
       "justifyContent": "center",
       "minWidth": 90,
       "opacity": 1,
-      "paddingHorizontal": 19,
-      "paddingVertical": 8.5,
+      "paddingHorizontal": 20,
+      "paddingVertical": 9.5,
     }
   }
 >
@@ -4371,8 +4371,8 @@ exports[`Button outline should render button with outline and outlineColor 1`] =
       "justifyContent": "center",
       "minWidth": 90,
       "opacity": 1,
-      "paddingHorizontal": 19,
-      "paddingVertical": 8.5,
+      "paddingHorizontal": 20,
+      "paddingVertical": 9.5,
     }
   }
 >
@@ -4461,8 +4461,8 @@ exports[`Button outline should return custom borderWidth according to outlineWid
       "justifyContent": "center",
       "minWidth": 90,
       "opacity": 1,
-      "paddingHorizontal": 17,
-      "paddingVertical": 6.5,
+      "paddingHorizontal": 20,
+      "paddingVertical": 9.5,
     }
   }
 >
@@ -4551,8 +4551,8 @@ exports[`Button outline should return disabled color for outline if button is di
       "justifyContent": "center",
       "minWidth": 90,
       "opacity": 1,
-      "paddingHorizontal": 19,
-      "paddingVertical": 8.5,
+      "paddingHorizontal": 20,
+      "paddingVertical": 9.5,
     }
   }
 >

--- a/src/components/button/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/button/__tests__/__snapshots__/index.spec.js.snap
@@ -1684,7 +1684,7 @@ exports[`Button container size should return style for round button 1`] = `
       "height": undefined,
       "justifyContent": "center",
       "opacity": 1,
-      "padding": 8.5,
+      "padding": 9.5,
       "width": undefined,
     }
   }

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -149,9 +149,8 @@ class Button extends PureComponent<Props, ButtonState> {
   }
 
   getContainerSizeStyle() {
-    const {avoidMinWidth, avoidInnerPadding, round, size: propsSize, outlineWidth: propsOutlineWidth} = this.props;
+    const {avoidMinWidth, avoidInnerPadding, round, size: propsSize} = this.props;
     const size = propsSize || DEFAULT_SIZE;
-    const outlineWidth = propsOutlineWidth || 1;
 
     const CONTAINER_STYLE_BY_SIZE: Dictionary<any> = {};
     CONTAINER_STYLE_BY_SIZE[Button.sizes.xSmall] = round
@@ -182,12 +181,6 @@ class Button extends PureComponent<Props, ButtonState> {
         paddingHorizontal: HORIZONTAL_PADDINGS.LARGE,
         minWidth: MIN_WIDTH.LARGE
       };
-
-    if (round) {
-      _.forEach(CONTAINER_STYLE_BY_SIZE, style => {
-        style.padding -= outlineWidth;
-      });
-    }
 
     const containerSizeStyle = CONTAINER_STYLE_BY_SIZE[size];
 

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -149,14 +149,7 @@ class Button extends PureComponent<Props, ButtonState> {
   }
 
   getContainerSizeStyle() {
-    const {
-      outline,
-      avoidMinWidth,
-      avoidInnerPadding,
-      round,
-      size: propsSize,
-      outlineWidth: propsOutlineWidth
-    } = this.props;
+    const {avoidMinWidth, avoidInnerPadding, round, size: propsSize, outlineWidth: propsOutlineWidth} = this.props;
     const size = propsSize || DEFAULT_SIZE;
     const outlineWidth = propsOutlineWidth || 1;
 
@@ -190,14 +183,9 @@ class Button extends PureComponent<Props, ButtonState> {
         minWidth: MIN_WIDTH.LARGE
       };
 
-    if (outline) {
+    if (round) {
       _.forEach(CONTAINER_STYLE_BY_SIZE, style => {
-        if (round) {
-          style.padding -= outlineWidth; // eslint-disable-line
-        } else {
-          style.paddingVertical -= outlineWidth; // eslint-disable-line
-          style.paddingHorizontal -= outlineWidth; // eslint-disable-line
-        }
+        style.padding -= outlineWidth;
       });
     }
 


### PR DESCRIPTION
## Description
Button `borderWidth` grow outside the container fix for outline button.
In outline mode, the padding isn't negative anymore so the border doesn't fill the button container inside part.

Snippet to reproduce:
```
import React, {Component} from 'react';
import {View, Colors, Stepper, Button} from 'react-native-ui-lib';

export default class PlaygroundScreen extends Component {
  state = {outlineWidth: 1};
  render() {
    const {outlineWidth} = this.state;
    return (
      <View bg-grey80 flex padding-20 center gap-s3>
        <Button label="Button" outline onPress={() => {}} outlineWidth={outlineWidth}/>
        <Button label="Button" outline round onPress={() => {}} outlineWidth={outlineWidth}/>
        <Button label="Button" onPress={() => {}} outlineWidth={outlineWidth} outlineColor={Colors.red30}/>
        <Button label="Button" round onPress={() => {}} outlineWidth={outlineWidth} outlineColor={Colors.red30}/>

        <Stepper
          value={outlineWidth}
          minValue={0}
          maxValue={10}
          step={1}
          onValueChange={value => this.setState({outlineWidth: value})}
        />
      </View>
    );
  }
}

```

## Changelog
Button `borderWidth` grow outside the container fix for outline button.

## Additional info
MADS-4436
