### PR TITLE
Button - undefined hitSlop overrides internal hitSlop

### DIFF
--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -368,7 +368,17 @@ class Button extends PureComponent<Props, ButtonState> {
   }
 
   render() {
-    const {onPress, disabled, style, testID, animateLayout, modifiers, forwardedRef, ...others} = this.props;
+    const {
+      onPress,
+      disabled,
+      style,
+      testID,
+      animateLayout,
+      modifiers,
+      forwardedRef,
+      hitSlop: hitSlopProp,
+      ...others
+    } = this.props;
     const shadowStyle = this.getShadowStyle();
     const {margins, paddings} = modifiers;
     const backgroundColor = this.getBackgroundColor();
@@ -399,7 +409,7 @@ class Button extends PureComponent<Props, ButtonState> {
         onPress={onPress}
         disabled={disabled}
         testID={testID}
-        hitSlop={this.getAccessibleHitSlop()}
+        hitSlop={hitSlopProp ?? this.getAccessibleHitSlop()}
         {...others}
         ref={forwardedRef}
       >


### PR DESCRIPTION
## Description
Fixed accessibleHitSlop overriding hitSlop when its passed with undefined.

## Changelog
N/A

## Additional info
MADS-4591