### PR TITLE
Build docs of services category in a separate folder

### DIFF
--- a/scripts/docs/buildDocsCommon.js
+++ b/scripts/docs/buildDocsCommon.js
@@ -6,7 +6,9 @@ const childProcess = require('child_process');
 const fs = require('fs');
 
 const COMPONENTS_DOCS_DIR = './docs/components';
-const VALID_CATEGORIES = [
+const SERVICES_DOCS_DIR = './docs/services';
+
+const VALID_COMPONENTS_CATEGORIES = [
   'foundation',
   'basic',
   'assets',
@@ -21,7 +23,9 @@ const VALID_CATEGORIES = [
   'overlays',
   'charts',
   'incubator',
-  'infra'
+  'infra',
+  // non components categories
+  'services'
 ];
 
 function buildDocs(apiFolders, componentsPreProcess) {
@@ -64,7 +68,7 @@ function processComponents(components) {
     const isParentComponent = parentComponents.includes(componentName);
     const isIncubatorComponent = component.category === 'incubator';
 
-    if (!VALID_CATEGORIES.includes(component.category)) {
+    if (!VALID_COMPONENTS_CATEGORIES.includes(component.category)) {
       console.error(`${componentName} has invalid category "${component.category}"`);
     }
 
@@ -88,9 +92,15 @@ function processComponents(components) {
       content += `${buildOldDocs(component)}\n`;
     }
 
-    const componentParentDir =
-      componentParentName || isParentComponent ? `/${componentParentName || componentName}` : '';
-    const dirPath = `${COMPONENTS_DOCS_DIR}/${component.category}${componentParentDir}`;
+
+    let dirPath;
+    if (component.category === 'services') {
+      dirPath = `${SERVICES_DOCS_DIR}`;
+    } else {
+      const componentParentDir =
+        componentParentName || isParentComponent ? `/${componentParentName || componentName}` : '';
+      dirPath = `${COMPONENTS_DOCS_DIR}/${component.category}${componentParentDir}`;
+    }
 
     if (!fs.existsSync(dirPath)) {
       fs.mkdirSync(dirPath, {recursive: true});

--- a/scripts/docs/buildDocsCommon.js
+++ b/scripts/docs/buildDocsCommon.js
@@ -106,7 +106,7 @@ function processComponents(components) {
       fs.mkdirSync(dirPath, {recursive: true});
     }
 
-    fs.writeFileSync(`${dirPath}/${component.name}.md`, content, {encoding: 'utf8'});
+    fs.writeFileSync(`${dirPath}/${component.name.replaceAll(' ', '_')}.md`, content, {encoding: 'utf8'});
   });
 }
 


### PR DESCRIPTION
## Description
I want to create (in private) some api.json files that will be part of the services section (not components) 
I updated the build script to create relevant md files in a separate (services) folder 

## Changelog
N/A

## Additional info
<!--
If applicable, add additional info such as link to the bug being fixed by this PR etc
-->
