### PR TITLE
Fix not showing dev tab when props is an empty array

### DIFF
--- a/docuilib/package.json
+++ b/docuilib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uilib-docs",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "main": "./src/index.ts",
   "scripts": {
     "docusaurus": "docusaurus",

--- a/docuilib/src/components/ComponentPage.tsx
+++ b/docuilib/src/components/ComponentPage.tsx
@@ -61,7 +61,7 @@ export default function ComponentPage({component}) {
   const buildTabs = () => {
     const tabs = component.docs?.tabs;
     const api = component.props;
-    const tabsArray = api ? [...tabs, devTab] : tabs;
+    const tabsArray = !_.isEmpty(api) ? [...tabs, devTab] : tabs;
     
     // TODO: align Tabs bottom border with TabItem's selected indication line
     if (tabs) {


### PR DESCRIPTION
## Description
Fix not showing dev tab when props is an empty array

## Changelog
NA

## Additional info
