### PR TITLE
Live-code device wrapper

### DIFF
--- a/docuilib/src/MobileDeviceWrapper.tsx
+++ b/docuilib/src/MobileDeviceWrapper.tsx
@@ -1,7 +1,6 @@
 import React, {useState, useEffect} from 'react';
 import {StyleSheet} from 'react-native';
 import {View, Text, Colors, Spacings} from 'react-native-ui-lib/core';
-
 import SegmentedControl from 'react-native-ui-lib/segmentedControl';
 
 interface SimulatorSize {
@@ -43,8 +42,8 @@ const MobileDeviceWrapper = ({children}) => {
   };
 
   return (
-    <View gap-s3 center>
-      <View gap-s1 marginV-s1>
+    <View gap-s3>
+      <View gap-s1 marginV-s1 center>
         <Text marginR-s3 style={styles.typesTitle}>
           Choose Type
         </Text>
@@ -54,23 +53,10 @@ const MobileDeviceWrapper = ({children}) => {
           onChangeIndex={index => {
             onPress(simulatorOptions[index].value);
           }}
+          backgroundColor={Colors.$backgroundDefault}
         />
       </View>
-
-      <View
-        style={{
-          ...simulatorSize,
-          alignSelf: 'center',
-          borderRadius: 40,
-          borderWidth: 4,
-          borderColor: Colors.$outlineDisabledHeavy,
-          marginTop: Spacings.s2,
-          marginBottom: Spacings.s2,
-          overflow: 'hidden'
-        }}
-      >
-        {children}
-      </View>
+      <View style={[styles.simulatorWrapper, simulatorSize]}>{children}</View>
     </View>
   );
 };
@@ -81,5 +67,13 @@ const styles = StyleSheet.create({
   typesTitle: {
     fontWeight: 'bold',
     textAlign: 'center'
+  },
+  simulatorWrapper: {
+    alignSelf: 'center',
+    borderRadius: 40,
+    borderWidth: 4,
+    borderColor: Colors.$outlineDisabledHeavy,
+    marginVertical: Spacings.s2,
+    overflow: 'hidden'
   }
 });

--- a/docuilib/src/MobileDeviceWrapper.tsx
+++ b/docuilib/src/MobileDeviceWrapper.tsx
@@ -1,0 +1,85 @@
+import React, {useState, useEffect} from 'react';
+import {StyleSheet} from 'react-native';
+import {View, Text, Colors, Spacings} from 'react-native-ui-lib/core';
+
+import SegmentedControl from 'react-native-ui-lib/segmentedControl';
+
+interface SimulatorSize {
+  width: number | undefined;
+  height: number | undefined;
+}
+
+enum SimulatorTypes {
+  MOBILE = 'MOBILE',
+  TABLET = 'TABLET'
+}
+
+const simulatorOptions = [
+  {label: 'Mobile', value: SimulatorTypes.MOBILE},
+  {label: 'Tablet', value: SimulatorTypes.TABLET}
+];
+
+const MobileDeviceWrapper = ({children}) => {
+  const [simulatorSize, setSimulatorSize] = useState<SimulatorSize>({width: 340, height: 754});
+  const [type, setType] = useState<SimulatorTypes>(SimulatorTypes.MOBILE);
+
+  useEffect(() => {
+    changeType();
+  }, [type]);
+
+  function changeType() {
+    switch (type) {
+      case SimulatorTypes.MOBILE:
+      default:
+        setSimulatorSize({width: 340, height: 754});
+        break;
+      case SimulatorTypes.TABLET:
+        setSimulatorSize({width: 900, height: 754});
+        break;
+    }
+  }
+  const onPress = (type: SimulatorTypes) => {
+    setType?.(type);
+  };
+
+  return (
+    <View gap-s3 center>
+      <View gap-s1 marginV-s1>
+        <Text marginR-s3 style={styles.typesTitle}>
+          Choose Type
+        </Text>
+        <SegmentedControl
+          initialIndex={0}
+          segments={simulatorOptions}
+          onChangeIndex={index => {
+            onPress(simulatorOptions[index].value);
+          }}
+        />
+      </View>
+
+      <View
+        style={{
+          ...simulatorSize,
+          alignSelf: 'center',
+          borderRadius: 40,
+          borderWidth: 4,
+          borderColor: Colors.$outlineDisabledHeavy,
+          marginTop: Spacings.s2,
+          marginBottom: Spacings.s2,
+          overflow: 'hidden'
+        }}
+      >
+        {children}
+      </View>
+    </View>
+  );
+};
+
+export default MobileDeviceWrapper;
+
+const styles = StyleSheet.create({
+  typesTitle: {
+    fontWeight: 'bold',
+    textAlign: 'center'
+  }
+});

--- a/docuilib/src/theme/ReactLiveScope/index.js
+++ b/docuilib/src/theme/ReactLiveScope/index.js
@@ -9,11 +9,13 @@ import RadioGroup from 'react-native-ui-lib/radioGroup';
 import SegmentedControl from 'react-native-ui-lib/segmentedControl';
 import Switch from 'react-native-ui-lib/switch';
 import TextField from 'react-native-ui-lib/textField';
+import MobileDeviceWrapper from '../../MobileDeviceWrapper';
 
 // Add react-live imports you need here
 const ReactLiveScope = {
   React,
   ...React,
+  MobileDeviceWrapper,
   /* uilib components */
   ActionBar,
   Button,

--- a/scripts/buildDocs.js
+++ b/scripts/buildDocs.js
@@ -156,8 +156,21 @@ function getFirstTab(component) {
   /* Snippet */
   if (component.snippet) {
     content += '### Usage\n';
-    content += '``` jsx live\n';
-    content += component.snippet?.map(item => _.replace(item, new RegExp(/\$[1-9]/, 'g'), '')).join('\n');
+    content += '```jsx live\n';
+
+    content += '\n';
+    content += '<MobileDeviceWrapper>\n';
+    // Map and wrap each snippet, then join them together
+    const wrappedSnippets = component.snippet
+      .map(item => {
+        // Replace placeholders and wrap with MobileDeviceWrapper
+        const cleanedSnippet = _.replace(item, new RegExp(/\$[1-9]/, 'g'), '');
+        return `${cleanedSnippet}`;
+      })
+      .join('\n');
+
+    content += wrappedSnippets;
+    content += '</MobileDeviceWrapper>\n';
     content += '\n```\n';
   }
 

--- a/scripts/buildDocs.js
+++ b/scripts/buildDocs.js
@@ -170,7 +170,7 @@ function getFirstTab(component) {
       .join('\n');
 
     content += wrappedSnippets;
-    content += '</MobileDeviceWrapper>\n';
+    content += '\n</MobileDeviceWrapper>\n';
     content += '\n```\n';
   }
 


### PR DESCRIPTION
## Description
Docs playground (`live-code`) device wrapper to simulate `Mobile or Tablet` device.
In the `buildDocs` script wrapping the component snippet with the `MobileDeviceWrapper` that changes the size of the `View` container according to the selected mode.

## Changelog
Docs playground (`live-code`) device wrapper to simulate `Mobile or Tablet` device.

## Additional info
MADS-4507
