### PR TITLE
Docs - section - renaming 'massage' type 'banner'

### DIFF
--- a/docuilib/src/components/ComponentPage.tsx
+++ b/docuilib/src/components/ComponentPage.tsx
@@ -22,7 +22,7 @@ export default function ComponentPage({component}) {
         switch (section.type) {
           case 'info':
           case 'tip':
-          case 'massage':
+          case 'banner':
             return <Banner section={section} component={component}/>;
           case 'list':
             return (

--- a/src/components/test.api.json
+++ b/src/components/test.api.json
@@ -182,13 +182,13 @@
             "type": "tip"
           },
           {
-            "type": "massage",
+            "type": "banner",
             "title": "NOTE",
             "description": "This is an interesting information"
           },
           {
-            "type": "massage",
-            "title": "MASSAGE",
+            "type": "banner",
+            "title": "Banner",
             "description": "This is some massage to the user",
             "color": "pink",
             "icon": ""


### PR DESCRIPTION

## Description
Docs - section - renaming 'massage' type 'banner' to align with component name


## Changelog
Docs - section - renaming 'massage' type 'banner'

## Additional info

