### PR TITLE
FloatingButton - Not pressable when wrapped with Keyboard.KeyboardTrackingView.

### DIFF
--- a/src/components/floatingButton/index.tsx
+++ b/src/components/floatingButton/index.tsx
@@ -211,7 +211,6 @@ class FloatingButton extends PureComponent<FloatingButtonProps> {
 
 const styles = StyleSheet.create({
   container: {
-    // ...StyleSheet.absoluteFillObject,
     top: undefined,
     zIndex: Constants.isAndroid ? 99 : undefined
   },

--- a/src/components/floatingButton/index.tsx
+++ b/src/components/floatingButton/index.tsx
@@ -211,7 +211,7 @@ class FloatingButton extends PureComponent<FloatingButtonProps> {
 
 const styles = StyleSheet.create({
   container: {
-    ...StyleSheet.absoluteFillObject,
+    // ...StyleSheet.absoluteFillObject,
     top: undefined,
     zIndex: Constants.isAndroid ? 99 : undefined
   },


### PR DESCRIPTION
## Description
When the `FloatingButton` is rendered inside the `Keyboard.KeyboardTrackingView` its not pressable. Removing the absoluteFillObject from the containing view style seems to solve this.
**ran it with a snapshot version in private. All test are passing but there is a chunk below the the button for some reason. Is also happens with a different component so its probably not related whats inside that view.**

<img src="https://github.com/user-attachments/assets/b0f82477-4608-4d9c-bfa9-6fa09a12c47d" width="250px"/>


## Changelog
FloatingButton - Fixed not pressable when wrapped with Keyboard.KeyboardTrackingView.

## Additional info
Snippet to reproduce:
```tsx
import React, {useRef} from 'react';
import {View, TextField, Button, Keyboard, FloatingButton} from 'react-native-ui-lib';

const PlaygroundScreen = () => {
  const textInput = useRef<any>(null);

  return (
    <View bg-grey80 flex>
      <TextField
        label="Enter Text"
        placeholder="Type here..."
        ref={textInput}
      />
      <Button label="Blur TextField" onPress={() => textInput.current?.blur()}/>
      <View bottom flex>
        <Keyboard.KeyboardTrackingView>
          <FloatingButton
            button={{
              label: 'Button'
            }}
            visible
          />
        </Keyboard.KeyboardTrackingView>
      </View>
    </View>
  );
};

export default PlaygroundScreen;

```
