### PR TITLE
fix/image-typed-as-any

### DIFF
--- a/src/components/image/index.tsx
+++ b/src/components/image/index.tsx
@@ -17,13 +17,13 @@ import {
   BaseComponentInjectedProps,
   MarginModifiers
 } from '../../commons/new';
+import {ComponentStatics} from '../../typings/common';
 import {RecorderProps} from '../../typings/recorderTypes';
 import {getAsset, isSvg} from '../../utils/imageUtils';
 import Overlay, {OverlayTypeType, OverlayIntensityType} from '../overlay';
 import SvgImage from '../svgImage';
 import View from '../view';
 import {Colors} from '../../style';
-import {ComponentStatics} from 'src/typings/common';
 
 export type ImageSourceType = string | RNImageProps['source'];
 


### PR DESCRIPTION
## Description
Change the import for ComponentStatics in `src/components/image/index.tsx` from absolute, to relative import

## Changelog
Make the image component have type annotations again instead of any

## Additional info
Close issue #3655 