### PR TITLE
Avatar animate mode not supported on web

### DIFF
--- a/src/components/avatar/avatar.api.json
+++ b/src/components/avatar/avatar.api.json
@@ -12,7 +12,7 @@
     {
       "name": "animate",
       "type": "boolean",
-      "description": "Adds fade in animation when Avatar image loads",
+      "description": "Adds fade in animation when Avatar image loads. This prop isn't supported on web (will be set to false by default when using web).",
       "default": "false"
     },
     {"name": "backgroundColor", "type": "string", "description": "Background color for Avatar"},

--- a/src/components/avatar/index.tsx
+++ b/src/components/avatar/index.tsx
@@ -21,6 +21,7 @@ import AnimatedImage, {AnimatedImageProps} from '../animatedImage';
 import * as AvatarHelper from '../../helpers/AvatarHelper';
 import {useThemeProps} from '../../hooks';
 import {isSvg} from '../../utils/imageUtils';
+import Constants from '../../commons/Constants';
 
 export enum BadgePosition {
   TOP_RIGHT = 'TOP_RIGHT',
@@ -287,7 +288,7 @@ const Avatar = forwardRef<any, AvatarProps>((props: AvatarProps, ref: React.Forw
   const renderImage = () => {
     if (source !== undefined) {
       // Looks like reanimated does not support SVG
-      const ImageContainer = animate && !isSvg(source) ? AnimatedImage : Image;
+      const ImageContainer = animate && !isSvg(source) && !Constants.isWeb ? AnimatedImage : Image;
       return (
         <ImageContainer
           style={_imageStyle}


### PR DESCRIPTION
## Description
AnimatedImage doesn't work on web platform.
When using animated Avatar we render AnimatedImage which doesn't work, for now when using web we will set animate to false to prevent Avatar not to render as expected.
snippet:
```
<Avatar source={src} animate /> 
```

## Changelog
Avatar with animated not supported on web.

## Additional info
MADS-4577
