### PR TITLE
Update ButtonProps to use IconProps for iconProps type

### DIFF
--- a/src/components/button/types.ts
+++ b/src/components/button/types.ts
@@ -10,6 +10,7 @@ import {
 import {TouchableOpacityProps} from '../touchableOpacity';
 import {TextProps} from '../text';
 import {ImageProps} from '../image';
+import type {IconProps} from '../icon';
 
 export enum ButtonSize {
   xSmall = 'xSmall',
@@ -53,7 +54,7 @@ export type ButtonProps = TouchableOpacityProps &
     /**
      * Other image props that will be passed to the image
      */
-    iconProps?: Partial<ImageProps>;
+    iconProps?: Partial<IconProps>;
     /**
      * Should the icon be right to the label
      */


### PR DESCRIPTION
## Description
Changed `ButtonProps.iconProps` to use `IconProps` instead of `ImageProps`.

## Changelog
Button - Fixed `iconProps` to use `IconProps`;

## Additional info
MADS-4593
