### PR TITLE
Removed migrate prop usage

### DIFF
--- a/src/components/picker/helpers/usePickerMigrationWarnings.tsx
+++ b/src/components/picker/helpers/usePickerMigrationWarnings.tsx
@@ -3,10 +3,10 @@ import {LogService} from '../../../services';
 import {PickerProps} from '../types';
 
 // TODO: Remove this whole file when migration is completed
-type UsePickerMigrationWarnings = Pick<
-  PickerProps,
-  'children' | 'migrate' | 'getItemLabel' | 'getItemValue' | 'onShow'
->;
+type UsePickerMigrationWarnings = Pick<PickerProps, 'children' | 'getItemLabel' | 'getItemValue' | 'onShow'> & {
+  //TODO: after finish Picker props migration, migrate should be removed
+  migrate?: boolean;
+};
 
 const usePickerMigrationWarnings = (props: UsePickerMigrationWarnings) => {
   const {children, migrate, getItemLabel, getItemValue, onShow} = props;

--- a/src/components/picker/helpers/usePickerSelection.tsx
+++ b/src/components/picker/helpers/usePickerSelection.tsx
@@ -3,9 +3,11 @@ import _ from 'lodash';
 import {PickerProps, PickerValue, PickerSingleValue, PickerMultiValue, PickerModes} from '../types';
 
 interface UsePickerSelectionProps
-  extends Pick<PickerProps, 'migrate' | 'value' | 'onChange' | 'getItemValue' | 'topBarProps' | 'mode'> {
+  extends Pick<PickerProps, 'value' | 'onChange' | 'getItemValue' | 'topBarProps' | 'mode'> {
   pickerExpandableRef: RefObject<any>;
   setSearchValue: (searchValue: string) => void;
+  //TODO: after finish Picker props migration, migrate should be removed
+  migrate?: boolean;
 }
 
 const usePickerSelection = (props: UsePickerSelectionProps) => {

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -44,7 +44,7 @@ type PickerStatics = {
   extractPickerItems: typeof extractPickerItems;
 };
 
-const Picker = React.forwardRef((props: PickerProps, ref) => {
+const Picker = React.forwardRef((props: PickerProps & {migrate?: boolean}, ref) => {
   const themeProps = useThemeProps(props, 'Picker');
   const {
     mode = PickerModes.SINGLE,

--- a/src/components/picker/types.ts
+++ b/src/components/picker/types.ts
@@ -50,11 +50,6 @@ export interface PickerSearchStyle {
 type PickerPropsDeprecation = {
   /**
    * @deprecated
-   * Temporary prop required for migration to Picker's new API
-   */
-  migrate?: boolean;
-  /**
-   * @deprecated
    * A function that extract the unique value out of the value prop in case value has a custom structure (e.g. {myValue, myLabel})
    */
   getItemValue?: (value: PickerValue) => any;
@@ -304,11 +299,13 @@ export interface PickerItemProps extends Pick<TouchableOpacityProps, 'customValu
 }
 
 export interface PickerContextProps
-  extends Pick<PickerProps, 'migrate' | 'value' | 'getItemValue' | 'getItemLabel' | 'renderItem' | 'selectionLimit'> {
+  extends Pick<PickerProps, 'value' | 'getItemValue' | 'getItemLabel' | 'renderItem' | 'selectionLimit'> {
   onPress: (value: PickerSingleValue) => void;
   isMultiMode: boolean;
   onSelectedLayout: (event: any) => any;
   selectionLimit: PickerProps['selectionLimit'];
+  //TODO: after finish Picker props migration, migrate should be removed
+  migrate?: boolean;
 }
 
 export type PickerItemsListProps = Pick<


### PR DESCRIPTION
## Description
Picker `migrate` prop usage removed, deprecation.
This deprecated prop, which already set to `true` as inner component prop caused some TS erros.
the prop now is an internal Picker prop.

## Changelog
Picker `migrate` prop usage removed, deprecation.

## Additional info
Issue #3110 
