### PR TITLE
add uilib-native module to project source paths

### DIFF
--- a/webDemo/webpack.config.js
+++ b/webDemo/webpack.config.js
@@ -22,7 +22,8 @@ const baseProjectSource = [
   path.resolve(appDirectory, 'node_modules/react-native-color'),
   path.resolve(appDirectory, 'node_modules/react-native-ui-lib'),
   path.resolve(appDirectory, 'node_modules/postcss'),
-  path.resolve(appDirectory, 'node_modules/postcss-js')
+  path.resolve(appDirectory, 'node_modules/postcss-js'),
+  path.resolve(appDirectory, 'node_modules/uilib-native')
 ];
 
 const useBabelForRN = {


### PR DESCRIPTION
## Description
Add `uilib-native` module to project source paths.
Since we upgraded to RN 0.73 I find this error appears about the native component coming from `uilib-native`.
To reproduce the issue, run `npm install` in the webDemo folder and start the project.

## Changelog
None

## Additional info
None
