### PR TITLE
Remove double header when component has Hero section

### DIFF
--- a/scripts/docs/buildDocsCommon.js
+++ b/scripts/docs/buildDocsCommon.js
@@ -70,8 +70,9 @@ function processComponents(components) {
     if (isParentComponent) {
       content += 'sidebar_position: 1\n';
     }
+    const title = component.docs?.hero ? '""' : `${isIncubatorComponent ? 'Incubator.' : ''}${component.name}`;
     content += `id: ${component.name}\n`;
-    content += `title: ${isIncubatorComponent ? 'Incubator.' : ''}${component.name}\n`;
+    content += `title: ${title}\n`;
     content += `sidebar_label: ${componentName}\n`;
     content += '---\n\n';
 


### PR DESCRIPTION
## Description
Remove double header when component has Hero section by setting an empty string in markdown title

## Changelog
N/A

## Additional info
