### PR TITLE
Picker - Fix wrong offset when items change from search

### DIFF
--- a/src/components/picker/PickerItemsList.tsx
+++ b/src/components/picker/PickerItemsList.tsx
@@ -80,7 +80,7 @@ const PickerItemsList = (props: PickerItemsListProps) => {
     return <PickerItem {...item}/>;
   }, []);
 
-  const listPropsWithMergedStyles = useMemo(() => {
+  const _listProps = useMemo(() => {
     return {
       ...listProps,
       style: [styles.list, listProps?.style]
@@ -95,7 +95,7 @@ const PickerItemsList = (props: PickerItemsListProps) => {
           data={items}
           renderItem={renderPropItems}
           keyExtractor={keyExtractor}
-          {...listPropsWithMergedStyles}
+          {..._listProps}
         />
       );
     }
@@ -106,7 +106,7 @@ const PickerItemsList = (props: PickerItemsListProps) => {
         renderItem={renderItem}
         keyExtractor={keyExtractor}
         testID={`${testID}.list`}
-        {...listPropsWithMergedStyles}
+        {..._listProps}
       />
     );
   };

--- a/src/components/picker/PickerItemsList.tsx
+++ b/src/components/picker/PickerItemsList.tsx
@@ -213,8 +213,7 @@ const styles = StyleSheet.create({
     ...Typography.text70
   },
   list: {
-    height: '100%',
-    backgroundColor: 'red'
+    height: '100%'
   }
 });
 

--- a/src/components/picker/PickerItemsList.tsx
+++ b/src/components/picker/PickerItemsList.tsx
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import React, {useCallback, useContext, useState} from 'react';
+import React, {useCallback, useContext, useMemo, useState} from 'react';
 import {StyleSheet, FlatList, TextInput, ListRenderItemInfo, ActivityIndicator} from 'react-native';
 import {Typography, Colors} from '../../style';
 import Assets from '../../assets';
@@ -80,6 +80,13 @@ const PickerItemsList = (props: PickerItemsListProps) => {
     return <PickerItem {...item}/>;
   }, []);
 
+  const listPropsWithMergedStyles = useMemo(() => {
+    return {
+      ...listProps,
+      style: [styles.list, listProps?.style]
+    };
+  }, [listProps]);
+
   const renderList = () => {
     if (items) {
       return (
@@ -88,7 +95,7 @@ const PickerItemsList = (props: PickerItemsListProps) => {
           data={items}
           renderItem={renderPropItems}
           keyExtractor={keyExtractor}
-          {...listProps}
+          {...listPropsWithMergedStyles}
         />
       );
     }
@@ -99,7 +106,7 @@ const PickerItemsList = (props: PickerItemsListProps) => {
         renderItem={renderItem}
         keyExtractor={keyExtractor}
         testID={`${testID}.list`}
-        {...listProps}
+        {...listPropsWithMergedStyles}
       />
     );
   };
@@ -204,6 +211,10 @@ const styles = StyleSheet.create({
     paddingRight: 16,
     flex: 1,
     ...Typography.text70
+  },
+  list: {
+    height: '100%',
+    backgroundColor: 'red'
   }
 });
 


### PR DESCRIPTION
## Description
Fixes bug where for some searched values in the Picker, the FlatList starts at an incorrect offset after the search. The FlatList items change, causing it to change its height and make it start the scroll at some negative offset. I've made it take the entire height that is left so this way the height will not change when the content changes so theres no jump.
I'm not sure if this is the correct solution. As it seems when the items change the FlatList goes under the TextInput, like having a negative offset so the picker item seems cut. After scrolling a little the item goes to its correct place and scroll resets correctly.
## Steps to reproduce:
1. Open the modal
2. Search for Sh
3. "Shell" item should be cut
## Playground to reproduce:
```tsx
import React, {Component} from 'react';
import {View, Picker} from 'react-native-ui-lib';

const options = [
  {label: 'Rust', value: 'rust'},
  {label: 'Dart', value: 'dart'},
  {label: 'Elixir', value: 'elixir'},
  {label: 'Haskell', value: 'haskell'},
  {label: 'Clojure', value: 'clojure'},
  {label: 'Lua', value: 'lua'},
  {label: 'Erlang', value: 'erlang'},
  {label: 'F#', value: 'fsharp'},
  {label: 'MATLAB', value: 'matlab'},
  {label: 'Shell', value: 'shell'},
  {label: 'SAS', value: 'sas'},
  {label: 'Solidity', value: 'solidity'},
  {label: 'Smalltalk', value: 'smalltalk'},
  {label: 'Scheme', value: 'scheme'},
  {label: 'Scratch', value: 'scratch'}
];
export default class PlaygroundScreen extends Component {
  render() {
    return (
      <View flex paddingT-s4>
        <Picker
          showSearch
          label="Select a language"
          items={options}
        />
      </View>
    );
  }
}
```

## Changelog
Picker - Fixes incorrect offset after search.

## Additional info
MADS-4601
