### PR TITLE
uilib-docs new version 3.1.3

### DIFF
--- a/docuilib/index.js
+++ b/docuilib/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./src');

--- a/docuilib/package.json
+++ b/docuilib/package.json
@@ -1,6 +1,7 @@
 {
   "name": "uilib-docs",
-  "version": "3.1.2",
+  "version": "3.1.3",
+  "main": "./src/index.ts",
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",


### PR DESCRIPTION
## Description
uilib-docs new version 3.1.3
changed the `main` entry point in `package.json` file to export `ReactLiveScope`.

## Changelog
uilib-docs new version 3.1.3

## Additional info
None
