### PR TITLE
removed picker migrate rule

### DIFF
--- a/eslint-rules/tests/component_prop_deprecation.json
+++ b/eslint-rules/tests/component_prop_deprecation.json
@@ -78,16 +78,5 @@
         "fix": {"propName": "subtitle"}
       }
     ]
-  }, 
-  {
-    "component": "Picker",
-    "source": "module-with-deprecations",
-    "props": [
-      {
-        "prop": "migrate",
-        "message": "Please make sure to pass the 'migrate' prop.",
-        "isRequired": true
-      }
-    ]
   }
 ]

--- a/eslint-rules/tests/lib/rules/component-prop-deprecation.js
+++ b/eslint-rules/tests/lib/rules/component-prop-deprecation.js
@@ -395,13 +395,6 @@ ruleTester.run('component-prop-deprecation', rule, {
         {message: `The 'Text' component's prop 't' is deprecated. Please use the 'title' prop instead.`},
         {message: `The 'Text' component's prop 's' is deprecated. Please use the 'subtitle' prop instead.`}
       ]
-    },
-    {
-      options: ruleOptions,
-      code: 'import {Picker} from \'module-with-deprecations\'; <Picker t="title" s="subtitle"/>',
-      errors: [
-        {message: `The 'Picker' component's prop 'migrate' is required. Please make sure to pass the 'migrate' prop.`}
-      ]
     }
   ]
 });


### PR DESCRIPTION
## Description
Removed `Picker` `migrate` prop rule from `eslint-rules`.
The `migrate` prop set as default to `true` the rule isn't necessary due the `Picker` refactor effort.

## Changelog
Removed `Picker` `migrate` prop rule from `eslint-rules`.

## Additional info
#3110 
