### PR TITLE
DateTimePicker - invoke value change only on real change

### DIFF
--- a/jestSetup/jest-setup.js
+++ b/jestSetup/jest-setup.js
@@ -143,3 +143,12 @@ if (typeof String.prototype.replaceAll === 'undefined') {
     return this.split(match).join(replace);
   };
 }
+
+jest.mock('../src/optionalDependencies', () => {
+  const actualOptional = jest.requireActual('../src/optionalDependencies');
+  const view = jest.requireActual('../src/components/view').default;
+  return {
+    ...actualOptional,
+    DateTimePickerPackage: view
+  };
+});

--- a/src/components/dateTimePicker/DateTimePicker.driver.ts
+++ b/src/components/dateTimePicker/DateTimePicker.driver.ts
@@ -1,0 +1,31 @@
+import {fireEvent} from '@testing-library/react-native';
+import {
+  ComponentProps,
+  ExpandableOverlayDriver,
+  ButtonDriver
+} from '../../testkit';
+
+export const DateTimePickerDriver = (props: ComponentProps) => {
+  const {renderTree, testID} = props;
+  const expandableOverlayDriver = ExpandableOverlayDriver({...props, testID: `${testID}.overlay`});
+  const openPicker = () => {
+    expandableOverlayDriver.open();
+  };
+  const discardPicker = () => {
+    ButtonDriver({...props, testID: `${testID}.cancel`}).press();
+  };
+  const submitSelection = () => {
+    ButtonDriver({...props, testID: `${testID}.done`}).press();
+  };
+  const changeDateTo = (date: Date) => {
+    const pickerElement = renderTree.getByTestId(`${testID}.picker`);
+    fireEvent(pickerElement, 'onChange', {type: 'set'}, date);
+  };
+
+  return {
+    openPicker,
+    discardPicker,
+    submitSelection,
+    changeDateTo
+  };
+};

--- a/src/components/dateTimePicker/DateTimePicker.driver.ts
+++ b/src/components/dateTimePicker/DateTimePicker.driver.ts
@@ -8,13 +8,13 @@ import {
 export const DateTimePickerDriver = (props: ComponentProps) => {
   const {renderTree, testID} = props;
   const expandableOverlayDriver = ExpandableOverlayDriver({...props, testID: `${testID}.overlay`});
-  const openPicker = () => {
+  const open = () => {
     expandableOverlayDriver.open();
   };
-  const discardPicker = () => {
+  const close = () => {
     ButtonDriver({...props, testID: `${testID}.cancel`}).press();
   };
-  const submitSelection = () => {
+  const select = () => {
     ButtonDriver({...props, testID: `${testID}.done`}).press();
   };
   const changeDateTo = (date: Date) => {
@@ -23,9 +23,9 @@ export const DateTimePickerDriver = (props: ComponentProps) => {
   };
 
   return {
-    openPicker,
-    discardPicker,
-    submitSelection,
+    open,
+    close,
+    select,
     changeDateTo
   };
 };

--- a/src/components/dateTimePicker/__tests__/index.spec.tsx
+++ b/src/components/dateTimePicker/__tests__/index.spec.tsx
@@ -31,10 +31,10 @@ describe('DateTimePicker', () => {
     const renderTree = render(<TestCase onChange={onChange} mode={mode} value={someDate}/>);
     expect(onChange).not.toHaveBeenCalled();
     const driver = DateTimePickerDriver({renderTree, testID});
-    driver.openPicker();
+    driver.open();
     driver.changeDateTo(mode === 'time' ? someDateNextHour : someDateNextDay);
     expect(onChange).not.toHaveBeenCalled();
-    driver.submitSelection();
+    driver.select();
     expect(onChange).toHaveBeenCalled();
   });
   test.each(['time', 'date'] as const)('should not invoke onChange when value is not changed - mode %s', mode => {
@@ -42,8 +42,8 @@ describe('DateTimePicker', () => {
     const renderTree = render(<TestCase onChange={onChange} mode={mode}/>);
     expect(onChange).not.toHaveBeenCalled();
     const driver = DateTimePickerDriver({renderTree, testID});
-    driver.openPicker();
-    driver.submitSelection();
+    driver.open();
+    driver.select();
     expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/src/components/dateTimePicker/__tests__/index.spec.tsx
+++ b/src/components/dateTimePicker/__tests__/index.spec.tsx
@@ -14,17 +14,9 @@ const TestCase = props => {
 };
 
 describe('DateTimePicker', () => {
-  it('should not invoke onChange when value is not changed - mode time', () => {
+  test.each(['time', 'date'])('should not invoke onChange when value is not changed - mode %s', mode => {
     const onChange = jest.fn();
-    const renderTree = render(<TestCase onChange={onChange} mode="time"/>);
-    expect(onChange).not.toHaveBeenCalled();
-    fireEvent.press(renderTree.getByTestId(testID));
-    fireEvent.press(renderTree.getByTestId(`${testID}.done`));
-    expect(onChange).not.toHaveBeenCalled();
-  });
-  it('should not invoke onChange when value is not changed - mode date', () => {
-    const onChange = jest.fn();
-    const renderTree = render(<TestCase onChange={onChange} mode="date"/>);
+    const renderTree = render(<TestCase onChange={onChange} mode={mode}/>);
     expect(onChange).not.toHaveBeenCalled();
     fireEvent.press(renderTree.getByTestId(testID));
     fireEvent.press(renderTree.getByTestId(`${testID}.done`));

--- a/src/components/dateTimePicker/__tests__/index.spec.tsx
+++ b/src/components/dateTimePicker/__tests__/index.spec.tsx
@@ -26,15 +26,6 @@ jest.mock('../../../optionalDependencies', () => {
 });
 
 describe('DateTimePicker', () => {
-  test.each(['time', 'date'] as const)('should not invoke onChange when value is not changed - mode %s', mode => {
-    const onChange = jest.fn();
-    const renderTree = render(<TestCase onChange={onChange} mode={mode}/>);
-    expect(onChange).not.toHaveBeenCalled();
-    const driver = DateTimePickerDriver({renderTree, testID});
-    driver.openPicker();
-    driver.submitSelection();
-    expect(onChange).not.toHaveBeenCalled();
-  });
   test.each(['time', 'date'] as const)('should invoke onChange when value is changed - mode %s', async mode => {
     const onChange = jest.fn();
     const renderTree = render(<TestCase onChange={onChange} mode={mode} value={someDate}/>);
@@ -45,5 +36,14 @@ describe('DateTimePicker', () => {
     expect(onChange).not.toHaveBeenCalled();
     driver.submitSelection();
     expect(onChange).toHaveBeenCalled();
+  });
+  test.each(['time', 'date'] as const)('should not invoke onChange when value is not changed - mode %s', mode => {
+    const onChange = jest.fn();
+    const renderTree = render(<TestCase onChange={onChange} mode={mode}/>);
+    expect(onChange).not.toHaveBeenCalled();
+    const driver = DateTimePickerDriver({renderTree, testID});
+    driver.openPicker();
+    driver.submitSelection();
+    expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/src/components/dateTimePicker/__tests__/index.spec.tsx
+++ b/src/components/dateTimePicker/__tests__/index.spec.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import {fireEvent, render} from '@testing-library/react-native';
+import DateTimePicker, {DateTimePickerProps} from '../index';
+
+
+const testID = 'dateTimePicker';
+const TestCase = props => {
+  const defaultProps: DateTimePickerProps = {
+    value: new Date('2021-04-04T00:00:00Z'),
+    migrateDialog: true,
+    testID
+  };
+  return <DateTimePicker {...defaultProps} {...props}/>;
+};
+
+describe('DateTimePicker', () => {
+  it('should not invoke onChange when value is not changed - mode time', () => {
+    const onChange = jest.fn();
+    const renderTree = render(<TestCase onChange={onChange} mode="time"/>);
+    expect(onChange).not.toHaveBeenCalled();
+    fireEvent.press(renderTree.getByTestId(testID));
+    fireEvent.press(renderTree.getByTestId(`${testID}.done`));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+  it('should not invoke onChange when value is not changed - mode date', () => {
+    const onChange = jest.fn();
+    const renderTree = render(<TestCase onChange={onChange} mode="date"/>);
+    expect(onChange).not.toHaveBeenCalled();
+    fireEvent.press(renderTree.getByTestId(testID));
+    fireEvent.press(renderTree.getByTestId(`${testID}.done`));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/dateTimePicker/__tests__/index.spec.tsx
+++ b/src/components/dateTimePicker/__tests__/index.spec.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import {fireEvent, render} from '@testing-library/react-native';
 import DateTimePicker, {DateTimePickerProps} from '../index';
-
+import {act} from 'react-test-renderer';
 
 const testID = 'dateTimePicker';
-const TestCase = props => {
+const TestCase = (props: Partial<Omit<DateTimePickerProps, 'dialogProps'>>) => {
   const defaultProps: DateTimePickerProps = {
     value: new Date('2021-04-04T00:00:00Z'),
     migrateDialog: true,
@@ -13,13 +13,39 @@ const TestCase = props => {
   return <DateTimePicker {...defaultProps} {...props}/>;
 };
 
+const someDate = new Date('2021-04-04T00:00:00Z');
+const someDateNextDay = new Date(someDate.getTime() + 24 * 60 * 60 * 1000);
+const someDateNextHour = new Date(someDate.getTime() + 60 * 60 * 1000);
+jest.mock('../../../optionalDependencies', () => {
+  const actualOptional = jest.requireActual('../../../optionalDependencies');
+  const view = jest.requireActual('../../view').default;
+  return {
+    ...actualOptional,
+    DateTimePickerPackage: view
+  };
+});
+
 describe('DateTimePicker', () => {
-  test.each(['time', 'date'])('should not invoke onChange when value is not changed - mode %s', mode => {
+  test.each(['time', 'date'] as const)('should not invoke onChange when value is not changed - mode %s', mode => {
     const onChange = jest.fn();
     const renderTree = render(<TestCase onChange={onChange} mode={mode}/>);
     expect(onChange).not.toHaveBeenCalled();
-    fireEvent.press(renderTree.getByTestId(testID));
+    fireEvent.press(renderTree.getByTestId(`${testID}.overlay`));
     fireEvent.press(renderTree.getByTestId(`${testID}.done`));
     expect(onChange).not.toHaveBeenCalled();
+  });
+  test.each(['time', 'date'] as const)('should invoke onChange when value is changed - mode %s', async mode => {
+    const onChange = jest.fn();
+    const renderTree = render(<TestCase onChange={onChange} mode={mode} value={someDate}/>);
+    expect(onChange).not.toHaveBeenCalled();
+    act(() => {
+      fireEvent.press(renderTree.getByTestId(`${testID}.overlay`));
+    });
+    fireEvent(renderTree.getByTestId(`${testID}.picker`),
+      'onChange',
+      {type: 'set'},
+      mode === 'time' ? someDateNextHour : someDateNextDay);
+    fireEvent.press(renderTree.getByTestId(`${testID}.done`));
+    expect(onChange).toHaveBeenCalled();
   });
 });

--- a/src/components/dateTimePicker/__tests__/index.spec.tsx
+++ b/src/components/dateTimePicker/__tests__/index.spec.tsx
@@ -32,10 +32,11 @@ describe('DateTimePicker', () => {
     expect(onChange).not.toHaveBeenCalled();
     const driver = DateTimePickerDriver({renderTree, testID});
     driver.open();
-    driver.changeDateTo(mode === 'time' ? someDateNextHour : someDateNextDay);
+    const dateToChangeTo = mode === 'time' ? someDateNextHour : someDateNextDay;
+    driver.changeDateTo(dateToChangeTo);
     expect(onChange).not.toHaveBeenCalled();
     driver.select();
-    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledWith(dateToChangeTo);
   });
   test.each(['time', 'date'] as const)('should not invoke onChange when value is not changed - mode %s', mode => {
     const onChange = jest.fn();

--- a/src/components/dateTimePicker/__tests__/index.spec.tsx
+++ b/src/components/dateTimePicker/__tests__/index.spec.tsx
@@ -16,14 +16,6 @@ const TestCase = (props: Partial<Omit<DateTimePickerProps, 'dialogProps'>>) => {
 const someDate = new Date('2021-04-04T00:00:00Z');
 const someDateNextDay = new Date(someDate.getTime() + 24 * 60 * 60 * 1000);
 const someDateNextHour = new Date(someDate.getTime() + 60 * 60 * 1000);
-jest.mock('../../../optionalDependencies', () => {
-  const actualOptional = jest.requireActual('../../../optionalDependencies');
-  const view = jest.requireActual('../../view').default;
-  return {
-    ...actualOptional,
-    DateTimePickerPackage: view
-  };
-});
 
 describe('DateTimePicker', () => {
   test.each(['time', 'date'] as const)('should invoke onChange when value is changed - mode %s', mode => {

--- a/src/components/dateTimePicker/__tests__/index.spec.tsx
+++ b/src/components/dateTimePicker/__tests__/index.spec.tsx
@@ -26,7 +26,7 @@ jest.mock('../../../optionalDependencies', () => {
 });
 
 describe('DateTimePicker', () => {
-  test.each(['time', 'date'] as const)('should invoke onChange when value is changed - mode %s', async mode => {
+  test.each(['time', 'date'] as const)('should invoke onChange when value is changed - mode %s', mode => {
     const onChange = jest.fn();
     const renderTree = render(<TestCase onChange={onChange} mode={mode} value={someDate}/>);
     expect(onChange).not.toHaveBeenCalled();

--- a/src/components/dateTimePicker/__tests__/index.spec.tsx
+++ b/src/components/dateTimePicker/__tests__/index.spec.tsx
@@ -4,18 +4,18 @@ import DateTimePicker, {DateTimePickerProps} from '../index';
 import {DateTimePickerDriver} from '../DateTimePicker.driver';
 
 const testID = 'dateTimePicker';
+const someDate = new Date('2021-04-04T00:00:00Z');
+const someDateNextDay = new Date(someDate.getTime() + 24 * 60 * 60 * 1000);
+const someDateNextHour = new Date(someDate.getTime() + 60 * 60 * 1000);
 const TestCase = (props: Partial<Omit<DateTimePickerProps, 'dialogProps'>>) => {
   const defaultProps: DateTimePickerProps = {
-    value: new Date('2021-04-04T00:00:00Z'),
+    value: someDate,
     migrateDialog: true,
     testID
   };
   return <DateTimePicker {...defaultProps} {...props}/>;
 };
 
-const someDate = new Date('2021-04-04T00:00:00Z');
-const someDateNextDay = new Date(someDate.getTime() + 24 * 60 * 60 * 1000);
-const someDateNextHour = new Date(someDate.getTime() + 60 * 60 * 1000);
 
 describe('DateTimePicker', () => {
   test.each(['time', 'date'] as const)('should invoke onChange when value is changed - mode %s', mode => {

--- a/src/components/dateTimePicker/__tests__/index.spec.tsx
+++ b/src/components/dateTimePicker/__tests__/index.spec.tsx
@@ -45,6 +45,7 @@ describe('DateTimePicker', () => {
       'onChange',
       {type: 'set'},
       mode === 'time' ? someDateNextHour : someDateNextDay);
+    expect(onChange).not.toHaveBeenCalled();
     fireEvent.press(renderTree.getByTestId(`${testID}.done`));
     expect(onChange).toHaveBeenCalled();
   });

--- a/src/components/dateTimePicker/__tests__/index.spec.tsx
+++ b/src/components/dateTimePicker/__tests__/index.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import {fireEvent, render} from '@testing-library/react-native';
+import {render} from '@testing-library/react-native';
 import DateTimePicker, {DateTimePickerProps} from '../index';
-import {act} from 'react-test-renderer';
+import {DateTimePickerDriver} from '../DateTimePicker.driver';
 
 const testID = 'dateTimePicker';
 const TestCase = (props: Partial<Omit<DateTimePickerProps, 'dialogProps'>>) => {
@@ -30,23 +30,20 @@ describe('DateTimePicker', () => {
     const onChange = jest.fn();
     const renderTree = render(<TestCase onChange={onChange} mode={mode}/>);
     expect(onChange).not.toHaveBeenCalled();
-    fireEvent.press(renderTree.getByTestId(`${testID}.overlay`));
-    fireEvent.press(renderTree.getByTestId(`${testID}.done`));
+    const driver = DateTimePickerDriver({renderTree, testID});
+    driver.openPicker();
+    driver.submitSelection();
     expect(onChange).not.toHaveBeenCalled();
   });
   test.each(['time', 'date'] as const)('should invoke onChange when value is changed - mode %s', async mode => {
     const onChange = jest.fn();
     const renderTree = render(<TestCase onChange={onChange} mode={mode} value={someDate}/>);
     expect(onChange).not.toHaveBeenCalled();
-    act(() => {
-      fireEvent.press(renderTree.getByTestId(`${testID}.overlay`));
-    });
-    fireEvent(renderTree.getByTestId(`${testID}.picker`),
-      'onChange',
-      {type: 'set'},
-      mode === 'time' ? someDateNextHour : someDateNextDay);
+    const driver = DateTimePickerDriver({renderTree, testID});
+    driver.openPicker();
+    driver.changeDateTo(mode === 'time' ? someDateNextHour : someDateNextDay);
     expect(onChange).not.toHaveBeenCalled();
-    fireEvent.press(renderTree.getByTestId(`${testID}.done`));
+    driver.submitSelection();
     expect(onChange).toHaveBeenCalled();
   });
 });

--- a/src/components/dateTimePicker/index.tsx
+++ b/src/components/dateTimePicker/index.tsx
@@ -21,6 +21,7 @@ import View from '../view';
 import Button, {ButtonProps} from '../button';
 import ExpandableOverlay, {ExpandableOverlayMethods, RenderCustomOverlayProps} from '../../incubator/expandableOverlay';
 import useOldApi, {OldApiProps} from './useOldApi';
+import {isSameDate, isSameHourAndMinute} from '../../utils/dateUtils';
 
 export type DateTimePickerMode = 'date' | 'time';
 
@@ -204,16 +205,7 @@ const DateTimePicker = forwardRef((props: DateTimePickerPropsInternal, ref: Forw
   }, []);
 
   const isValueChanged = useCallback(() => {
-    if (mode === 'time') {
-      return (
-        chosenDate.current?.getHours() !== value?.getHours() || chosenDate.current?.getMinutes() !== value?.getMinutes()
-      );
-    }
-    return (
-      chosenDate.current?.getFullYear() !== value?.getFullYear() ||
-      chosenDate.current?.getMonth() !== value?.getMonth() ||
-      chosenDate.current?.getDate() !== value?.getDate()
-    );
+    return mode === 'time' ? !isSameHourAndMinute(chosenDate.current, value) : !isSameDate(chosenDate.current, value);
   }, [mode, value]);
 
   const onDonePressed = useCallback(() => {

--- a/src/components/dateTimePicker/index.tsx
+++ b/src/components/dateTimePicker/index.tsx
@@ -214,7 +214,7 @@ const DateTimePicker = forwardRef((props: DateTimePickerPropsInternal, ref: Forw
       // since handleChange() is not called on iOS when there is no actual change
       chosenDate.current = new Date();
     }
-    if (isValueChanged() && chosenDate.current) {
+    if (chosenDate.current && isValueChanged()) {
       onChange?.(chosenDate?.current);
     }
     setValue(chosenDate.current);

--- a/src/components/dateTimePicker/index.tsx
+++ b/src/components/dateTimePicker/index.tsx
@@ -203,16 +203,30 @@ const DateTimePicker = forwardRef((props: DateTimePickerPropsInternal, ref: Forw
     expandable.current?.toggleExpandable?.();
   }, []);
 
+  const isValueChanged = useCallback(() => {
+    if (mode === 'time') {
+      return (
+        chosenDate.current?.getHours() !== value?.getHours() || chosenDate.current?.getMinutes() !== value?.getMinutes()
+      );
+    }
+    return (
+      chosenDate.current?.getFullYear() !== value?.getFullYear() ||
+      chosenDate.current?.getMonth() !== value?.getMonth() ||
+      chosenDate.current?.getDate() !== value?.getDate()
+    );
+  }, [mode, value]);
+
   const onDonePressed = useCallback(() => {
     toggleExpandableOverlay();
     if (Constants.isIOS && !chosenDate.current) {
       // since handleChange() is not called on iOS when there is no actual change
       chosenDate.current = new Date();
     }
-
-    onChange?.(chosenDate.current!);
+    if (isValueChanged() && chosenDate.current) {
+      onChange?.(chosenDate?.current);
+    }
     setValue(chosenDate.current);
-  }, [toggleExpandableOverlay, onChange]);
+  }, [toggleExpandableOverlay, onChange, isValueChanged]);
 
   const handleChange = useCallback((event: any = {}, date: Date) => {
     // NOTE: will be called on Android even when there was no actual change

--- a/src/testkit/index.ts
+++ b/src/testkit/index.ts
@@ -19,3 +19,4 @@ export {WheelPickerDriver} from '../components/WheelPicker/WheelPicker.driver';
 export {WheelPickerItemDriver} from '../components/WheelPicker/WheelPickerItem.driver';
 export {PickerDriver} from '../components/picker/Picker.driver.new';
 export {ExpandableOverlayDriver} from '../incubator/expandableOverlay/ExpandableOverlay.driver';
+export {DateTimePickerDriver} from '../components/dateTimePicker/DateTimePicker.driver';

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,0 +1,10 @@
+export function isSameDate(date1?: Date, date2?: Date) {
+  return (
+    date1?.getFullYear() === date2?.getFullYear() &&
+    date1?.getMonth() === date2?.getMonth() &&
+    date1?.getDate() === date2?.getDate()
+  );
+}
+export function isSameHourAndMinute(date1?: Date, date2?: Date) {
+  return date1?.getHours() === date2?.getHours() && date1?.getMinutes() === date2?.getMinutes();
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 import * as TextUtils from './textUtils';
 import * as StyleUtils from './styleUtils';
+import * as DateUtils from './dateUtils';
 
-export {TextUtils, StyleUtils};
+export {TextUtils, StyleUtils, DateUtils};


### PR DESCRIPTION
## Description
Added handling to invoke onChange only when the value really change.

## Changelog
DateTimePicker - onChange fixes. Only calls onChange when value really changes.

## Additional info
MADS-4209
MADS-4210
MADS-4211
