### PR TITLE
Add textColor and backgroundColor props to DateTimePicker component

### DIFF
--- a/demo/src/screens/componentScreens/DateTimePickerScreen.tsx
+++ b/demo/src/screens/componentScreens/DateTimePickerScreen.tsx
@@ -68,6 +68,7 @@ export default class DateTimePickerScreen extends Component<{}, State> {
             placeholder={'Select a date'}
             // textColor={Colors.red30}
             // backgroundColor={Colors.$backgroundDark}
+            // cancelButtonProps={{iconStyle: {tintColor: Colors.$iconDefaultLight}}}
             // value={new Date('October 13, 2014')}
           />
           <DateTimePicker

--- a/demo/src/screens/componentScreens/DateTimePickerScreen.tsx
+++ b/demo/src/screens/componentScreens/DateTimePickerScreen.tsx
@@ -66,6 +66,8 @@ export default class DateTimePickerScreen extends Component<{}, State> {
             containerStyle={{marginVertical: 20}}
             label={'Date'}
             placeholder={'Select a date'}
+            // textColor={Colors.red30}
+            // backgroundColor={Colors.$backgroundDark}
             // value={new Date('October 13, 2014')}
           />
           <DateTimePicker

--- a/src/components/dateTimePicker/index.tsx
+++ b/src/components/dateTimePicker/index.tsx
@@ -95,6 +95,14 @@ export type DateTimePickerProps = OldApiProps &
      */
     display?: string;
     /**
+     * Text color of the wheel picker items
+     */
+    textColor?: string;
+    /**
+     * Background color of the wheel picker
+     */
+    backgroundColor?: string;
+    /**
      * Confirm button props
      */
     confirmButtonProps?: ButtonProps;
@@ -137,6 +145,8 @@ const DateTimePicker = forwardRef((props: DateTimePickerPropsInternal, ref: Forw
     onChange,
     dialogProps,
     migrateDialog,
+    textColor = Colors.$textDefault,
+    backgroundColor = Colors.$backgroundDefault,
     headerStyle,
     testID,
     display = Constants.isIOS ? 'spinner' : undefined,
@@ -185,6 +195,10 @@ const DateTimePicker = forwardRef((props: DateTimePickerPropsInternal, ref: Forw
       ...dialogProps
     };
   }, [dialogProps, testID]);
+
+  const dateTimePickerStyle = useMemo(() => {
+    return {backgroundColor};
+  }, [backgroundColor]);
 
   const {getStringValue: getStringValueOld} = useOldApi({dateFormat, dateFormatter, timeFormat, timeFormatter});
 
@@ -240,6 +254,7 @@ const DateTimePicker = forwardRef((props: DateTimePickerPropsInternal, ref: Forw
         row
         spread
         bg-$backgroundDefault
+        backgroundColor={backgroundColor}
         paddingH-20
         style={[styles.header, headerStyle]}
         testID={`${testID}.header`}
@@ -280,6 +295,8 @@ const DateTimePicker = forwardRef((props: DateTimePickerPropsInternal, ref: Forw
         minuteInterval={minuteInterval}
         timeZoneOffsetInMinutes={timeZoneOffsetInMinutes}
         display={display}
+        textColor={textColor}
+        style={dateTimePickerStyle}
         themeVariant={themeVariant}
         testID={`${testID}.picker`}
       />


### PR DESCRIPTION
## Description
Add textColor and backgroundColor props to DateTimePicker component
This allows us to control the color we use in the component and have it support branded colors properly 

## Changelog
Add textColor and backgroundColor props to DateTimePicker component

## Additional info
MADS-4583