### PR TITLE
Refactor HintDriver to allow optional style flattening in tests

### DIFF
--- a/src/components/hint/__tests__/index.spec.tsx
+++ b/src/components/hint/__tests__/index.spec.tsx
@@ -47,14 +47,14 @@ describe('Hint Screen component test', () => {
     const renderTree = render(<TestCase visible/>);
     const driver = HintDriver({renderTree, testID: HINT_TEST_ID});
     const hintBubble = await driver.getHintBubble();
-    expect(hintBubble.getStyle().backgroundColor).toBe(expectedColor);
+    expect(hintBubble.getStyle(true).backgroundColor).toBe(expectedColor);
   });
 
   it('Should color hint bubble with provided color prop', async () => {
     const renderTree = render(<TestCase visible color={Colors.white}/>);
     const driver = HintDriver({renderTree, testID: HINT_TEST_ID});
     const hintBubble = await driver.getHintBubble();
-    expect(hintBubble.getStyle().backgroundColor).toBe(Colors.white);
+    expect(hintBubble.getStyle(true).backgroundColor).toBe(Colors.white);
   });
 
   it('Should modal be not visible when hint is not visible', async () => {

--- a/src/components/view/View.driver.new.ts
+++ b/src/components/view/View.driver.new.ts
@@ -4,8 +4,9 @@ import {useComponentDriver, ComponentProps} from '../../testkit/new/Component.dr
 export const ViewDriver = (props: ComponentProps) => {
   const driver = useComponentDriver(props);
 
-  const getStyle = () => {
-    return StyleSheet.flatten(driver.getElement().props.style);
+  const getStyle = (flatten = false) => {
+    const style = driver.getElement().props.style;
+    return flatten ? StyleSheet.flatten(style) : style;
   };
   return {...driver, getStyle};
 };


### PR DESCRIPTION
## Description
Add support to flatten style in View driver, this helps with testing specific cases when styles are a complex, nested object

## Changelog
Support flatten style in View driver 

## Additional info
