### PR TITLE
onTokenPress show hex value and system color

### DIFF
--- a/docuilib/src/components/ColorsSection.js
+++ b/docuilib/src/components/ColorsSection.js
@@ -77,7 +77,8 @@ export function ColorsTable() {
 
   const onTokenPress = value => {
     Clipboard.setString(value);
-    const message = `Copied ${value} to clipboard`;
+    const systemColorName = Colors.getSystemColorByHex(value);
+    const message = `Copied ${value} to clipboard\n System color: ${systemColorName}`;
     setMessage(message);
     toggleToastVisibility();
   };


### PR DESCRIPTION
## Description
Docs Colors page, onTokenPress show hex value and system color.
This change is according to the UX request.

## Changelog
None

## Additional info
None
