### PR TITLE
Docs - Fix development main entry

### DIFF
--- a/docuilib/docusaurus.config.js
+++ b/docuilib/docusaurus.config.js
@@ -18,7 +18,7 @@ const darkCodeTheme = themes.dracula;
     trailingSlash: false,
     customFields: {
       docsMainEntry: 'getting-started/setup',
-      docsDevelopmentMainEntry: 'next/getting-started/setup',
+      docsDevelopmentVersion: 'next',
       expoSnackLink: 'https://snack.expo.io/@ethanshar/rnuilib_snack',
       stars: '4.7'
     },

--- a/docuilib/docusaurus.config.js
+++ b/docuilib/docusaurus.config.js
@@ -18,6 +18,7 @@ const darkCodeTheme = themes.dracula;
     trailingSlash: false,
     customFields: {
       docsMainEntry: 'getting-started/setup',
+      docsDevelopmentMainEntry: 'next/getting-started/setup',
       expoSnackLink: 'https://snack.expo.io/@ethanshar/rnuilib_snack',
       stars: '4.7'
     },

--- a/docuilib/package.json
+++ b/docuilib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uilib-docs",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "main": "./src/index.ts",
   "scripts": {
     "docusaurus": "docusaurus",

--- a/docuilib/src/components/MainSection.tsx
+++ b/docuilib/src/components/MainSection.tsx
@@ -10,7 +10,7 @@ const STARS_COUNT_KEY = 'starsCount';
 
 export default () => {
   const {siteConfig} = useDocusaurusContext();
-  const {expoSnackLink, docsMainEntry, docsDevelopmentMainEntry} = siteConfig.customFields;
+  const {expoSnackLink, docsMainEntry, docsDevelopmentVersion} = siteConfig.customFields;
   const [starsCount, setStarsCount] = useState(localStorage.getItem(STARS_COUNT_KEY) ?? siteConfig.customFields.stars);
 
   useEffect(() => {
@@ -40,7 +40,7 @@ export default () => {
         </div>
 
         <div className={styles.buttons}>
-          <Link to={`/docs/${location.hostname === 'localhost' ? docsDevelopmentMainEntry : docsMainEntry}`}>
+          <Link to={`/docs/${location.hostname === 'localhost' ? `${docsDevelopmentVersion}/` : ''}${docsMainEntry}`}>
             <button className={'button dark'}>View Docs</button>
           </Link>
 

--- a/docuilib/src/components/MainSection.tsx
+++ b/docuilib/src/components/MainSection.tsx
@@ -40,7 +40,7 @@ export default () => {
         </div>
 
         <div className={styles.buttons}>
-          <Link to={`/docs/${location.hostname.startsWith('localhost') ? docsDevelopmentMainEntry : docsMainEntry}`}>
+          <Link to={`/docs/${location.hostname === 'localhost' ? docsDevelopmentMainEntry : docsMainEntry}`}>
             <button className={'button dark'}>View Docs</button>
           </Link>
 

--- a/docuilib/src/components/MainSection.tsx
+++ b/docuilib/src/components/MainSection.tsx
@@ -10,7 +10,7 @@ const STARS_COUNT_KEY = 'starsCount';
 
 export default () => {
   const {siteConfig} = useDocusaurusContext();
-  const {expoSnackLink, docsMainEntry} = siteConfig.customFields;
+  const {expoSnackLink, docsMainEntry, docsDevelopmentMainEntry} = siteConfig.customFields;
   const [starsCount, setStarsCount] = useState(localStorage.getItem(STARS_COUNT_KEY) ?? siteConfig.customFields.stars);
 
   useEffect(() => {
@@ -40,7 +40,7 @@ export default () => {
         </div>
 
         <div className={styles.buttons}>
-          <Link to={`docs/${location.hostname === 'localhost' ? 'next/' : ''}${docsMainEntry}`}>
+          <Link to={`/docs/${location.hostname.startsWith('localhost') ? docsDevelopmentMainEntry : docsMainEntry}`}>
             <button className={'button dark'}>View Docs</button>
           </Link>
 


### PR DESCRIPTION
## Description
Fixed view docs button going to `next` version of docs when in localhost. This was breaking private docs because we don't use next in it.

## Changelog
N/A

## Additional info
N/A