### PR TITLE
ColorPicker.Dialog exporting ColorPickerDialog

### DIFF
--- a/src/components/colorPicker/index.tsx
+++ b/src/components/colorPicker/index.tsx
@@ -8,6 +8,7 @@ import Button from '../button';
 import ColorPalette, {ColorPaletteProps} from '../colorPalette';
 import {SWATCH_MARGIN, SWATCH_SIZE} from '../colorSwatch';
 import ColorPickerDialog, {ColorPickerDialogProps} from './ColorPickerDialog';
+import type {ComponentStatics} from '../../typings/common';
 
 interface Props extends ColorPickerDialogProps, Pick<ColorPaletteProps, 'onValueChange'> {
   /**
@@ -119,7 +120,7 @@ const ColorPicker = (props: Props) => {
 ColorPicker.displayName = 'ColorPicker';
 ColorPicker.Dialog = ColorPickerDialog;
 
-export default asBaseComponent<Props, {Dialog: typeof ColorPickerDialog}>(ColorPicker);
+export default asBaseComponent<Props, ComponentStatics<typeof ColorPicker>>(ColorPicker);
 
 const plusButtonContainerWidth = SWATCH_SIZE + 20 + 12;
 const plusButtonContainerHeight = 92 - 2 * SWATCH_MARGIN;

--- a/src/components/colorPicker/index.tsx
+++ b/src/components/colorPicker/index.tsx
@@ -117,8 +117,9 @@ const ColorPicker = (props: Props) => {
 };
 
 ColorPicker.displayName = 'ColorPicker';
+ColorPicker.Dialog = ColorPickerDialog;
 
-export default asBaseComponent<Props>(ColorPicker);
+export default asBaseComponent<Props, {Dialog: typeof ColorPickerDialog}>(ColorPicker);
 
 const plusButtonContainerWidth = SWATCH_SIZE + 20 + 12;
 const plusButtonContainerHeight = 92 - 2 * SWATCH_MARGIN;


### PR DESCRIPTION
## Description
`ColorPicker.Dialog` exporting `ColorPickerDialog`.
This export help us to use `ColorPickerDialog` after package build (usage for Doc's).
Checked by `build:local` package.

## Changelog
`ColorPicker.Dialog` exporting `ColorPickerDialog`.

## Additional info
None
