### PR TITLE
Components defaultProps migrate to default parameters

### DIFF
--- a/src/components/dash/index.tsx
+++ b/src/components/dash/index.tsx
@@ -12,16 +12,16 @@ export type Layout = {
 
 export interface DashProps extends ViewProps {
   vertical?: boolean;
-  gap: number;
-  length: number;
-  thickness: number;
+  gap?: number;
+  length?: number;
+  thickness?: number;
   color?: string;
   style?: StyleProp<ViewStyle>;
   containerStyle?: StyleProp<ViewStyle>;
 }
 
 const Dash = (props: DashProps) => {
-  const {containerStyle, vertical, gap, length, thickness, color, style, testID} = props;
+  const {containerStyle, vertical, gap = 6, length = 6, thickness = 2, color, style, testID} = props;
   const [measurements, setMeasurements] = useState<Layout | undefined>();
 
   const onDashLayout = useCallback((event: LayoutChangeEvent) => {
@@ -52,7 +52,7 @@ const Dash = (props: DashProps) => {
     const _length = (vertical ? measurements?.height : measurements?.width) || 0;
     const n = Math.ceil(_length / (gap + length));
     const dash = [];
-    
+
     for (let i = 0; i < n; i++) {
       dash.push(<View key={i} bg-$outlineDefault backgroundColor={color} style={dashStyle}/>);
     }
@@ -68,11 +68,6 @@ const Dash = (props: DashProps) => {
 };
 
 export default Dash;
-Dash.defaultProps = {
-  gap: 6,
-  length: 6,
-  thickness: 2
-};
 
 const styles = StyleSheet.create({
   row: {

--- a/src/components/dialog/DialogDismissibleView.tsx
+++ b/src/components/dialog/DialogDismissibleView.tsx
@@ -57,7 +57,14 @@ interface LocationProps {
 const DEFAULT_DIRECTION = PanningProvider.Directions.DOWN;
 
 const DialogDismissibleView = (props: Props) => {
-  const {direction = DEFAULT_DIRECTION, visible: propsVisible, containerStyle, style, children, onDismiss} = props;
+  const {
+    direction = DEFAULT_DIRECTION,
+    visible: propsVisible,
+    containerStyle,
+    style,
+    children,
+    onDismiss = () => {}
+  } = props;
   // @ts-expect-error
   const {isPanning, dragDeltas, swipeDirections} = useContext<PanContextProps>(PanningContext);
 
@@ -245,10 +252,6 @@ const DialogDismissibleView = (props: Props) => {
 };
 
 DialogDismissibleView.displayName = 'IGNORE';
-DialogDismissibleView.defaultProps = {
-  direction: DEFAULT_DIRECTION,
-  onDismiss: () => {}
-};
 
 export default DialogDismissibleView;
 

--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -56,7 +56,7 @@ const Icon = forwardRef((props: Props, ref: any) => {
     style,
     supportRTL,
     source,
-    assetGroup,
+    assetGroup = 'icons',
     assetName,
     modifiers,
     recorderTag,

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -47,7 +47,7 @@ type PickerStatics = {
 const Picker = React.forwardRef((props: PickerProps, ref) => {
   const themeProps = useThemeProps(props, 'Picker');
   const {
-    mode,
+    mode = PickerModes.SINGLE,
     fieldType = PickerFieldTypes.form,
     selectionLimit,
     showSearch,
@@ -86,10 +86,10 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
   const [items, setItems] = useState<PickerItemProps[]>(propItems || extractPickerItems(themeProps));
   const pickerExpandable = useRef<ExpandableOverlayMethods>(null);
   const pickerRef = useImperativePickerHandle(ref, pickerExpandable);
-  
+
   // TODO: Remove this when migration is completed, starting of v8
   // usePickerMigrationWarnings({children, migrate, getItemLabel, getItemValue});
-  
+
   useEffect(() => {
     if (propItems) {
       setItems(propItems);
@@ -295,9 +295,7 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
 
 // @ts-expect-error
 Picker.Item = PickerItem;
-Picker.defaultProps = {
-  mode: PickerModes.SINGLE
-};
+
 Picker.displayName = 'Picker';
 // @ts-expect-error
 Picker.modes = PickerModes;

--- a/src/components/stackAggregator/index.tsx
+++ b/src/components/stackAggregator/index.tsx
@@ -68,10 +68,10 @@ const StackAggregator = (props: StackAggregatorProps) => {
     containerStyle,
     buttonProps,
     collapsed = true,
-    disablePresses,
+    disablePresses = false,
     onItemPress,
     contentContainerStyle,
-    itemBorderRadius,
+    itemBorderRadius = 0,
     onCollapseWillChange,
     onCollapseChanged
   } = props;
@@ -301,11 +301,6 @@ const StackAggregator = (props: StackAggregatorProps) => {
 
 export default asBaseComponent<StackAggregatorProps>(StackAggregator);
 StackAggregator.displayName = 'StackAggregator';
-StackAggregator.defaultProps = {
-  collapsed: true,
-  disablePresses: false,
-  itemBorderRadius: 0
-};
 
 const styles = StyleSheet.create({
   subContainer: {


### PR DESCRIPTION
## Description
React will stop support `defaultProps` in feature major release warning.
Migrate `defaultProps` to parameter props for: `Dash, DialogDismissibleView, Icon, Picker, StackAggregator`.
Related React docs [link](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-proptypes-and-defaultprops)

## Changelog
Functional component `defaultProps` migrate to `parameter props`.

## Additional info
Related issue #3285 
