### PR TITLE
uilib-docs src index export

### DIFF
--- a/docuilib/index.js
+++ b/docuilib/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./src');

--- a/docuilib/package.json
+++ b/docuilib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uilib-docs",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",


### PR DESCRIPTION
## Description
Patch PR, exporting `src index` file of `uilib-docs` from package root instead from src only.
Based on [PR](https://github.com/wix/react-native-ui-lib/pull/3286).

## Changelog
`uilib-docs` src index file export.

## Additional info
None
