### PR TITLE
use badge size to set icon/image dimensions

### DIFF
--- a/demo/src/screens/__tests__/__snapshots__/AvatarScreen.spec.js.snap
+++ b/demo/src/screens/__tests__/__snapshots__/AvatarScreen.spec.js.snap
@@ -2049,6 +2049,8 @@ exports[`AvatarScreen renders screen 1`] = `
                   {
                     "backgroundColor": "#FFC50D",
                     "flex": 1,
+                    "height": 14,
+                    "width": 14,
                   },
                   false,
                 ]

--- a/src/components/badge/index.tsx
+++ b/src/components/badge/index.tsx
@@ -224,8 +224,9 @@ class Badge extends PureComponent<BadgeProps> {
   }
 
   renderIcon() {
-    const {icon, iconStyle, iconProps, borderColor, label} = this.props;
+    const {icon, iconStyle, iconProps, borderColor, label, size} = this.props;
     const flex = label ? 0 : 1;
+    const iconSize = {width: size, height: size};
     return (
       icon && (
         <Image
@@ -237,6 +238,7 @@ class Badge extends PureComponent<BadgeProps> {
           {...iconProps}
           style={{
             flex,
+            ...iconSize,
             ...iconStyle
           }}
         />


### PR DESCRIPTION
## Description
Use badge size to determine the Icon/Image dimensions.
When passing `badgeProps` to `Avatar` component with `icon & size` props, when rendering the icon there is no usage of the size prop.

## Changelog
Use badge size to determine the Icon/Image dimensions.

## Additional info
None