### PR TITLE
Reverted the deletion of the avatar tests

### DIFF
--- a/src/components/avatar/__tests__/index.spec.js
+++ b/src/components/avatar/__tests__/index.spec.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import {StyleSheet} from 'react-native';
+import {render} from '@testing-library/react-native';
+import {Avatar} from '../index';
+
+function verifyBadgeSize(renderTree, expectedSize) {
+  const badge = renderTree.getByTestId('avatar.onlineBadge');
+  const style = StyleSheet.flatten(badge.props.style);
+  expect(style.width).toEqual(expectedSize);
+  expect(style.height).toEqual(expectedSize);
+}
+
+describe('Avatar Badge', () => {
+  describe('badgeProps.size supports number', () => {
+    it('should return 99 as the size number given', () => {
+      const renderTree = render(<Avatar testID={'avatar'} badgeProps={{size: 99}}/>);
+      verifyBadgeSize(renderTree, 99);
+    });
+
+    it('should return default when passing 0 as size', () => {
+      const renderTree = render(<Avatar testID={'avatar'} badgeProps={{size: 0}}/>);
+      verifyBadgeSize(renderTree, 10);
+    });
+  });
+});


### PR DESCRIPTION
## Description
These tests were not supposed to be deleted in the avatar hit target change pr (https://github.com/wix/react-native-ui-lib/pull/3521)

## Changelog
N/A

## Additional info
N/A
