### PR TITLE
useScrollTo - Fix Android RTL issue with post rn73

### DIFF
--- a/src/hooks/useScrollTo/index.ts
+++ b/src/hooks/useScrollTo/index.ts
@@ -62,16 +62,16 @@ const useScrollTo = <T extends ScrollToSupportedViews>(props: ScrollToProps<T>):
   [horizontal]);
 
   const scrollTo = useCallback((offset: number, animated = true) => {
-    if (
-      horizontal &&
-        Constants.isRTL &&
-        Constants.isAndroid &&
-        !_.isUndefined(contentSize.current) &&
-        !_.isUndefined(containerSize.current)
-    ) {
-      const scrollingWidth = Math.max(0, contentSize.current - containerSize.current);
-      offset = scrollingWidth - offset;
-    }
+    // if (
+    //   horizontal &&
+    //     Constants.isRTL &&
+    //     Constants.isAndroid &&
+    //     !_.isUndefined(contentSize.current) &&
+    //     !_.isUndefined(containerSize.current)
+    // ) {
+    //   const scrollingWidth = Math.max(0, contentSize.current - containerSize.current);
+    //   offset = scrollingWidth - offset;
+    // }
 
     // @ts-ignore
     if (_.isFunction(scrollViewRef.current?.scrollToOffset)) {


### PR DESCRIPTION
## Description
Fix offset calculation on android RTL. The offset was flipped because the scroll offset was flipped until rn73. Its now aligned with the ios offset.

## Changelog
useScrollTo - Fixed Android RTL flipped offset caculcation.

## Additional info
MADS-4674