### PR TITLE
Make Constants.statusBarHeight dynamic on phone orientation change

### DIFF
--- a/src/commons/Constants.ts
+++ b/src/commons/Constants.ts
@@ -40,11 +40,11 @@ isTablet = Platform.isPad || (getAspectRatio() < 1.6 && Math.max(screenWidth, sc
 function setStatusBarHeight() {
   const {StatusBarManager} = NativeModules;
   statusBarHeight = StatusBarManager?.HEIGHT || 0; // So there will be a value for any case
-  // statusBarHeight = isIOS ? 20 : StatusBarManager.HEIGHT;
-  // if (isIOS) {
-  //   // override guesstimate height with the actual height from StatusBarManager
-  //   StatusBarManager.getHeight((data: any) => (statusBarHeight = data.height));
-  // }
+  
+  if (isIOS) {
+    // override guesstimate height with the actual height from StatusBarManager
+    StatusBarManager.getHeight((data: any) => (statusBarHeight = data.height));
+  }
 }
 
 function getAspectRatio() {


### PR DESCRIPTION
## Description
When starting IOS application in landscape mode and then changing to portrait statusBarHeight value wont change and remain 0.


## Changelog
inside Constants.ts made statusBarHeight dynamic to mobile orientation changes
Instead of using StatusBarManager.HEIGHT, now  setStatusBarHeight will use StatusBarManager.getHeight() method which provides the right height when called (HEIGHT is declared once when the app initialized)

