### PR TITLE
Fix sortable list components flexMigration

### DIFF
--- a/src/components/sortableGridList/index.tsx
+++ b/src/components/sortableGridList/index.tsx
@@ -86,7 +86,7 @@ export default SortableGridList;
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1
+    flexGrow: 1
   },
   listContent: {
     flexWrap: 'wrap',

--- a/src/components/sortableList/index.tsx
+++ b/src/components/sortableList/index.tsx
@@ -104,7 +104,7 @@ const SortableList = <ItemT extends SortableListItemProps>(props: SortableListPr
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1
+    flexGrow: 1
   }
 });
 


### PR DESCRIPTION
## Description
Fix sortable list components flexMigration  to use a container with flexGrow
Using flex caused issue when rendering the list in a specific layout with horizontal direction

```
<View flex>
  <View>
    <SortableList horizontal ...../>
  </View>
<View>

```

## Changelog
Fix sortable list components flexMigration

## Additional info
<!--
If applicable, add additional info such as link to the bug being fixed by this PR etc
-->
