### PR TITLE
Fixed rare case of infinitive animation of animated image

### DIFF
--- a/demo/src/screens/__tests__/__snapshots__/AvatarScreen.spec.js.snap
+++ b/demo/src/screens/__tests__/__snapshots__/AvatarScreen.spec.js.snap
@@ -1450,6 +1450,7 @@ exports[`AvatarScreen renders screen 1`] = `
             assetGroup="icons"
             onError={[Function]}
             onLoad={[Function]}
+            onLoadStart={[Function]}
             source={
               {
                 "uri": "https://static.pexels.com/photos/60628/flower-garden-blue-sky-hokkaido-japan-60628.jpeg",

--- a/src/components/animatedImage/index.tsx
+++ b/src/components/animatedImage/index.tsx
@@ -36,12 +36,13 @@ const AnimatedImage = (props: AnimatedImageProps) => {
     loader,
     style,
     onLoad: propsOnLoad,
+    onLoadStart: propsOnLoadStart,
     animationDuration = 300,
     testID,
     ...others
   } = props;
 
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
   const opacity = useSharedValue(0);
 
   useDidUpdate(() => {
@@ -50,16 +51,23 @@ const AnimatedImage = (props: AnimatedImageProps) => {
     }
   }, [loader]);
 
-  const onLoad = useCallback((event: NativeSyntheticEvent<ImageLoadEventData>) => {
-    setIsLoading(false);
-    propsOnLoad?.(event);
-    // did not start the animation already
-    if (opacity.value === 0) {
-      opacity.value = withTiming(1, {duration: animationDuration});
-    }
-  },
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [setIsLoading, propsOnLoad, animationDuration]);
+  const onLoad = useCallback(
+    (event: NativeSyntheticEvent<ImageLoadEventData>) => {
+      setIsLoading(false);
+      propsOnLoad?.(event);
+      // did not start the animation already
+      if (opacity.value === 0) {
+        opacity.value = withTiming(1, {duration: animationDuration});
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [setIsLoading, propsOnLoad, animationDuration]
+  );
+
+  const onLoadStart = useCallback(() => {
+    setIsLoading(true);
+    propsOnLoadStart?.();
+  }, [setIsLoading, propsOnLoadStart, animationDuration]);
 
   const fadeInStyle = useAnimatedStyle(() => {
     return {opacity: opacity.value};
@@ -75,6 +83,7 @@ const AnimatedImage = (props: AnimatedImageProps) => {
         style={_style}
         source={source}
         onLoad={onLoad}
+        onLoadStart={onLoadStart}
         testID={testID}
         imageStyle={undefined}
       />


### PR DESCRIPTION
## Description
<!--
Enter description to help the reviewer understand what's the change about...
-->
This is a fix of a rare case of infinitive skeleton  animation in AnimatedImage component that happens when the component is invisible.

## Changelog
<!--
Add a quick message for our users about this change (include Component name, relevant props and general purpose of the PR)
-->
AnimatedImage
## Additional info
<!--
If applicable, add additional info such as link to the bug being fixed by this PR etc
-->
This issue could happen for example in a long scroll list of animated images that are out of screen. In that case image is not starting to being loaded but we do start to show the animation (invisible).
This is not a real problem in production, but it does brakes Detox tests in components that are using AnimatedImage