### PR TITLE
Add internal assets type export to index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 /* ===== General Stuff ===== */
 export {default as Assets} from './assets';
 export type {emojis as EmojisAssetsType} from './assets/emojis';
+export type {internal as InternalAssetsType} from './assets/internal';
 export * from './style';
 export * from './services';
 export * from 'uilib-native';


### PR DESCRIPTION
## Description
In addition to the new Assets `internal` path, we need to export his type.
[Related PR](https://github.com/wix/react-native-ui-lib/pull/3618)

## Changelog
None

## Additional info
None
