### PR TITLE
refcator color props type

### DIFF
--- a/src/components/actionBar/index.tsx
+++ b/src/components/actionBar/index.tsx
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import React, {Component} from 'react';
-import {StyleSheet, ViewStyle} from 'react-native';
+import {StyleSheet, ViewStyle, ColorValue} from 'react-native';
 import {Colors, Shadows} from '../../style';
 import {asBaseComponent} from '../../commons/new';
 import View from '../view';
@@ -14,7 +14,7 @@ export type ActionBarProps = {
   /**
    * action bar background color
    */
-  backgroundColor?: string;
+  backgroundColor?: ColorValue;
   /**
    * actions for the action bar
    */

--- a/src/components/avatar/index.tsx
+++ b/src/components/avatar/index.tsx
@@ -8,7 +8,8 @@ import {
   ImagePropsBase,
   ImageStyle,
   TextStyle,
-  AccessibilityProps
+  AccessibilityProps,
+  ColorValue
 } from 'react-native';
 import {Colors, BorderRadiuses} from '../../style';
 import {extractAccessibilityProps} from '../../commons/modifiers';
@@ -55,7 +56,7 @@ export type AvatarProps = Pick<AccessibilityProps, 'accessibilityLabel'> &
     /**
      * Background color for Avatar
      */
-    backgroundColor?: string;
+    backgroundColor?: ColorValue;
     /**
      * Badge location on Avatar
      */

--- a/src/components/badge/index.tsx
+++ b/src/components/badge/index.tsx
@@ -8,7 +8,8 @@ import {
   TextStyle,
   TouchableOpacityProps,
   ViewStyle,
-  ViewProps
+  ViewProps,
+  ColorValue
 } from 'react-native';
 import {extractAccessibilityProps} from '../../commons/modifiers';
 import {asBaseComponent} from '../../commons/new';
@@ -18,10 +19,9 @@ import Image from '../image';
 import View from '../view';
 import Text from '../text';
 
-
 const LABEL_FORMATTER_VALUES = [1, 2, 3, 4] as const;
 
-type LabelFormatterValues = typeof LABEL_FORMATTER_VALUES[number];
+type LabelFormatterValues = (typeof LABEL_FORMATTER_VALUES)[number];
 
 export type BadgeProps = ViewProps &
   TouchableOpacityProps & {
@@ -33,7 +33,7 @@ export type BadgeProps = ViewProps &
     /**
      * Color of the badge background
      */
-    backgroundColor?: string;
+    backgroundColor?: ColorValue;
     /**
      * the badge size
      */
@@ -100,7 +100,7 @@ export type BadgeProps = ViewProps &
  */
 class Badge extends PureComponent<BadgeProps> {
   static displayName = 'Badge';
-  
+
   styles: ReturnType<typeof createStyles>;
 
   constructor(props: BadgeProps) {

--- a/src/components/button/types.ts
+++ b/src/components/button/types.ts
@@ -1,4 +1,4 @@
-import {ImageStyle, TextStyle, StyleProp} from 'react-native';
+import {ImageStyle, TextStyle, StyleProp, ColorValue} from 'react-native';
 import {
   BaseComponentInjectedProps,
   ForwardRefInjectedProps,
@@ -65,11 +65,11 @@ export type ButtonProps = TouchableOpacityProps &
     /**
      * Color of the button background
      */
-    backgroundColor?: string;
+    backgroundColor?: ColorValue;
     /**
      * Color of the disabled button background
      */
-    disabledBackgroundColor?: string;
+    disabledBackgroundColor?: ColorValue;
     /**
      * Size of the button [large, medium, small, xSmall]
      */
@@ -142,7 +142,7 @@ export type ButtonProps = TouchableOpacityProps &
      * callback for getting activeBackgroundColor (e.g. (calculatedBackgroundColor, prop) => {...})
      * better set using ThemeManager
      */
-    getActiveBackgroundColor?: (backgroundColor: string, props: any) => string;
+    getActiveBackgroundColor?: (backgroundColor: ColorValue, props: any) => ColorValue;
     /**
      * should animate layout change
      * Note?: For Android you must set 'setLayoutAnimationEnabledExperimental(true)' via RN's 'UIManager'

--- a/src/components/card/CardSection.tsx
+++ b/src/components/card/CardSection.tsx
@@ -1,12 +1,11 @@
 import _ from 'lodash';
 import React, {PureComponent} from 'react';
-import {StyleSheet, ViewStyle, ImageStyle, ImageSourcePropType, StyleProp} from 'react-native';
+import {StyleSheet, ViewStyle, ImageStyle, ImageSourcePropType, StyleProp, ColorValue} from 'react-native';
 import {asBaseComponent} from '../../commons/new';
 import View, {ViewProps} from '../view';
 import Text, {TextProps} from '../text';
 import Image, {ImageProps} from '../image';
 import asCardChild, {asCardChildProps} from './asCardChild';
-
 
 type ContentType = TextProps & {text?: string};
 
@@ -23,7 +22,7 @@ export type CardSectionProps = ViewProps & {
   /**
    * Give the section a background color
    */
-  backgroundColor?: string;
+  backgroundColor?: ColorValue;
   /**
    * Image props for a leading icon to render before the text
    */

--- a/src/components/card/index.tsx
+++ b/src/components/card/index.tsx
@@ -3,7 +3,14 @@ import React, {PureComponent} from 'react';
 import {StyleSheet, Animated, StyleProp, ViewStyle} from 'react-native';
 import {Colors, BorderRadiuses} from '../../style';
 // import {PureBaseComponent} from '../../commons';
-import {Constants, asBaseComponent, forwardRef, BaseComponentInjectedProps, ForwardRefInjectedProps, MarginModifiers} from '../../commons/new';
+import {
+  Constants,
+  asBaseComponent,
+  forwardRef,
+  BaseComponentInjectedProps,
+  ForwardRefInjectedProps,
+  MarginModifiers
+} from '../../commons/new';
 import View, {ViewProps} from '../view';
 import TouchableOpacity, {TouchableOpacityProps} from '../touchableOpacity';
 import Icon from '../icon';
@@ -38,7 +45,8 @@ export interface CardSelectionOptions {
 
 export {CardSectionProps};
 export type CardProps = ViewProps &
-  TouchableOpacityProps & MarginModifiers & {
+  TouchableOpacityProps &
+  MarginModifiers & {
     /**
      * card custom width
      */
@@ -188,7 +196,7 @@ class Card extends PureComponent<PropTypes, State> {
   get backgroundStyle() {
     const {enableBlur, backgroundColor = Colors.$backgroundElevated} = this.props;
 
-    if (Constants.isIOS && enableBlur) {
+    if (Constants.isIOS && enableBlur && typeof backgroundColor === 'string') {
       return {backgroundColor: Colors.rgba(backgroundColor, 0.85)};
     } else {
       return {backgroundColor};

--- a/src/components/chip/index.tsx
+++ b/src/components/chip/index.tsx
@@ -1,6 +1,15 @@
 import _ from 'lodash';
 import React, {useCallback} from 'react';
-import {StyleSheet, StyleProp, ViewStyle, ViewProps, ImageStyle, TextStyle, ImageSourcePropType} from 'react-native';
+import {
+  StyleSheet,
+  StyleProp,
+  ViewStyle,
+  ViewProps,
+  ImageStyle,
+  TextStyle,
+  ImageSourcePropType,
+  ColorValue
+} from 'react-native';
 import Assets from '../../assets';
 import {asBaseComponent} from '../../commons/new';
 import {BorderRadiuses, Spacings, Colors} from 'style';
@@ -25,7 +34,7 @@ export type ChipProps = ViewProps &
     /**
      * Chip's background color
      */
-    backgroundColor?: string;
+    backgroundColor?: ColorValue;
     /**
      * The Chip borderRadius
      */

--- a/src/components/colorPalette/index.tsx
+++ b/src/components/colorPalette/index.tsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import memoize from 'memoize-one';
 import React, {PureComponent} from 'react';
-import {StyleSheet, StyleProp, ViewStyle} from 'react-native';
+import {StyleSheet, StyleProp, ViewStyle, ColorValue} from 'react-native';
 import {Colors} from '../../style';
 import {Constants} from '../../commons/new';
 import View from '../view';
@@ -56,7 +56,7 @@ interface Props {
   /**
    * The ColorPalette's background color
    */
-  backgroundColor?: string;
+  backgroundColor?: ColorValue;
 }
 export type ColorPaletteProps = Props;
 

--- a/src/components/colorPicker/index.tsx
+++ b/src/components/colorPicker/index.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import {StyleSheet} from 'react-native';
+import {StyleSheet, ColorValue} from 'react-native';
 import {asBaseComponent} from '../../commons/new';
 import Assets from '../../assets';
 import {Colors} from '../../style';
@@ -41,7 +41,7 @@ interface Props extends ColorPickerDialogProps, Pick<ColorPaletteProps, 'onValue
   /**
    * The ColorPicker's background color
    */
-  backgroundColor?: string;
+  backgroundColor?: ColorValue;
 }
 export type ColorPickerProps = Props;
 

--- a/src/components/dialog/OverlayFadingBackground.tsx
+++ b/src/components/dialog/OverlayFadingBackground.tsx
@@ -1,12 +1,12 @@
 import React, {useRef, useEffect, useCallback, useMemo} from 'react';
 import View from '../view';
-import {Animated} from 'react-native';
+import {Animated, ColorValue} from 'react-native';
 
 interface Props {
   testID?: string;
   dialogVisibility?: boolean;
   modalVisibility?: boolean;
-  overlayBackgroundColor?: string;
+  overlayBackgroundColor?: ColorValue;
   onFadeDone?: () => void;
   fadeOut?: boolean;
 }
@@ -34,7 +34,8 @@ const OverlayFadingBackground = ({
       duration: 400,
       useNativeDriver: true
     }).start(onFadeDone);
-  }, [fadeAnimation, onFadeDone]);
+  },
+  [fadeAnimation, onFadeDone]);
 
   useEffect(() => {
     if (!isAnimating.current && (!dialogVisibility || fadeOut)) {

--- a/src/components/dialog/index.tsx
+++ b/src/components/dialog/index.tsx
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import React, {Component} from 'react';
-import {StyleSheet, StyleProp, ViewStyle, ModalPropsIOS, AccessibilityProps} from 'react-native';
+import {StyleSheet, StyleProp, ViewStyle, ModalPropsIOS, AccessibilityProps, ColorValue} from 'react-native';
 import {Colors} from '../../style';
 import {AlignmentModifiers, extractAlignmentsValues} from '../../commons/modifiers';
 import {Constants, asBaseComponent} from '../../commons/new';
@@ -38,7 +38,7 @@ export interface DialogProps extends AlignmentModifiers, RNPartialProps {
   /**
    * The color of the overlay background
    */
-  overlayBackgroundColor?: string;
+  overlayBackgroundColor?: ColorValue;
   /**
    * The dialog width (default: 90%)
    */

--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -1,6 +1,6 @@
 import isUndefined from 'lodash/isUndefined';
 import React, {useMemo, forwardRef} from 'react';
-import {Image, ImageProps as RNImageProps, StyleSheet, StyleProp, ViewStyle} from 'react-native';
+import {Image, ImageProps as RNImageProps, StyleSheet, StyleProp, ViewStyle, ColorValue} from 'react-native';
 import {asBaseComponent, BaseComponentInjectedProps, MarginModifiers, Constants} from '../../commons/new';
 import {ComponentStatics} from '../../typings/common';
 import {getAsset, isSvg, isBase64ImageContent} from '../../utils/imageUtils';
@@ -27,7 +27,7 @@ export type IconProps = Omit<RNImageProps, 'source'> &
     /**
      * the icon tint
      */
-    tintColor?: string | null;
+    tintColor?: ColorValue | null;
     /**
      * the icon size
      */

--- a/src/components/image/index.tsx
+++ b/src/components/image/index.tsx
@@ -8,7 +8,8 @@ import {
   ImageBackground,
   ImageBackgroundProps,
   NativeSyntheticEvent,
-  ImageErrorEventData
+  ImageErrorEventData,
+  ColorValue
 } from 'react-native';
 import {
   Constants,
@@ -46,7 +47,7 @@ export type ImageProps = Omit<RNImageProps, 'source'> &
     /**
      * the asset tint
      */
-    tintColor?: string;
+    tintColor?: ColorValue;
     /**
      * whether the image should flip horizontally on RTL locals
      */
@@ -71,7 +72,7 @@ export type ImageProps = Omit<RNImageProps, 'source'> &
     /**
      * Pass a custom color for the overlay
      */
-    overlayColor?: string;
+    overlayColor?: ColorValue;
     /**
      * Render an overlay with custom content
      */

--- a/src/components/loaderScreen/types.ts
+++ b/src/components/loaderScreen/types.ts
@@ -1,32 +1,32 @@
-import {ActivityIndicatorProps, TextStyle, ViewStyle} from 'react-native';
+import {ActivityIndicatorProps, TextStyle, ViewStyle, ColorValue} from 'react-native';
 
 export type LoaderScreenProps = ActivityIndicatorProps & {
-    /**
-     * Color of the loading indicator
-     */
-    loaderColor?: string;
-    /**
-     * Custom loader
-     */
-    customLoader?: React.ReactChild;
-    /**
-     * Color of the loader background (only when passing 'overlay')
-     */
-    backgroundColor?: string;
-    /**
-     * loader message
-     */
-    message?: string;
-    /**
-     * message style
-     */
-    messageStyle?: TextStyle,
-    /**
-     * Show the screen as an absolute overlay
-     */
-    overlay?: boolean;
-     /**
-     * Custom container style
-     */
-    containerStyle?: ViewStyle;
+  /**
+   * Color of the loading indicator
+   */
+  loaderColor?: string;
+  /**
+   * Custom loader
+   */
+  customLoader?: React.ReactChild;
+  /**
+   * Color of the loader background (only when passing 'overlay')
+   */
+  backgroundColor?: ColorValue;
+  /**
+   * loader message
+   */
+  message?: string;
+  /**
+   * message style
+   */
+  messageStyle?: TextStyle;
+  /**
+   * Show the screen as an absolute overlay
+   */
+  overlay?: boolean;
+  /**
+   * Custom container style
+   */
+  containerStyle?: ViewStyle;
 };

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -8,7 +8,8 @@ import {
   TouchableWithoutFeedback,
   GestureResponderEvent,
   KeyboardAvoidingView,
-  KeyboardAvoidingViewProps
+  KeyboardAvoidingViewProps,
+  ColorValue
 } from 'react-native';
 import {BlurViewPackage} from '../../optionalDependencies';
 import {Constants, asBaseComponent} from '../../commons/new';
@@ -34,7 +35,7 @@ export interface ModalProps extends RNModalProps {
   /**
    * the background color of the overlay
    */
-  overlayBackgroundColor?: string;
+  overlayBackgroundColor?: ColorValue;
   /**
    * The modal's end-to-end test identifier
    */
@@ -93,7 +94,11 @@ class Modal extends Component<ModalProps> {
         >
           {/*
             // @ts-ignore */}
-          <TouchableWithoutFeedback {...accessibilityProps} onPress={onBackgroundPress} testID={`${testID}.TouchableOverlay`}>
+          <TouchableWithoutFeedback
+            {...accessibilityProps}
+            onPress={onBackgroundPress}
+            testID={`${testID}.TouchableOverlay`}
+          >
             <View style={isScreenReaderEnabled ? styles.accessibleOverlayView : styles.fill}/>
           </TouchableWithoutFeedback>
         </View>

--- a/src/components/overlay/index.tsx
+++ b/src/components/overlay/index.tsx
@@ -1,6 +1,6 @@
 import {isUndefined} from 'lodash';
 import React, {PureComponent} from 'react';
-import {StyleSheet, Image, ImageProps, ImageSourcePropType} from 'react-native';
+import {StyleSheet, Image, ImageProps, ImageSourcePropType, ColorValue} from 'react-native';
 import {Colors} from '../../style';
 import View from '../view';
 
@@ -35,7 +35,7 @@ export type OverlayTypes = Pick<ImageProps, 'borderRadius'> & {
   /**
    * The overlay color
    */
-  color?: string;
+  color?: ColorValue;
   /**
    * Custom overlay content to be rendered on top of the image
    */

--- a/src/components/scrollBar/index.tsx
+++ b/src/components/scrollBar/index.tsx
@@ -6,7 +6,8 @@ import {
   ImageSourcePropType,
   NativeSyntheticEvent,
   NativeScrollEvent,
-  LayoutChangeEvent
+  LayoutChangeEvent,
+  ColorValue
 } from 'react-native';
 import {ScrollView, FlatList} from 'react-native-gesture-handler';
 import {Colors} from '../../style';
@@ -47,7 +48,7 @@ export interface ScrollBarProps extends FlatListProps<any> {
   /**
    * The gradient's tint color
    */
-  gradientColor?: string;
+  gradientColor?: ColorValue;
   /**
    * The gradient's image, instead of the default image.
    * NOTE: pass an image for the right-hand side and it will be flipped to match the left-hand side

--- a/src/components/segmentedControl/index.tsx
+++ b/src/components/segmentedControl/index.tsx
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import React, {useRef, useCallback, useEffect} from 'react';
-import {StyleSheet, StyleProp, ViewStyle, TextStyle, LayoutChangeEvent} from 'react-native';
+import {StyleSheet, StyleProp, ViewStyle, TextStyle, LayoutChangeEvent, ColorValue} from 'react-native';
 import {
   Easing,
   useAnimatedReaction,
@@ -56,11 +56,11 @@ export type SegmentedControlProps = {
   /**
    * The background color of the inactive segments
    */
-  backgroundColor?: string;
+  backgroundColor?: ColorValue;
   /**
    * The background color of the active segment
    */
-  activeBackgroundColor?: string;
+  activeBackgroundColor?: ColorValue;
   /**
    * The color of the active segment outline
    */
@@ -191,9 +191,14 @@ const SegmentedControl = (props: SegmentedControlProps) => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   [initialIndex, segments.length]);
 
-  const containerOnLayout = useCallback(({nativeEvent: {layout: {height}}} : LayoutChangeEvent) => {
+  const containerOnLayout = useCallback(({
+    nativeEvent: {
+      layout: {height}
+    }
+  }: LayoutChangeEvent) => {
     containerHeight.value = height;
-  }, [containerHeight]);
+  },
+  [containerHeight]);
 
   const animatedStyle = useAnimatedStyle(() => {
     const {value} = segmentsStyle;
@@ -244,7 +249,11 @@ const SegmentedControl = (props: SegmentedControlProps) => {
     });
   return (
     <View style={containerStyle} testID={testID}>
-      {label && <Text bodySmall $textNeutralHeavy marginB-s1 {...labelProps}>{label}</Text>}
+      {label && (
+        <Text bodySmall $textNeutralHeavy marginB-s1 {...labelProps}>
+          {label}
+        </Text>
+      )}
       <View row center onLayout={containerOnLayout} style={[styles.container, style, {borderRadius, backgroundColor}]}>
         <View
           reanimated

--- a/src/components/svgImage/index.tsx
+++ b/src/components/svgImage/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {ColorValue} from 'react-native';
 import {isSvg, isSvgUri} from '../../utils/imageUtils';
 import {SvgPackage} from '../../optionalDependencies';
 
@@ -10,7 +11,7 @@ export interface SvgImageProps {
   /**
    * the asset tint
    */
-  tintColor?: string | null;
+  tintColor?: ColorValue | null;
   data: any; // TODO: I thought this should be string | React.ReactNode but it doesn't work properly
 }
 

--- a/src/components/tabController/TabBar.tsx
+++ b/src/components/tabController/TabBar.tsx
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import React, {useMemo, useContext, useState, useRef, ReactNode} from 'react';
-import {StyleSheet, Platform, StyleProp, ViewStyle} from 'react-native';
+import {StyleSheet, Platform, StyleProp, ViewStyle, ColorValue} from 'react-native';
 import Reanimated, {runOnJS, useAnimatedReaction, useAnimatedStyle, interpolate} from 'react-native-reanimated';
 import TabBarContext from './TabBarContext';
 import TabBarItem, {TabControllerItemProps} from './TabBarItem';
@@ -86,11 +86,11 @@ export interface TabControllerBarProps {
    * TODO: rename to feedbackColor
    * Apply background color on press for TouchableOpacity
    */
-  activeBackgroundColor?: string;
+  activeBackgroundColor?: ColorValue;
   /**
    * The TabBar background Color
    */
-  backgroundColor?: string;
+  backgroundColor?: ColorValue;
   /**
    * Props for the start \ end faders
    */

--- a/src/components/tabController/TabBarItem.tsx
+++ b/src/components/tabController/TabBarItem.tsx
@@ -1,6 +1,6 @@
 // TODO: support commented props
 import React, {useCallback, useContext, useEffect, useRef, useMemo, ReactElement} from 'react';
-import {StyleSheet, TextStyle, LayoutChangeEvent, StyleProp, ViewStyle, TextProps} from 'react-native';
+import {StyleSheet, TextStyle, LayoutChangeEvent, StyleProp, ViewStyle, TextProps, ColorValue} from 'react-native';
 import _ from 'lodash';
 import Reanimated, {runOnJS, useAnimatedStyle, useSharedValue} from 'react-native-reanimated';
 import {Gesture, GestureDetector} from 'react-native-gesture-handler';
@@ -26,7 +26,7 @@ export interface TabControllerItemProps extends Pick<TabControllerBarProps, 'spr
   /**
    * Extra label props to pass to label Text element
    */
-  labelProps?: Omit<TextProps, 'style'> ;
+  labelProps?: Omit<TextProps, 'style'>;
   /**
    * custom selected label style
    */
@@ -86,12 +86,12 @@ export interface TabControllerItemProps extends Pick<TabControllerBarProps, 'spr
   /**
    * Apply background color for the tab bar item
    */
-  backgroundColor?: string;
+  backgroundColor?: ColorValue;
   /**
    * TODO: rename to feedbackColor
    * Apply background color on press for TouchableOpacity
    */
-  activeBackgroundColor?: string;
+  activeBackgroundColor?: ColorValue;
   /**
    * Pass custom style
    */

--- a/src/components/touchableOpacity/index.tsx
+++ b/src/components/touchableOpacity/index.tsx
@@ -3,7 +3,8 @@ import React, {PureComponent} from 'react';
 import {
   GestureResponderEvent,
   TouchableOpacity as RNTouchableOpacity,
-  TouchableOpacityProps as RNTouchableOpacityProps
+  TouchableOpacityProps as RNTouchableOpacityProps,
+  ColorValue
 } from 'react-native';
 import {
   asBaseComponent,
@@ -25,7 +26,7 @@ export interface TouchableOpacityProps
   /**
    * background color for TouchableOpacity
    */
-  backgroundColor?: string;
+  backgroundColor?: ColorValue;
   /**
    * throttle time in MS for onPress callback
    */
@@ -37,7 +38,7 @@ export interface TouchableOpacityProps
   /**
    * Apply background color on TouchableOpacity when active (press is on)
    */
-  activeBackgroundColor?: string;
+  activeBackgroundColor?: ColorValue;
   /**
    * Will apply scale press feedback. This will enforce the useNative prop
    */

--- a/src/components/view/index.tsx
+++ b/src/components/view/index.tsx
@@ -1,6 +1,6 @@
 import {useModifiers, useThemeProps} from 'hooks';
 import React, {useEffect, useMemo, useState} from 'react';
-import {View as RNView, SafeAreaView, Animated, ViewProps as RNViewProps, StyleProp, ViewStyle} from 'react-native';
+import {View as RNView, SafeAreaView, Animated, ViewProps as RNViewProps, StyleProp, ViewStyle, ColorValue} from 'react-native';
 import type {AnimateProps as RNReanimatedProps} from 'react-native-reanimated';
 import {Constants, ContainerModifiers} from '../../commons/new';
 import type {RecorderProps} from '../../typings/recorderTypes';
@@ -42,7 +42,7 @@ export interface ViewProps extends Omit<RNViewProps, 'style'>, ReanimatedProps, 
   /**
    * Set background color
    */
-  backgroundColor?: string;
+  backgroundColor?: ColorValue;
   style?: StyleProp<ViewStyle | Animated.AnimatedProps<ViewStyle>>;
 }
 

--- a/src/components/wizard/types.ts
+++ b/src/components/wizard/types.ts
@@ -1,5 +1,5 @@
 import {ImageProps} from '../image';
-import {StyleProp, TextStyle, ViewStyle} from 'react-native';
+import {StyleProp, TextStyle, ViewStyle, ColorValue} from 'react-native';
 
 export enum WizardStepStates {
   ENABLED = 'enabled',
@@ -29,11 +29,11 @@ export interface WizardStepProps {
   /**
    * Color of the step index (or of the icon, when provided)
    */
-  color?: string;
+  color?: ColorValue;
   /**
    * Color of the circle
    */
-  circleColor?: string;
+  circleColor?: ColorValue;
   /**
    * The step's circle size (diameter)
    */
@@ -41,7 +41,7 @@ export interface WizardStepProps {
   /**
    * Circle's background color
    */
-  circleBackgroundColor?: string;
+  circleBackgroundColor?: ColorValue;
   /**
    * Icon to replace the (default) index
    */

--- a/src/incubator/TouchableOpacity.tsx
+++ b/src/incubator/TouchableOpacity.tsx
@@ -1,5 +1,5 @@
 import React, {PropsWithChildren, useCallback, useMemo} from 'react';
-import {LayoutChangeEvent} from 'react-native';
+import {LayoutChangeEvent, ColorValue} from 'react-native';
 import Reanimated, {
   useAnimatedStyle,
   useSharedValue,
@@ -17,11 +17,11 @@ export type TouchableOpacityProps = {
   /**
    * Background color
    */
-  backgroundColor?: string;
+  backgroundColor?: ColorValue;
   /**
    * Background color when actively pressing the touchable
    */
-  feedbackColor?: string;
+  feedbackColor?: ColorValue;
   /**
    * Opacity value when actively pressing the touchable
    */
@@ -155,11 +155,7 @@ function TouchableOpacity(props: Props) {
   const Container = props.onLongPress ? LongPressGestureHandler : View;
 
   return (
-    <TapGestureHandler
-      onHandlerStateChange={tapGestureHandler}
-      shouldCancelWhenOutside
-      enabled={!disabled}
-    >
+    <TapGestureHandler onHandlerStateChange={tapGestureHandler} shouldCancelWhenOutside enabled={!disabled}>
       <Reanimated.View>
         <Container onHandlerStateChange={longPressGestureHandler} shouldCancelWhenOutside>
           <Reanimated.View

--- a/src/incubator/toast/types.ts
+++ b/src/incubator/toast/types.ts
@@ -1,5 +1,5 @@
 import {ReactElement, ReactNode} from 'react';
-import {ImageSourcePropType, StyleProp, TextStyle, ViewStyle} from 'react-native';
+import {ImageSourcePropType, StyleProp, TextStyle, ViewStyle, ColorValue} from 'react-native';
 import {ButtonProps} from '../../components/button';
 import {TextProps} from '../../components/text';
 
@@ -109,6 +109,6 @@ export interface ToastProps {
   /**
    * The background color of the toast
    */
-  backgroundColor?: string;
+  backgroundColor?: ColorValue;
   children?: ReactNode;
 }


### PR DESCRIPTION
## Description
Changed `color` props type from` `string` to `react-native - ColorValue` type.
The `ColorValue` support `OpaqueColorValue` which support platform colors and dynamic colors.
Currently with `string` type we don't have support for that, this was request in the community open issues.
Example to reproduce type error:
```
 const dynamicColor: ColorValue = PlatformColor('systemBlueColor');
 <Button marginV-20 label="Button" backgroundColor={dynamicColor}/>
```

## Changelog
Components `colors` props type change from `string` to `ColorValue`.

## Additional info
#3202 