### PR TITLE
removed default background from picker item list

### DIFF
--- a/src/components/picker/PickerItemsList.tsx
+++ b/src/components/picker/PickerItemsList.tsx
@@ -168,7 +168,7 @@ const PickerItemsList = (props: PickerItemsListProps) => {
   };
 
   return (
-    <View bg-$backgroundDefault style={wrapperContainerStyle} useSafeArea={useSafeArea}>
+    <View style={wrapperContainerStyle} useSafeArea={useSafeArea}>
       {renderPickerHeader()}
       {renderContent()}
     </View>


### PR DESCRIPTION
## Description
Remove default background color from `PickerItemList` to let the user pass `overlayBackgroundColor` to the Modal.
Please check this in dark mode also.

## Changelog
Picker support for Modal `overlayBackgroundColor`, removed default color from PickerItemList.

## Additional info
#3111 
