### PR TITLE
Make Constants.statusBarHeight dynamic on phone orientation change

### DIFF
--- a/jestSetup/jest-setup.js
+++ b/jestSetup/jest-setup.js
@@ -18,7 +18,6 @@ Object.defineProperties = (obj, props) => {
 
 global._UILIB_TESTING = true;
 
-NativeModules.StatusBarManager = {getHeight: jest.fn()};
 jest.spyOn(AccessibilityInfo, 'isScreenReaderEnabled').mockImplementation(() => Promise.resolve(false));
 
 // mock native modules
@@ -98,6 +97,7 @@ jest.mock('react-native-gesture-handler',
 jest.mock('react-native', () => {
   const reactNative = jest.requireActual('react-native');
   reactNative.NativeModules.KeyboardTrackingViewTempManager = {};
+  reactNative.NativeModules.StatusBarManager = {getHeight: jest.fn()};
   const OriginalModal = reactNative.Modal;
   const React = jest.requireActual('react');
   const useDidUpdate = require('./useDidUpdate').default;

--- a/src/commons/Constants.ts
+++ b/src/commons/Constants.ts
@@ -40,11 +40,11 @@ isTablet = Platform.isPad || (getAspectRatio() < 1.6 && Math.max(screenWidth, sc
 function setStatusBarHeight() {
   const {StatusBarManager} = NativeModules;
   statusBarHeight = StatusBarManager?.HEIGHT || 0; // So there will be a value for any case
-  // statusBarHeight = isIOS ? 20 : StatusBarManager.HEIGHT;
-  // if (isIOS) {
-  //   // override guesstimate height with the actual height from StatusBarManager
-  //   StatusBarManager.getHeight((data: any) => (statusBarHeight = data.height));
-  // }
+  
+  if (isIOS) {
+    // override guesstimate height with the actual height from StatusBarManager
+    StatusBarManager.getHeight((data:{height:number}) => (statusBarHeight = data.height));
+  }
 }
 
 function getAspectRatio() {


### PR DESCRIPTION
## Description
inside Constants.ts made statusBarHeight dynamic to mobile orientation changes
Instead of using StatusBarManager.HEIGHT, now setStatusBarHeight will use StatusBarManager.getHeight() method which provides the right height when called (HEIGHT is declared once when the app initialized)

When starting IOS application in landscape mode and then changing to portrait statusBarHeight value wont change and remain 0.

## Changelog
Fix statusBarHeight value to by dynamic when changing orientation



