### PR TITLE
implement dismiss state management for closeExpandable control

### DIFF
--- a/src/components/picker/__tests__/index.spec.tsx
+++ b/src/components/picker/__tests__/index.spec.tsx
@@ -114,7 +114,7 @@ describe('Picker', () => {
         expect(driver.isOpen()).toBeTruthy();
         driver.cancel();
         expect(driver.isOpen()).toBeFalsy();
-        expect(onDismiss).toHaveBeenCalledTimes(2); // TODO: this should be 1
+        expect(onDismiss).toHaveBeenCalledTimes(1);
       });
 
       // TODO: this test is not passing yet


### PR DESCRIPTION
## Description
Picker when passing `onDismiss` from `customPickerProps` the `onDismiss` getting called twice.
Snippet:
```
 <Picker
        placeholder="Favorite Language"
        value={language}
        onChange={item => setLanguage(item)}
        items={options}
        customPickerProps={{
          modalProps: {
            onDismiss: () => console.log('dismissed')
          }
        }}
      />
```
This issue occurs both on Modal and Dialog.

Implemented a state machine pattern to track the component's dismiss state.

## Changelog
ExpandableOverlay - Implemented state machine pattern to prevent duplicate onDismiss calls

## Additional Info
MADS-4656