### PR TITLE
Eslint - Fix default import capture

### DIFF
--- a/eslint-rules/lib/rules/no-direct-import.js
+++ b/eslint-rules/lib/rules/no-direct-import.js
@@ -61,21 +61,6 @@ module.exports = {
       return context.options[0].rules || [context.options[0]];
     }
 
-    function checkImportDeclaration(node) {
-      const source = node.source.value;
-      const rule = getRules().find((rule) => rule.origin === source);
-
-      if (rule) {
-        report(node, rule, 'import', node.source);
-      }
-    }
-    function isRequireFunction(node) {
-      return node.callee.type === 'Identifier' &&
-                    node.callee.name === 'require' &&
-                    node.arguments.length > 0 &&
-                    node.arguments[0].type === 'Literal'
-    }
-
     function report(node, rule, type, textToReplace) {
       try {
         const {applyAutofix, destination} = rule;
@@ -92,6 +77,22 @@ module.exports = {
       } catch (err) {
         handleError(RULE_ID, err, context.getFilename());
       }
+    }
+
+    function checkImportDeclaration(node) {
+      const source = node.source.value;
+      const rule = getRules().find((rule) => rule.origin === source);
+
+      if (rule) {
+        report(node, rule, 'import', node.source);
+      }
+    }
+
+    function isRequireFunction(node) {
+      return node.callee.type === 'Identifier' &&
+                    node.callee.name === 'require' &&
+                    node.arguments.length > 0 &&
+                    node.arguments[0].type === 'Literal'
     }
 
     function checkRequire(node) {

--- a/eslint-rules/lib/rules/no-direct-import.js
+++ b/eslint-rules/lib/rules/no-direct-import.js
@@ -1,4 +1,4 @@
-const {handleError, addToImports} = require('../utils');
+const {handleError} = require('../utils');
 
 const RULE_ID = 'no-direct-import';
 const MAP_SCHEMA = {
@@ -56,14 +56,27 @@ module.exports = {
       return customMessage || `Do not ${type} directly from '${origin}'. Please use '${destination}'${autofixMessage}.`;
     }
 
-    function checkAndReport(node, type, importedModuleNameToReplace) {
-      const imports = [];
-      addToImports(node, imports);
-      const modules = new Set(collectModulesFromImports(imports));
-      const rule = getRules().find((rule) => modules.has(rule.origin));
-      if (!rule) {
-        return;
+    function getRules() {
+      // To support both structures; single rule or array of rules
+      return context.options[0].rules || [context.options[0]];
+    }
+
+    function checkImportDeclaration(node) {
+      const source = node.source.value;
+      const rule = getRules().find((rule) => rule.origin === source);
+
+      if (rule) {
+        report(node, rule, 'import', node.source);
       }
+    }
+    function isRequireFunction(node) {
+      return node.callee.type === 'Identifier' &&
+                    node.callee.name === 'require' &&
+                    node.arguments.length > 0 &&
+                    node.arguments[0].type === 'Literal'
+    }
+
+    function report(node, rule, type, textToReplace) {
       try {
         const {applyAutofix, destination} = rule;
         const message = getErrorMessage(rule, type);
@@ -72,7 +85,7 @@ module.exports = {
           message,
           fix(fixer) {
             if (node && applyAutofix && destination) {
-              return fixer.replaceText(importedModuleNameToReplace, `'${destination}'`);
+              return fixer.replaceText(textToReplace, `'${destination}'`);
             }
           }
         });
@@ -81,30 +94,20 @@ module.exports = {
       }
     }
 
-    function getRules() {
-      // To support both structures; single rule or array of rules
-      return context.options[0].rules || [context.options[0]];
-    }
-
-    function collectModulesFromImports(imports) {
-      const collection = [];
-      imports.forEach((moduleImports) => {
-        collection.push(...Object.keys(moduleImports));
-      });
-      return collection;
-    }
-
-    function getModuleNameFromRequire(node) {
-      return (node.init.object ? node.init.object.arguments : node.init.arguments)[0]
-    }
-
-    function getModuleNameFromImport(node) {
-      return node.source;
+    function checkRequire(node) {
+      if (!isRequireFunction(node)) {
+        return;
+      }
+      const source = node.arguments[0].value;
+      const rule = getRules().find((rule) => rule.origin === source);
+      if (rule) {
+        report(node, rule, 'require', node.arguments[0]);
+      }
     }
 
     return {
-      ImportDeclaration: (node) => checkAndReport(node, 'import', getModuleNameFromImport(node)),
-      VariableDeclarator: (node) => checkAndReport(node, 'require', getModuleNameFromRequire(node)),
+      ImportDeclaration: checkImportDeclaration,
+      CallExpression: checkRequire
     };
   }
 };

--- a/eslint-rules/lib/utils/importUtils.js
+++ b/eslint-rules/lib/utils/importUtils.js
@@ -18,7 +18,7 @@ function _addToImports_fromImport(node, imports) {
   if (specifiers) {
     const newImports = {};
     specifiers.forEach(specifier => {
-      if (specifier.type === 'ImportSpecifier' || specifier.type === 'ImportNamespaceSpecifier') {
+      if (specifier.type === 'ImportSpecifier' || specifier.type === 'ImportNamespaceSpecifier' || specifier.type === 'ImportDefaultSpecifier') {
         const isNamespace = specifier.type === 'ImportNamespaceSpecifier';
         const value = _.get(specifier, 'imported.name') || _.get(specifier, 'local.name');
         newImports[specifier.local.name] = isNamespace ? {value, isNamespace} : value;

--- a/eslint-rules/tests/lib/rules/no-direct-import.js
+++ b/eslint-rules/tests/lib/rules/no-direct-import.js
@@ -30,14 +30,14 @@ const validExample1 = `import {Component} from 'another-module';`;
 const validExample2 = `import {Component} from 'new-module';`;
 const validExample3 = `const {Component} = require('another-module');`;
 const validExample4 = `const test = require('new-module').test;`;
-const validExample5 = `import something from 'another-module';`;
+const validDefault = `import something from 'another-module';`;
 
 const invalidExample1 = `import {Component} from 'some-module';`;
 const invalidExample2 = `import {Component} from 'old-module';`;
 const invalidExample3 = `const {Component} = require('some-module');`;
 const invalidExample4 = `const {Component} = require('old-module');`;
 const invalidExample5 = `const test = require(\'some-module\').test;`;
-const invalidExample6 = `import something from 'some-module';`;
+const invalidDefault = `import something from 'some-module';`;
 
 const error1 = `Do not import directly from 'some-module'. Please use 'another-module' (autofix available).`;
 const error2 = `Do not import directly from 'old-module'. Please use 'new-module' (autofix available).`;
@@ -72,7 +72,7 @@ ruleTester.run('no-direct-import', rule, {
     },
     {
       options: ruleOptions,
-      code: validExample5
+      code: validDefault
     }
   ],
   invalid: [
@@ -140,11 +140,11 @@ ruleTester.run('no-direct-import', rule, {
     },
     {
       options: ruleOptions,
-      code: invalidExample6,
+      code: invalidDefault,
+      output: 'import something from \'another-module\';',
       errors: [
         {message: error1}
-      ],
-      output: `import something from 'another-module';`
+      ]
     }
   ]
 });

--- a/eslint-rules/tests/lib/rules/no-direct-import.js
+++ b/eslint-rules/tests/lib/rules/no-direct-import.js
@@ -30,12 +30,14 @@ const validExample1 = `import {Component} from 'another-module';`;
 const validExample2 = `import {Component} from 'new-module';`;
 const validExample3 = `const {Component} = require('another-module');`;
 const validExample4 = `const test = require('new-module').test;`;
+const validExample5 = `import something from 'another-module';`;
 
 const invalidExample1 = `import {Component} from 'some-module';`;
 const invalidExample2 = `import {Component} from 'old-module';`;
 const invalidExample3 = `const {Component} = require('some-module');`;
 const invalidExample4 = `const {Component} = require('old-module');`;
 const invalidExample5 = `const test = require(\'some-module\').test;`;
+const invalidExample6 = `import something from 'some-module';`;
 
 const error1 = `Do not import directly from 'some-module'. Please use 'another-module' (autofix available).`;
 const error2 = `Do not import directly from 'old-module'. Please use 'new-module' (autofix available).`;
@@ -67,6 +69,10 @@ ruleTester.run('no-direct-import', rule, {
     {
       options: ruleOptionsArray,
       code: validExample4
+    },
+    {
+      options: ruleOptions,
+      code: validExample5
     }
   ],
   invalid: [
@@ -131,6 +137,14 @@ ruleTester.run('no-direct-import', rule, {
       errors: [
         {message: requireError1}
       ]
+    },
+    {
+      options: ruleOptions,
+      code: invalidExample6,
+      errors: [
+        {message: error1}
+      ],
+      output: `import something from 'another-module';`
     }
   ]
 });


### PR DESCRIPTION
## Description
Fixed `addToImports` to handle default import.

## Changelog
Eslint - Fixed default import rule capture.

## Additional info
MADS-4416
