### PR TITLE
Incubator.Dialog - Fixed content component being created on every render.

### DIFF
--- a/src/incubator/Dialog/index.tsx
+++ b/src/incubator/Dialog/index.tsx
@@ -127,7 +127,7 @@ const Dialog = (props: DialogProps, ref: ForwardedRef<DialogImperativeMethods>) 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const {DialogContent, containerProps, containerStyle} = useDialogContent({
+  const {getDialogContent, containerProps, containerStyle} = useDialogContent({
     showCloseButton,
     close,
     closeButtonProps,
@@ -215,7 +215,7 @@ const Dialog = (props: DialogProps, ref: ForwardedRef<DialogImperativeMethods>) 
     <GestureDetector gesture={panGesture}>
       {/* @ts-expect-error should be fixed in version 3.5 (https://github.com/software-mansion/react-native-reanimated/pull/4881) */}
       <View {...containerProps} reanimated style={style} onLayout={onLayout} ref={setRef} testID={testID}>
-        <DialogContent/>
+        {getDialogContent()}
       </View>
     </GestureDetector>
   );

--- a/src/incubator/Dialog/index.tsx
+++ b/src/incubator/Dialog/index.tsx
@@ -127,7 +127,7 @@ const Dialog = (props: DialogProps, ref: ForwardedRef<DialogImperativeMethods>) 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const {getDialogContent, containerProps, containerStyle} = useDialogContent({
+  const {renderDialogContent, containerProps, containerStyle} = useDialogContent({
     showCloseButton,
     close,
     closeButtonProps,
@@ -215,7 +215,7 @@ const Dialog = (props: DialogProps, ref: ForwardedRef<DialogImperativeMethods>) 
     <GestureDetector gesture={panGesture}>
       {/* @ts-expect-error should be fixed in version 3.5 (https://github.com/software-mansion/react-native-reanimated/pull/4881) */}
       <View {...containerProps} reanimated style={style} onLayout={onLayout} ref={setRef} testID={testID}>
-        {getDialogContent()}
+        {renderDialogContent()}
       </View>
     </GestureDetector>
   );

--- a/src/incubator/Dialog/useDialogContent.tsx
+++ b/src/incubator/Dialog/useDialogContent.tsx
@@ -49,7 +49,7 @@ const useDialogContent = (props: InternalDialogCloseButtonProps) => {
     return showCloseButton ? [propsContainerStyle, styles.transparent] : propsContainerStyle;
   }, [showCloseButton, propsContainerStyle]);
 
-  const getDialogContent = () => {
+  const renderDialogContent = () => {
     const DialogContent = (
       <>
         {headerProps && <DialogHeader {...headerProps}/>}
@@ -69,7 +69,7 @@ const useDialogContent = (props: InternalDialogCloseButtonProps) => {
     }
   };
 
-  return {getDialogContent, containerStyle, containerProps};
+  return {renderDialogContent, containerStyle, containerProps};
 };
 
 export default useDialogContent;

--- a/src/incubator/Dialog/useDialogContent.tsx
+++ b/src/incubator/Dialog/useDialogContent.tsx
@@ -49,7 +49,7 @@ const useDialogContent = (props: InternalDialogCloseButtonProps) => {
     return showCloseButton ? [propsContainerStyle, styles.transparent] : propsContainerStyle;
   }, [showCloseButton, propsContainerStyle]);
 
-  const DialogContent = () => {
+  const getDialogContent = () => {
     const DialogContent = (
       <>
         {headerProps && <DialogHeader {...headerProps}/>}
@@ -69,7 +69,7 @@ const useDialogContent = (props: InternalDialogCloseButtonProps) => {
     }
   };
 
-  return {DialogContent, containerStyle, containerProps};
+  return {getDialogContent, containerStyle, containerProps};
 };
 
 export default useDialogContent;


### PR DESCRIPTION
## Description
The new useDialogContent hook was creating a component (DialogContent) on every render and then rendering it. This component is a "new" component every time therefore causing the component to render nonstop.
This could also be solved using useMemo but I don't see any use to it since DialogContent has no state.

## Changelog
Incubator.Dialog - Fixed content renders.

## Additional info
MADS-4444
