### PR TITLE
add customizable header button props and deprecate doneButtonColor

### DIFF
--- a/src/components/colorPicker/ColorPickerDialog.tsx
+++ b/src/components/colorPicker/ColorPickerDialog.tsx
@@ -9,7 +9,24 @@ import {getColorValue, getValidColorString, getTextColor, BORDER_RADIUS, HSLColo
 import ColorPickerDialogHeader from './ColorPickerDialogHeader';
 import ColorPickerPreview from './ColorPickerPreview';
 import ColorPickerDialogSliders from './ColorPickerDialogSliders';
+import {ButtonProps} from '../button';
 
+type ColorPickerHeaderButtonProps = {
+  /**
+   * Ok (v) button color
+   */
+  doneButtonColor?: string;
+  /**
+   * Done button props
+   */
+  doneButtonProps?: Pick<ButtonProps, 'iconSource' | 'iconStyle'>;
+  /**
+   * Dismiss button props
+   */
+  dismissButtonProps?: Pick<ButtonProps, 'iconSource' | 'iconStyle'>;
+};
+
+// TODO: deprecate doneButtonColor prop
 export interface ColorPickerDialogProps extends DialogProps {
   /**
    * The initial color to pass the picker dialog
@@ -30,15 +47,21 @@ export interface ColorPickerDialogProps extends DialogProps {
   /**
    * Accessibility labels as an object of strings, ex. {addButton: 'add custom color using hex code', dismissButton: 'dismiss', doneButton: 'done', input: 'custom hex color code'}
    */
-  /**
-   * Ok (v) button color
-   */
-  doneButtonColor?: string;
   accessibilityLabels?: {
     dismissButton?: string;
     doneButton?: string;
     input?: string;
   };
+  /**
+   * @deprecated
+   * Ok (v) button color
+   * Pass doneButtonColor via colorPickerHeaderProps
+   */
+  doneButtonColor?: string;
+  /**
+   * Color Picker header button props, done and dismiss button customize props
+   */
+  colorPickerHeaderProps?: ColorPickerHeaderButtonProps;
   /**
    * Whether to use the new Slider implementation using Reanimated
    */
@@ -64,7 +87,8 @@ const ColorPickerDialog = (props: ColorPickerDialogProps) => {
     accessibilityLabels,
     doneButtonColor,
     previewInputStyle,
-    migrate
+    migrate,
+    colorPickerHeaderProps
   } = props;
 
   const [keyboardHeight, setKeyboardHeight] = useState(KEYBOARD_HEIGHT);
@@ -172,6 +196,7 @@ const ColorPickerDialog = (props: ColorPickerDialogProps) => {
         testID={testID}
         doneButtonColor={doneButtonColor}
         onDismiss={onDismiss}
+        colorPickerHeaderProps={colorPickerHeaderProps}
       />
       <ColorPickerPreview
         color={color}

--- a/src/components/colorPicker/ColorPickerDialogHeader.tsx
+++ b/src/components/colorPicker/ColorPickerDialogHeader.tsx
@@ -9,14 +9,22 @@ import {Colors} from '../../style';
 import {ColorPickerDialogProps} from './ColorPickerDialog';
 import {BORDER_RADIUS} from './ColorPickerPresenter';
 
-type HeaderProps = Pick<ColorPickerDialogProps, 'doneButtonColor' | 'accessibilityLabels' | 'testID'> & {
+type HeaderProps = Pick<
+  ColorPickerDialogProps,
+  'doneButtonColor' | 'accessibilityLabels' | 'testID' | 'colorPickerHeaderProps'
+> & {
   valid: boolean;
   onDismiss: () => void;
   onDonePressed: () => void;
 };
 
 const ColorPickerDialogHeader = (props: HeaderProps) => {
-  const {onDismiss, accessibilityLabels, testID, doneButtonColor, valid, onDonePressed} = props;
+  const {onDismiss, accessibilityLabels, testID, doneButtonColor, valid, onDonePressed, colorPickerHeaderProps} = props;
+  const {
+    doneButtonProps,
+    dismissButtonProps,
+    doneButtonColor: doneButtonHeaderColorProp
+  } = colorPickerHeaderProps || {};
 
   return (
     <View row spread bg-$backgroundDefault paddingH-20 style={styles.header}>
@@ -27,15 +35,17 @@ const ColorPickerDialogHeader = (props: HeaderProps) => {
         onPress={onDismiss}
         accessibilityLabel={_.get(accessibilityLabels, 'dismissButton')}
         testID={`${testID}.dialog.cancel`}
+        {...dismissButtonProps}
       />
       <Button
-        color={doneButtonColor}
+        color={doneButtonColor || doneButtonHeaderColorProp}
         disabled={!valid}
         link
         iconSource={Assets.icons.check}
         onPress={onDonePressed}
         accessibilityLabel={_.get(accessibilityLabels, 'doneButton')}
         testID={`${testID}.dialog.done`}
+        {...doneButtonProps}
       />
     </View>
   );

--- a/src/components/colorSwatch/index.tsx
+++ b/src/components/colorSwatch/index.tsx
@@ -5,7 +5,7 @@ import {Colors} from '../../style';
 import {asBaseComponent, BaseComponentInjectedProps, Constants, ColorsModifiers} from '../../commons/new';
 import View from '../view';
 import TouchableOpacity from '../touchableOpacity';
-import Image from '../image';
+import Image, {ImageProps} from '../image';
 
 export interface ColorInfo {
   index?: number;
@@ -49,6 +49,10 @@ interface Props {
    * Color swatch size
    */
   size?: number;
+  /**
+   * Icon image source
+   */
+  selectedIconSource?: ImageProps['source'];
 }
 export type ColorSwatchProps = Props & ColorsModifiers;
 
@@ -160,7 +164,7 @@ class ColorSwatch extends PureComponent<Props & BaseComponentInjectedProps> {
   };
 
   renderContent() {
-    const {style, onPress, unavailable, size = DEFAULT_SIZE, ...others} = this.props;
+    const {style, onPress, unavailable, size = DEFAULT_SIZE, selectedIconSource, ...others} = this.props;
     const {isSelected} = this.state;
     const Container = onPress ? TouchableOpacity : View;
     const tintColor = this.getTintColor(this.color);
@@ -184,7 +188,7 @@ class ColorSwatch extends PureComponent<Props & BaseComponentInjectedProps> {
           <View style={[this.styles.unavailable, {backgroundColor: tintColor}]}/>
         ) : (
           <Animated.Image
-            source={Assets.icons.check}
+            source={selectedIconSource || Assets.icons.check}
             style={{
               tintColor,
               opacity: isSelected,


### PR DESCRIPTION
## Description
ColorPickerDialog new `colorPickerHeaderProps` prop to customize the header button icons.
`doneButtonColor` prop deprecation, moved into the `colorPickerHeaderProps`.
ColorSwatch new `selectedIcon` prop to customize the selected button.

## Changelog
ColorPickerDialog and ColorSwatch buttons and icons customize props.

## Additional info
MADS-4531