### PR TITLE
Fix/picker new dialog usage of topbar

### DIFF
--- a/demo/src/screens/componentScreens/PickerScreen.tsx
+++ b/demo/src/screens/componentScreens/PickerScreen.tsx
@@ -185,18 +185,12 @@ export default class PickerScreen extends Component {
             onChange={item => this.setState({option: item})}
             topBarProps={{title: 'Languages'}}
             useDialog
-            renderHeader={({onDone, onCancel}) => (
-              <View padding-s5 row spread>
-                <Button link label="Cancel" onPress={onCancel}/>
-                <Button link label="Done" onPress={onDone}/>
-              </View>
-            )}
-            customPickerProps={{migrateDialog: true, dialogProps: {bottom: true, width: '100%', height: '45%'}}}
+            customPickerProps={{migrateDialog: true, dialogProps: {headerProps: {title: 'Languages'}}}}
             showSearch
             searchPlaceholder={'Search a language'}
             items={dialogOptions}
           />
-          
+
           <Text marginB-10 text70 $textDefault>
             Custom Picker:
           </Text>

--- a/src/components/picker/PickerItemsList.tsx
+++ b/src/components/picker/PickerItemsList.tsx
@@ -32,7 +32,8 @@ const PickerItemsList = (props: PickerItemsListProps) => {
     useSafeArea,
     useDialog,
     mode,
-    testID
+    testID,
+    migrateDialog = false
   } = props;
   const context = useContext(PickerContext);
 
@@ -138,7 +139,7 @@ const PickerItemsList = (props: PickerItemsListProps) => {
           </Text>
         </View>
       );
-    } else if (!useDialog || mode === PickerModes.MULTI) {
+    } else if (!migrateDialog && (!useDialog || mode === PickerModes.MULTI)) {
       return <Modal.TopBar testID={`${props.testID}.topBar`} {...topBarProps}/>;
     }
   };

--- a/src/components/picker/__tests__/index.spec.tsx
+++ b/src/components/picker/__tests__/index.spec.tsx
@@ -158,7 +158,7 @@ describe('Picker', () => {
   });
 
   describe('Dialog', () => {
-    const dialogProps = {useDialog: true, customPickerProps: {migrateDialog: true}};
+    const dialogProps = {useDialog: true};
     
     describe('Test value', () => {
       it('Get correct value of a single item', () => {
@@ -258,7 +258,7 @@ describe('Picker', () => {
   describe('Picker field types', () => {
     describe('Test filter field type', () => {
       const placeholderText = 'Select a Filter';
-      
+
       it('should render a filter picker', () => {
         const driver = getDriver({fieldType: 'filter', placeholder: placeholderText});
         expect(driver.isOpen()).toBeFalsy();
@@ -267,11 +267,11 @@ describe('Picker', () => {
         expect(label.props.children).toEqual(placeholderText);
       });
     });
-    
+
     describe('Test settings field type', () => {
       const labelText = 'Settings';
       const placeholderText = 'Select a setting';
-      
+
       it('should render a settings picker with label', async () => {
         const driver = getDriver({fieldType: 'settings', label: labelText, placeholder: placeholderText});
         const label = screen.getByTestId(`${testID}.settings.type.label`);

--- a/src/components/picker/helpers/usePickerDialogProps.tsx
+++ b/src/components/picker/helpers/usePickerDialogProps.tsx
@@ -16,14 +16,20 @@ const NEW_DIALOG_PROPS = {
 };
 
 const usePickerDialogProps = (props: PickerProps, onDone: any) => {
-  const {customPickerProps, mode} = props;
+  const {customPickerProps, mode, testID} = props;
   const migrateDialog = customPickerProps?.migrateDialog;
   const defaultProps = migrateDialog ? NEW_DIALOG_PROPS : DIALOG_PROPS;
 
   const modifiedHeaderProps = migrateDialog && {
     headerProps: {
       trailingAccessory: (
-        <Button label="Save" link style={{height: 30}} onPress={mode === PickerModes.MULTI ? onDone : undefined}/>
+        <Button
+          label="Save"
+          link
+          style={{height: 30}}
+          onPress={mode === PickerModes.MULTI ? onDone : undefined}
+          testID={`${testID}.dialog.header.save`}
+        />
       ),
       ...customPickerProps?.dialogProps?.headerProps
     }

--- a/src/components/picker/helpers/usePickerDialogProps.tsx
+++ b/src/components/picker/helpers/usePickerDialogProps.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import {PickerProps, PickerModes} from '../types';
+import Button from '../../button';
+
+const DIALOG_PROPS = {
+  bottom: true,
+  width: '100%',
+  height: 250
+};
+
+const NEW_DIALOG_PROPS = {
+  bottom: true,
+  useSafeArea: true,
+  height: '60%',
+  width: '95%'
+};
+
+const usePickerDialogProps = (props: PickerProps, onDone: any) => {
+  const {customPickerProps, mode} = props;
+  const migrateDialog = customPickerProps?.migrateDialog;
+  const defaultProps = migrateDialog ? NEW_DIALOG_PROPS : DIALOG_PROPS;
+
+  const modifiedHeaderProps = migrateDialog && {
+    headerProps: {
+      trailingAccessory: (
+        <Button label="Save" link style={{height: 30}} onPress={mode === PickerModes.MULTI ? onDone : undefined}/>
+      ),
+      ...customPickerProps?.dialogProps?.headerProps
+    }
+  };
+
+  const dialogProps: PickerProps['customPickerProps'] = {
+    dialogProps: {
+      ...defaultProps,
+      ...customPickerProps?.dialogProps,
+      ...modifiedHeaderProps
+    }
+  };
+
+  return dialogProps;
+};
+
+export default usePickerDialogProps;

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -17,6 +17,7 @@ import usePickerSearch from './helpers/usePickerSearch';
 import useImperativePickerHandle from './helpers/useImperativePickerHandle';
 import useFieldType from './helpers/useFieldType';
 import useNewPickerProps from './helpers/useNewPickerProps';
+import usePickerDialogProps from './helpers/usePickerDialogProps';
 // import usePickerMigrationWarnings from './helpers/usePickerMigrationWarnings';
 import {extractPickerItems} from './PickerPresenter';
 import {
@@ -30,12 +31,6 @@ import {
   PickerItemsListProps,
   PickerMethods
 } from './types';
-
-const DIALOG_PROPS = {
-  bottom: true,
-  width: '100%',
-  height: 250
-};
 
 type PickerStatics = {
   Item: typeof PickerItem;
@@ -110,6 +105,8 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
     setSearchValue,
     mode
   });
+
+  const {dialogProps = {}} = usePickerDialogProps(themeProps, () => onDoneSelecting(multiDraftValue));
 
   const {label, accessibilityInfo} = usePickerLabel({
     value,
@@ -242,6 +239,7 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
         renderHeader={renderHeader}
         listProps={listProps}
         useSafeArea={useSafeArea}
+        migrateDialog={customPickerProps?.migrateDialog}
       >
         {filteredChildren}
       </PickerItemsList>
@@ -271,15 +269,16 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
   return (
     <PickerContext.Provider value={contextValue}>
       {
+        //@ts-ignore remove after dialog migration finished
         <ExpandableOverlay
           ref={pickerExpandable}
           useDialog={useDialog || useWheelPicker}
-          dialogProps={DIALOG_PROPS}
           expandableContent={expandableModalContent}
           renderCustomOverlay={renderOverlay ? _renderOverlay : undefined}
           onPress={onPress}
           testID={testID}
           {...customPickerProps}
+          dialogProps={dialogProps}
           disabled={themeProps.editable === false}
         >
           {renderTextField()}

--- a/src/components/picker/types.ts
+++ b/src/components/picker/types.ts
@@ -316,7 +316,9 @@ export type PickerItemsListProps = Pick<
   | 'testID'
 > & {
   //TODO: after finish Picker props migration, items should be taken from PickerProps
+  //Remove the migrateDialog prop when the dialog migration finished in v8
   items?: {value: any; label: any}[];
+  migrateDialog?: boolean;
 };
 
 export type PickerMethods = TextFieldMethods & ExpandableOverlayMethods;


### PR DESCRIPTION
## Description
Picker shouldn't render `Modal.TopBar` when using the new Dialog.
New `usePickerDialogProps` hook to combing the default props of the Dialog with the custom props the user sent.

## Changelog
Fix Picker shouldn't render `Modal.TopBar` when using the new Dialog.

## Additional info
N/A