### PR TITLE
wheel picker separators code refactor

### DIFF
--- a/src/components/WheelPicker/index.tsx
+++ b/src/components/WheelPicker/index.tsx
@@ -349,6 +349,7 @@ const WheelPicker = <T extends WheelPickerItemValue>(props: WheelPickerProps<T>)
 
   return (
     <View testID={testID} bg-$backgroundDefault style={style}>
+      {separators}
       <View row centerH>
         <View flexG>
           <AnimatedFlatList
@@ -383,7 +384,6 @@ const WheelPicker = <T extends WheelPickerItemValue>(props: WheelPickerProps<T>)
       {label && labelContainer}
       {fader(FaderPosition.BOTTOM)}
       {fader(FaderPosition.TOP)}
-      {separators}
     </View>
   );
 };


### PR DESCRIPTION
## Description
WheelPicker separators was rendered above the AnimatedFlatList, which cause that the separator render over the current item.

example code snippet (from the example screen):
```
           <WheelPicker
            initialValue={'February'}
            activeTextColor={Colors.$textPrimary}
            inactiveTextColor={Colors.$textNeutralHeavy}
            items={monthItems}
            textStyle={Typography.text60R}
            numberOfVisibleRows={3}
            separatorsStyle={{backgroundColor: Colors.red70}}
          />
```

## Changelog
WheelPicker separators render below the list items.          

## Additional info
#3028 
