### PR TITLE
Usage component support live preview for compatible components

### DIFF
--- a/docuilib/src/components/UILivePreview.tsx
+++ b/docuilib/src/components/UILivePreview.tsx
@@ -5,14 +5,20 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import {View, Colors} from 'react-native-ui-lib/core';
 import ReactLiveScope from '../theme/ReactLiveScope';
+import CodeBlock from '@theme/CodeBlock';
 
 export const IFRAME_MESSAGE_TYPE = 'LIVE_PREVIEW_CODE_UPDATE_MESSAGE';
 
-export default function UILivePreview({code: codeProp}) {
+export default function UILivePreview(props) {
+  const {code: codeProp, componentName, liveScopeSupport = false} = props;
   const [code, setCode] = useState(codeProp);
   const [iframeLoaded, setIframeLoaded] = useState(false);
   const {siteConfig} = useDocusaurusContext();
   const iframeRef = useRef(null);
+
+  const supportedComponentNames = Object.keys(ReactLiveScope);
+  const componentLivePlaygroundSupport =
+    liveScopeSupport || (componentName && supportedComponentNames.includes(componentName));
 
   useEffect(() => {
     if (iframeLoaded) {
@@ -28,6 +34,10 @@ export default function UILivePreview({code: codeProp}) {
   const liveEditorStyle = useMemo(() => {
     return {overflowY: 'scroll', scrollbarWidth: 'none'};
   }, []);
+
+  if (!componentLivePlaygroundSupport) {
+    return <CodeBlock language="jsx">{code}</CodeBlock>;
+  }
 
   return (
     <BrowserOnly>

--- a/docuilib/src/components/UILivePreview.tsx
+++ b/docuilib/src/components/UILivePreview.tsx
@@ -9,7 +9,7 @@ import CodeBlock from '@theme/CodeBlock';
 
 export const IFRAME_MESSAGE_TYPE = 'LIVE_PREVIEW_CODE_UPDATE_MESSAGE';
 
-export default function UILivePreview({code: codeProp, componentName, liveScopeSupport = false}) {
+export default function UILivePreview({code: codeProp, componentName = undefined, liveScopeSupport = false}) {
   const [code, setCode] = useState(codeProp);
   const [iframeLoaded, setIframeLoaded] = useState(false);
   const {siteConfig} = useDocusaurusContext();

--- a/docuilib/src/components/UILivePreview.tsx
+++ b/docuilib/src/components/UILivePreview.tsx
@@ -9,8 +9,7 @@ import CodeBlock from '@theme/CodeBlock';
 
 export const IFRAME_MESSAGE_TYPE = 'LIVE_PREVIEW_CODE_UPDATE_MESSAGE';
 
-export default function UILivePreview(props) {
-  const {code: codeProp, componentName, liveScopeSupport = false} = props;
+export default function UILivePreview({code: codeProp, componentName, liveScopeSupport = false}) {
   const [code, setCode] = useState(codeProp);
   const [iframeLoaded, setIframeLoaded] = useState(false);
   const {siteConfig} = useDocusaurusContext();

--- a/docuilib/src/components/pageComponents/Usage.tsx
+++ b/docuilib/src/components/pageComponents/Usage.tsx
@@ -6,11 +6,12 @@ import ReactLiveScope from '../../theme/ReactLiveScope';
 import UILivePreview from '../UILivePreview';
 
 export const Usage = ({component}) => {
-  const componentLivePlaygroundSupport = !!ReactLiveScope[component.name];
-  const code = component.snippet?.map(item => _.replace(item, new RegExp(/\$[1-9]/, 'g'), '')).join('\n');
+  const supportedComponentNames = Object.keys(ReactLiveScope);
+  const componentLivePlaygroundSupport = supportedComponentNames.includes(component.name);
   if (component.snippet) {
+    const code = component.snippet.map(item => _.replace(item, new RegExp(/\$[1-9]/, 'g'), '')).join('\n');
     return componentLivePlaygroundSupport ? (
-      <UILivePreview code={code}/>
+      <UILivePreview code={code} liveScopeSupport/>
     ) : (
       <CodeBlock language="jsx">{code}</CodeBlock>
     );

--- a/docuilib/src/components/pageComponents/Usage.tsx
+++ b/docuilib/src/components/pageComponents/Usage.tsx
@@ -2,15 +2,17 @@ import _ from 'lodash';
 import React from 'react';
 import CodeBlock from '@theme/CodeBlock';
 import '../ComponentPage.module.scss';
+import ReactLiveScope from '../../theme/ReactLiveScope';
+import UILivePreview from '../UILivePreview';
 
 export const Usage = ({component}) => {
+  const componentLivePlaygroundSupport = !!ReactLiveScope[component.name];
+  const code = component.snippet?.map(item => _.replace(item, new RegExp(/\$[1-9]/, 'g'), '')).join('\n');
   if (component.snippet) {
-    return (
-      <div>
-        <CodeBlock language="jsx">
-          {component.snippet?.map(item => _.replace(item, new RegExp(/\$[1-9]/, 'g'), '')).join('\n')}
-        </CodeBlock>
-      </div>
+    return componentLivePlaygroundSupport ? (
+      <UILivePreview code={code}/>
+    ) : (
+      <CodeBlock language="jsx">{code}</CodeBlock>
     );
   }
 };

--- a/scripts/docs/buildDocsCommon.js
+++ b/scripts/docs/buildDocsCommon.js
@@ -184,7 +184,7 @@ function buildOldDocs(component) {
   /* Snippet */
   if (component.snippet) {
     content += `### Usage\n`;
-    content += `<UILivePreview code={\`${component.snippet
+    content += `<UILivePreview componentName={"${component.name}"} code={\`${component.snippet
       ?.map(item => _.replace(item, new RegExp(/\$[1-9]/, 'g'), ''))
       .join('\n')
       .toString()}\`}/>\n\n`;


### PR DESCRIPTION
## Description
Docs - `Usage` section, should show live playground or code block.
If the component is part of the `ReactLiveScope` we should show live playground else code block.[
Old PR](https://github.com/wix/react-native-ui-lib/pull/3452) - closed because of the `api` files.

## Changelog
Docs - `Usage` section, should show live playground or code block.

## Additional info
None
