### PR TITLE
enabled partial sizes to the chip size

### DIFF
--- a/src/components/chip/index.tsx
+++ b/src/components/chip/index.tsx
@@ -17,7 +17,7 @@ export type ChipProps = ViewProps &
     /**
      * Chip's size. Number or a width and height object.
      */
-    size?: number | {width: number; height: number};
+    size?: number | Partial<{width: number; height: number}>;
     /**
      * On Chip press callback
      */


### PR DESCRIPTION
## Description
Enabled the chip to get only partial width and height to the size prop. Currently if you wanted you couldn't change only one of them (typing wise)

## Changelog
Chip - changed size typings.

## Additional info
MADS-4439
