### PR TITLE
Assets add exports for web usage

### DIFF
--- a/demo/src/screens/__tests__/__snapshots__/AvatarScreen.spec.js.snap
+++ b/demo/src/screens/__tests__/__snapshots__/AvatarScreen.spec.js.snap
@@ -937,6 +937,7 @@ exports[`AvatarScreen renders screen 1`] = `
           }
           style={
             [
+              false,
               undefined,
               undefined,
               {
@@ -1194,6 +1195,7 @@ exports[`AvatarScreen renders screen 1`] = `
           }
           style={
             [
+              false,
               undefined,
               undefined,
               {
@@ -1465,6 +1467,7 @@ exports[`AvatarScreen renders screen 1`] = `
             }
             style={
               [
+                false,
                 undefined,
                 undefined,
                 {
@@ -1659,6 +1662,7 @@ exports[`AvatarScreen renders screen 1`] = `
           }
           style={
             [
+              false,
               undefined,
               undefined,
               {
@@ -1916,6 +1920,7 @@ exports[`AvatarScreen renders screen 1`] = `
           }
           style={
             [
+              false,
               undefined,
               undefined,
               {
@@ -2046,6 +2051,7 @@ exports[`AvatarScreen renders screen 1`] = `
               }
               style={
                 [
+                  false,
                   null,
                   undefined,
                   undefined,
@@ -2218,6 +2224,7 @@ exports[`AvatarScreen renders screen 1`] = `
           }
           style={
             [
+              false,
               undefined,
               undefined,
               {
@@ -2448,6 +2455,7 @@ exports[`AvatarScreen renders screen 1`] = `
           }
           style={
             [
+              false,
               undefined,
               undefined,
               {
@@ -2678,6 +2686,7 @@ exports[`AvatarScreen renders screen 1`] = `
           }
           style={
             [
+              false,
               undefined,
               undefined,
               {
@@ -2866,6 +2875,7 @@ exports[`AvatarScreen renders screen 1`] = `
           }
           style={
             [
+              false,
               undefined,
               undefined,
               {

--- a/src/assets/icons/index.web.js
+++ b/src/assets/icons/index.web.js
@@ -1,0 +1,27 @@
+console.log(`inside index.web.js`);
+export const icons = {
+  get check() {
+    return {uri: require('./check.png'), dimensions: {width: 24, height: 24}};
+  },
+  get checkSmall() {
+    return {uri: require('./check-small.png'), dimensions: {width: 24, height: 24}};
+  },
+  get minusSmall() {
+    return {uri: require('./minusSmall.png'), dimensions: {width: 24, height: 24}};
+  },
+  get plusSmall() {
+    return {uri: require('./plusSmall.png'), dimensions: {width: 24, height: 24}};
+  },
+  get search() {
+    return {uri: require('./search.png'), dimensions: {width: 24, height: 24}};
+  },
+  get x() {
+    return {uri: require('./x.png'), dimensions: {width: 24, height: 24}};
+  },
+  get xMedium() {
+    return {uri: require('./xMedium.png'), dimensions: {width: 24, height: 24}};
+  },
+  get xFlat() {
+    return {uri: require('./xFlat.png'), dimensions: {width: 24, height: 24}};
+  }
+};

--- a/src/assets/images/index.web.js
+++ b/src/assets/images/index.web.js
@@ -1,0 +1,5 @@
+export const images = {
+  get gradient() {
+    return {uri: require('./gradient.png'), dimensions: {width: 56, height: 2}};
+  }
+};

--- a/src/components/hint/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/components/hint/__tests__/__snapshots__/index.spec.tsx.snap
@@ -240,6 +240,7 @@ exports[`Hint Screen component test Different positions and scenarios center pos
         }
         style={
           [
+            false,
             {
               "tintColor": "#5A48F5",
             },
@@ -518,6 +519,7 @@ exports[`Hint Screen component test Different positions and scenarios center pos
         }
         style={
           [
+            false,
             {
               "tintColor": "#5A48F5",
             },
@@ -797,6 +799,7 @@ exports[`Hint Screen component test Different positions and scenarios left posit
         }
         style={
           [
+            false,
             {
               "tintColor": "#5A48F5",
             },
@@ -1075,6 +1078,7 @@ exports[`Hint Screen component test Different positions and scenarios left posit
         }
         style={
           [
+            false,
             {
               "tintColor": "#5A48F5",
             },
@@ -1354,6 +1358,7 @@ exports[`Hint Screen component test Different positions and scenarios right posi
         }
         style={
           [
+            false,
             {
               "tintColor": "#5A48F5",
             },
@@ -1632,6 +1637,7 @@ exports[`Hint Screen component test Different positions and scenarios right posi
         }
         style={
           [
+            false,
             {
               "tintColor": "#5A48F5",
             },

--- a/src/components/image/index.tsx
+++ b/src/components/image/index.tsx
@@ -244,6 +244,7 @@ class Image extends PureComponent<Props, State> {
       // @ts-ignore
       <ImageView
         style={[
+          Constants.isWeb && source?.dimensions,
           tintColor && {tintColor},
           shouldFlipRTL && styles.rtlFlipped,
           width && {width},


### PR DESCRIPTION
## Description
When using Image in web we need to pass the `width and height` style props.
Assets add exports for web usage that include the asset dimensions.
For now Iv'e add the same size to al the icons (24x24 which is the regular size).

```
TODO: Add explanation about using images on web
```

## Changelog
Assets support on web.

## Additional info
MADS-4531