### PR TITLE
Fix number of columns in iPad Pro 11 inch

### DIFF
--- a/src/components/gridList/gridList.api.json
+++ b/src/components/gridList/gridList.api.json
@@ -6,8 +6,16 @@
   "extendsLink": ["https://reactnative.dev/docs/flatlist"],
   "example": "https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/GridListScreen.tsx",
   "props": [
-    {"name": "numColumns", "type": "number", "description": "Number of items to show in a row (ignored when passing maxItemWidth)"},
-    {"name": "itemSpacing", "type": "number", "description": "Spacing between each item"},
+    {
+      "name": "numColumns",
+      "type": "number",
+      "description": "Number of items to show in a row (ignored when passing maxItemWidth)"
+    },
+    {
+      "name": "itemSpacing",
+      "type": "number",
+      "description": "Spacing between each item (if maxItemWidth is passed this will be the minimum spacing)"
+    },
     {
       "name": "maxItemWidth",
       "type": "number",

--- a/src/components/gridList/types.ts
+++ b/src/components/gridList/types.ts
@@ -10,7 +10,7 @@ export interface GridListBaseProps extends Pick<FlatListProps<any>, 'style' | 'c
    */
   numColumns?: number;
   /**
-   * Spacing between each item
+   * Spacing between each item (if maxItemWidth is passed this will be the minimum spacing)
    */
   itemSpacing?: number;
   /**

--- a/src/components/sortableGridList/__tests__/usePresenter.spec.tsx
+++ b/src/components/sortableGridList/__tests__/usePresenter.spec.tsx
@@ -5,7 +5,8 @@ import {Constants} from '../../../commons/new';
 
 describe('SortableGridList presenter tests', () => {
   const makeSUT = ({numOfColumns = DEFAULT_NUM_COLUMNS, itemSpacing = DEFAULT_ITEM_SPACINGS}) => {
-    return renderHook(() => usePresenter(numOfColumns, itemSpacing));
+    const itemSize = Constants.screenWidth / numOfColumns;
+    return renderHook(() => usePresenter(numOfColumns, itemSize, itemSpacing));
   };
 
   describe('ltr', () => {

--- a/src/components/sortableGridList/index.tsx
+++ b/src/components/sortableGridList/index.tsx
@@ -10,7 +10,7 @@ import SortableItem from './SortableItem';
 import usePresenter from './usePresenter';
 import {ItemsOrder, SortableGridListProps, ItemProps} from './types';
 
-import useGridLayout, {DEFAULT_ITEM_SPACINGS} from '../gridList/useGridLayout';
+import useGridLayout from '../gridList/useGridLayout';
 
 function generateItemsOrder(data: SortableGridListProps['data']) {
   return _.map(data, item => item.id);
@@ -19,9 +19,9 @@ function generateItemsOrder(data: SortableGridListProps['data']) {
 function SortableGridList<T = any>(props: SortableGridListProps<T>) {
   const {renderItem, onOrderChange, flexMigration, orderByIndex = false, ...others} = props;
 
-  const {itemContainerStyle, numberOfColumns, listStyle, listContentStyle, listColumnWrapperStyle} =
+  const {itemContainerStyle, numberOfColumns, itemWidth, itemSpacing, listStyle, listContentStyle, listColumnWrapperStyle} =
     useGridLayout(props);
-  const {itemSpacing = DEFAULT_ITEM_SPACINGS, data} = others;
+  const {data} = others;
   const itemsOrder = useSharedValue<ItemsOrder>(generateItemsOrder(data));
 
   // TODO: Remove once flexMigration migration is completed
@@ -36,7 +36,7 @@ function SortableGridList<T = any>(props: SortableGridListProps<T>) {
     itemsOrder.value = generateItemsOrder(data);
   }, [data]);
 
-  const presenter = usePresenter(numberOfColumns, itemSpacing);
+  const presenter = usePresenter(numberOfColumns, itemWidth, itemSpacing);
 
   const onChange = useCallback(() => {
     const newData: ItemProps<T>[] = [];

--- a/src/components/sortableGridList/usePresenter.ts
+++ b/src/components/sortableGridList/usePresenter.ts
@@ -4,16 +4,14 @@ import {ItemLayout, ItemsOrder} from './types';
 
 export const WINDOW_WIDTH = Constants.windowWidth;
 export const DEFAULT_NO_OF_COLUMNS = 3;
-export const getItemSize = (numOfColumns: number, viewWidth: number) => viewWidth / numOfColumns;
 
 export const animationConfig = {
   easing: Easing.inOut(Easing.ease),
   duration: 350
 };
 
-const usePresenter = (numOfColumns: number, itemSpacing: number) => {
+const usePresenter = (numOfColumns: number, itemSize: number, itemSpacing: number) => {
   const itemLayout = useSharedValue<ItemLayout>(undefined);
-  const itemSize = getItemSize(numOfColumns, Constants.screenWidth);
 
   return {
     updateItemLayout: (layout: {width: number; height: number}) => {


### PR DESCRIPTION
## DO NOT MERGE
I did not test in private yet

## Description
I only managed to reproduce the bug in iPad Pro 11 inch (iOS 17.0 - did not test in other OS)
I did not test in private because I was not sure what'll you'll think about this relatively large change.

What went wrong?
In this scenario `numberOfColumns` was set to 6 (in `useGridLayout`) but it seems that there was no room for all the items, I think this is partly because we have more than one source-of-truth regarding `itemWidth` (`itemSize`) and `itemSpacing`.

I've changed the calculations (the `numberOfColumns` is now more complex...) to what I think should be and allowed `itemSpacing` to change in case `maxItemWidth` is passed.

The values are now also used in `usePresenter` instead of it recalculating the size and using the default `itemSpacing`.

## Changelog
⚠️  Fix number of columns in iPad Pro 11 inch

## Additional info
Ticket 3786
