### PR TITLE
Fix error with the TabController and Gesture Handler when passing a ref

### DIFF
--- a/src/components/tabController/TabBarItem.tsx
+++ b/src/components/tabController/TabBarItem.tsx
@@ -134,6 +134,7 @@ export default function TabBarItem({
   ignore,
   style,
   spreadItems,
+  onPress,
   ...props
 }: Props) {
   const {currentPage, setCurrentIndex} = useContext(TabBarContext);
@@ -207,7 +208,7 @@ export default function TabBarItem({
         setCurrentIndex(index);
       }
 
-      props.onPress && runOnJS(props.onPress)(index);
+      onPress && runOnJS(onPress)(index);
     })
     .onFinalize(() => {
       isPressed.value = false;


### PR DESCRIPTION
## Description
There was an error occurring when using a tab item with a trailingAccessory which was passed with a ref on it. We're not sure what exactly causes the error but seems like taking the onPress outside of the scope of the handler fixes the error.
## Changelog
TabBarItem - onPress taken from props at the beginning.

## Additional info
MADS-4537
