### PR TITLE
Update iframe src in ContentItem to include page-selector parameter

### DIFF
--- a/docuilib/src/components/pageComponents/ContentItem.tsx
+++ b/docuilib/src/components/pageComponents/ContentItem.tsx
@@ -86,8 +86,8 @@ export const ContentItem = ({item, componentName, showCodeButton}: ContentItemPr
   const getFigmaEmbed = item => {
     const value = item.value;
     const height = item.height || 450;
-
-    return <iframe width={'100%'} height={height} src={value}/>;
+    const modifiedValue = !value.includes('page-selector=') ? value + '&page-selector=false' : value;
+    return <iframe width={'100%'} height={height} src={modifiedValue}/>;
   };
 
   const getImage = (value, style = undefined) => {


### PR DESCRIPTION
## Description
When using Figma embed link we should add `page-selector=false` to hide the page selector on our docs.
`modifiedValue` takes care of that, when the embed link doesn't include `page-selector`.

## Changelog
ContentItem - Figma embed hide page selector.

## Additional info
None