### PR TITLE
Support live code for components

### DIFF
--- a/docuilib/src/theme/ReactLiveScope/index.js
+++ b/docuilib/src/theme/ReactLiveScope/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
-import Text from 'react-native-ui-lib/text';
-import View from 'react-native-ui-lib/view';
-import Button from 'react-native-ui-lib/button';
+import {Colors} from 'react-native-ui-lib/style';
+import {Button, Image, Text, TouchableOpacity, View} from 'react-native-ui-lib/core';
 import TextField from 'react-native-ui-lib/textField';
 import SegmentedControl from 'react-native-ui-lib/segmentedControl';
 
@@ -10,11 +9,14 @@ const ReactLiveScope = {
   React,
   ...React,
   /* uilib components */
-  View,
+  Button,
+  Colors,
+  Image,
+  SegmentedControl,
   Text,
-  Button, 
   TextField,
-  SegmentedControl
+  TouchableOpacity,
+  View
 };
 
 export default ReactLiveScope;

--- a/scripts/buildDocs.js
+++ b/scripts/buildDocs.js
@@ -100,7 +100,7 @@ components.forEach(component => {
   /* Snippet */
   if (component.snippet) {
     content += `### Usage\n`;
-    content += '```\n';
+    content += '``` jsx live\n';
     content += component.snippet?.map(item => _.replace(item, new RegExp(/\$[1-9]/, 'g'), '')).join('\n');
     content += '\n```\n';
   }

--- a/src/components/image/image.api.json
+++ b/src/components/image/image.api.json
@@ -47,6 +47,6 @@
     {"name": "useBackgroundContainer", "type": "boolean", "description": "Use a container for the Image, this can solve issues on Android when animation needs to be performed on the same view; i.e. animation related crashes on Android."}
   ],
   "snippet": [
-    "<Image source={{uri: 'https://github.com/wix/react-native-ui-lib/blob/master/demo/src/assets/images/card-example.jpg'}$1}/>"
+    "<Image width={50} height={50} source={{uri: 'https://images.pexels.com/photos/748837/pexels-photo-748837.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260'}$1}/>"
   ]
 }

--- a/src/components/textField/textField.api.json
+++ b/src/components/textField/textField.api.json
@@ -138,12 +138,13 @@
     "<TextField",
     "  placeholder={'Placeholder'$1}",
     "  floatingPlaceholder$2",
-    "  onChangeText={onChangeText$3}",
+    "  onChangeText={text => console.log(text)$3}",
     "  enableErrors$4",
-    "  validate={['required', 'email', (value) => value.length > 6]$5}",
-    "  validationMessage={['Field is required', 'Email is invalid', 'Password is too short']$6}",
-    "  showCharCounter$7",
-    "  maxLength={30$8}",
+    "  validateOnChange$5",
+    "  validate={['required', (value) => value.length > 6]$6}",
+    "  validationMessage={['Field is required', 'Password is too short']$7}",
+    "  showCharCounter$8",
+    "  maxLength={30$9}",
     "/>"
   ]
 }

--- a/src/components/touchableOpacity/touchableOpacity.api.json
+++ b/src/components/touchableOpacity/touchableOpacity.api.json
@@ -31,6 +31,6 @@
     {"name": "onPress", "type": "(props?: TouchableOpacityProps & {event: GestureResponderEvent} | any) => void", "description": "On press callback"}
   ],
   "snippet": [
-    "<TouchableOpacity onPress={() => console.log('pressed')$1}/>"
+    "<TouchableOpacity onPress={() => console.log('pressed')$1}><Text text40>Click Me!</Text></TouchableOpacity>"
   ]
 }

--- a/src/components/view/view.api.json
+++ b/src/components/view/view.api.json
@@ -25,5 +25,14 @@
     {"name": "recorderTag", "type": "'mask' | 'unmask'", "description": "Recorder Tag"},
     {"name": "style", "type": "ViewStyle", "description": "Custom style"}
   ],
-  "snippet": ["<View style={{width: 50, height: 50}} bg-orange50/>"]
+  "snippet": [
+   "<View row gap-s5 centerV>",
+   "  <View style={{width: 200, height: 200}} bg-purple40 centerH>",
+   "  <View style={{width: 60, height: 60}} bg-green20/>",
+   "  </View>",
+   "  <View style={{width: 150, height: 150}} bg-orange30 bottom right>",
+   "  <View style={{width: 50, height: 50}} bg-yellow40 br100 margin-s2/>",
+   "  </View>",
+   "</View>"
+  ]
 }

--- a/src/components/view/view.api.json
+++ b/src/components/view/view.api.json
@@ -24,5 +24,6 @@
     {"name": "backgroundColor", "type": "string", "description": "Set background color"},
     {"name": "recorderTag", "type": "'mask' | 'unmask'", "description": "Recorder Tag"},
     {"name": "style", "type": "ViewStyle", "description": "Custom style"}
-  ]
+  ],
+  "snippet": ["<View style={{width: 50, height: 50}} bg-orange50/>"]
 }


### PR DESCRIPTION
## Description
Support live code for components .

* Need to add components to `ReactLiveScope` and test all relevant components.
* Some snippets need to be fixed.
* Looks like the `$1` (etc) are ignored (at least in the components I've tested).
* In `View`: `<View style={{width: 50, height: 50}} bg-orange50/>` is working while `<View width={50} height={50} bg-orange50/>` is not working (I did not test in the webDemo or dig deeper, it is also working in `Image` for example).

## Changelog
None

## Additional info
Ticket 4470
