### PR TITLE
Picker - Larger hit target for accessibility

### DIFF
--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -274,6 +274,8 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
     showLoader
   ]);
 
+  const accessbileHitSlop = useMemo(() => ({top: 10, bottom: 10}), []);
+
   return (
     <PickerContext.Provider value={contextValue}>
       {
@@ -286,6 +288,7 @@ const Picker = React.forwardRef((props: PickerProps, ref) => {
           renderCustomOverlay={renderOverlay ? _renderOverlay : undefined}
           onPress={onPress}
           testID={testID}
+          hitSlop={fieldType !== PickerFieldTypes.form ? accessbileHitSlop : undefined}
           {...customPickerProps}
           disabled={themeProps.editable === false}
         >


### PR DESCRIPTION
## Description
When the Picker is in the regular form type, with the text field, the picker hit target is large enough to fix the 48x48 hit box. When the picker is in the other field types - settings and filter its smaller - no label on top so the hit target is small. I made the hit target a little larger when its in these special cases.
## Changelog
Picker - Larger hit target for settings and filter pickers

## Additional info
MADS-4591
