### PR TITLE
Revert - set default icon size for web platform

### DIFF
--- a/demo/src/screens/__tests__/__snapshots__/TextFieldScreen.spec.js.snap
+++ b/demo/src/screens/__tests__/__snapshots__/TextFieldScreen.spec.js.snap
@@ -3294,10 +3294,6 @@ exports[`TextField Screen renders screen 1`] = `
                 }
                 style={
                   [
-                    {
-                      "height": undefined,
-                      "width": undefined,
-                    },
                     undefined,
                     {
                       "height": 16,
@@ -3942,10 +3938,6 @@ exports[`TextField Screen renders screen 1`] = `
                 }
                 style={
                   [
-                    {
-                      "height": undefined,
-                      "width": undefined,
-                    },
                     undefined,
                     undefined,
                     undefined,
@@ -3974,10 +3966,6 @@ exports[`TextField Screen renders screen 1`] = `
             }
             style={
               [
-                {
-                  "height": undefined,
-                  "width": undefined,
-                },
                 undefined,
                 undefined,
                 undefined,
@@ -4674,10 +4662,6 @@ exports[`TextField Screen renders screen 1`] = `
               }
               style={
                 [
-                  {
-                    "height": undefined,
-                    "width": undefined,
-                  },
                   undefined,
                   undefined,
                   undefined,
@@ -6871,10 +6855,6 @@ exports[`TextField Screen renders screen 1`] = `
               style={
                 [
                   {
-                    "height": undefined,
-                    "width": undefined,
-                  },
-                  {
                     "marginLeft": 4,
                   },
                   {
@@ -7807,10 +7787,6 @@ exports[`TextField Screen renders screen 1`] = `
               }
               style={
                 [
-                  {
-                    "height": undefined,
-                    "width": undefined,
-                  },
                   undefined,
                   undefined,
                   undefined,

--- a/demo/src/screens/__tests__/__snapshots__/TextFieldScreen.spec.js.snap
+++ b/demo/src/screens/__tests__/__snapshots__/TextFieldScreen.spec.js.snap
@@ -3295,6 +3295,7 @@ exports[`TextField Screen renders screen 1`] = `
                 style={
                   [
                     undefined,
+                    undefined,
                     {
                       "height": 16,
                       "width": 16,
@@ -3941,6 +3942,7 @@ exports[`TextField Screen renders screen 1`] = `
                     undefined,
                     undefined,
                     undefined,
+                    undefined,
                     {
                       "tintColor": "#5A48F5",
                     },
@@ -3966,6 +3968,7 @@ exports[`TextField Screen renders screen 1`] = `
             }
             style={
               [
+                undefined,
                 undefined,
                 undefined,
                 undefined,
@@ -4662,6 +4665,7 @@ exports[`TextField Screen renders screen 1`] = `
               }
               style={
                 [
+                  undefined,
                   undefined,
                   undefined,
                   undefined,
@@ -6857,6 +6861,7 @@ exports[`TextField Screen renders screen 1`] = `
                   {
                     "marginLeft": 4,
                   },
+                  undefined,
                   {
                     "height": 16,
                     "width": 16,
@@ -7787,6 +7792,7 @@ exports[`TextField Screen renders screen 1`] = `
               }
               style={
                 [
+                  undefined,
                   undefined,
                   undefined,
                   undefined,

--- a/demo/src/screens/__tests__/__snapshots__/TextFieldScreen.spec.js.snap
+++ b/demo/src/screens/__tests__/__snapshots__/TextFieldScreen.spec.js.snap
@@ -3294,6 +3294,10 @@ exports[`TextField Screen renders screen 1`] = `
                 }
                 style={
                   [
+                    {
+                      "height": undefined,
+                      "width": undefined,
+                    },
                     undefined,
                     {
                       "height": 16,
@@ -3938,6 +3942,10 @@ exports[`TextField Screen renders screen 1`] = `
                 }
                 style={
                   [
+                    {
+                      "height": undefined,
+                      "width": undefined,
+                    },
                     undefined,
                     undefined,
                     undefined,
@@ -3966,6 +3974,10 @@ exports[`TextField Screen renders screen 1`] = `
             }
             style={
               [
+                {
+                  "height": undefined,
+                  "width": undefined,
+                },
                 undefined,
                 undefined,
                 undefined,
@@ -4662,6 +4674,10 @@ exports[`TextField Screen renders screen 1`] = `
               }
               style={
                 [
+                  {
+                    "height": undefined,
+                    "width": undefined,
+                  },
                   undefined,
                   undefined,
                   undefined,
@@ -6855,6 +6871,10 @@ exports[`TextField Screen renders screen 1`] = `
               style={
                 [
                   {
+                    "height": undefined,
+                    "width": undefined,
+                  },
+                  {
                     "marginLeft": 4,
                   },
                   {
@@ -7787,6 +7807,10 @@ exports[`TextField Screen renders screen 1`] = `
               }
               style={
                 [
+                  {
+                    "height": undefined,
+                    "width": undefined,
+                  },
                   undefined,
                   undefined,
                   undefined,

--- a/src/components/button/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/button/__tests__/__snapshots__/index.spec.js.snap
@@ -1228,6 +1228,10 @@ exports[`Button container size should have no padding of button is an icon butto
     source={14}
     style={
       [
+        {
+          "height": undefined,
+          "width": undefined,
+        },
         undefined,
         undefined,
         undefined,
@@ -2449,6 +2453,10 @@ exports[`Button icon should apply color on icon 1`] = `
     source={12}
     style={
       [
+        {
+          "height": undefined,
+          "width": undefined,
+        },
         undefined,
         undefined,
         undefined,
@@ -2525,6 +2533,10 @@ exports[`Button icon should apply color on icon 2`] = `
     source={12}
     style={
       [
+        {
+          "height": undefined,
+          "width": undefined,
+        },
         undefined,
         undefined,
         undefined,
@@ -2601,6 +2613,10 @@ exports[`Button icon should apply the right icon color 1`] = `
     source={12}
     style={
       [
+        {
+          "height": undefined,
+          "width": undefined,
+        },
         undefined,
         undefined,
         undefined,
@@ -2677,6 +2693,10 @@ exports[`Button icon should apply the right icon color 2`] = `
     source={12}
     style={
       [
+        {
+          "height": undefined,
+          "width": undefined,
+        },
         undefined,
         undefined,
         undefined,
@@ -2755,6 +2775,10 @@ exports[`Button icon should apply the right icon color 3`] = `
     source={12}
     style={
       [
+        {
+          "height": undefined,
+          "width": undefined,
+        },
         undefined,
         undefined,
         undefined,
@@ -2833,6 +2857,10 @@ exports[`Button icon should include custom iconStyle provided as a prop 1`] = `
     source={12}
     style={
       [
+        {
+          "height": undefined,
+          "width": undefined,
+        },
         undefined,
         undefined,
         undefined,
@@ -2914,6 +2942,10 @@ exports[`Button icon should return icon style according to different variations 
     source={12}
     style={
       [
+        {
+          "height": undefined,
+          "width": undefined,
+        },
         undefined,
         undefined,
         undefined,
@@ -2990,6 +3022,10 @@ exports[`Button icon should return icon style according to different variations 
     source={12}
     style={
       [
+        {
+          "height": undefined,
+          "width": undefined,
+        },
         undefined,
         undefined,
         undefined,
@@ -3066,6 +3102,10 @@ exports[`Button icon should return icon style according to different variations 
     source={12}
     style={
       [
+        {
+          "height": undefined,
+          "width": undefined,
+        },
         undefined,
         undefined,
         undefined,
@@ -4420,6 +4460,10 @@ exports[`Button labelColor should return undefined color if this is an icon butt
     source={12}
     style={
       [
+        {
+          "height": undefined,
+          "width": undefined,
+        },
         undefined,
         undefined,
         undefined,

--- a/src/components/button/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/button/__tests__/__snapshots__/index.spec.js.snap
@@ -1228,10 +1228,6 @@ exports[`Button container size should have no padding of button is an icon butto
     source={14}
     style={
       [
-        {
-          "height": undefined,
-          "width": undefined,
-        },
         undefined,
         undefined,
         undefined,
@@ -2453,10 +2449,6 @@ exports[`Button icon should apply color on icon 1`] = `
     source={12}
     style={
       [
-        {
-          "height": undefined,
-          "width": undefined,
-        },
         undefined,
         undefined,
         undefined,
@@ -2533,10 +2525,6 @@ exports[`Button icon should apply color on icon 2`] = `
     source={12}
     style={
       [
-        {
-          "height": undefined,
-          "width": undefined,
-        },
         undefined,
         undefined,
         undefined,
@@ -2613,10 +2601,6 @@ exports[`Button icon should apply the right icon color 1`] = `
     source={12}
     style={
       [
-        {
-          "height": undefined,
-          "width": undefined,
-        },
         undefined,
         undefined,
         undefined,
@@ -2693,10 +2677,6 @@ exports[`Button icon should apply the right icon color 2`] = `
     source={12}
     style={
       [
-        {
-          "height": undefined,
-          "width": undefined,
-        },
         undefined,
         undefined,
         undefined,
@@ -2775,10 +2755,6 @@ exports[`Button icon should apply the right icon color 3`] = `
     source={12}
     style={
       [
-        {
-          "height": undefined,
-          "width": undefined,
-        },
         undefined,
         undefined,
         undefined,
@@ -2857,10 +2833,6 @@ exports[`Button icon should include custom iconStyle provided as a prop 1`] = `
     source={12}
     style={
       [
-        {
-          "height": undefined,
-          "width": undefined,
-        },
         undefined,
         undefined,
         undefined,
@@ -2942,10 +2914,6 @@ exports[`Button icon should return icon style according to different variations 
     source={12}
     style={
       [
-        {
-          "height": undefined,
-          "width": undefined,
-        },
         undefined,
         undefined,
         undefined,
@@ -3022,10 +2990,6 @@ exports[`Button icon should return icon style according to different variations 
     source={12}
     style={
       [
-        {
-          "height": undefined,
-          "width": undefined,
-        },
         undefined,
         undefined,
         undefined,
@@ -3102,10 +3066,6 @@ exports[`Button icon should return icon style according to different variations 
     source={12}
     style={
       [
-        {
-          "height": undefined,
-          "width": undefined,
-        },
         undefined,
         undefined,
         undefined,
@@ -4460,10 +4420,6 @@ exports[`Button labelColor should return undefined color if this is an icon butt
     source={12}
     style={
       [
-        {
-          "height": undefined,
-          "width": undefined,
-        },
         undefined,
         undefined,
         undefined,

--- a/src/components/button/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/button/__tests__/__snapshots__/index.spec.js.snap
@@ -1231,6 +1231,7 @@ exports[`Button container size should have no padding of button is an icon butto
         undefined,
         undefined,
         undefined,
+        undefined,
         {
           "tintColor": "#FFFFFF",
         },
@@ -2452,6 +2453,7 @@ exports[`Button icon should apply color on icon 1`] = `
         undefined,
         undefined,
         undefined,
+        undefined,
         {
           "tintColor": "green",
         },
@@ -2525,6 +2527,7 @@ exports[`Button icon should apply color on icon 2`] = `
     source={12}
     style={
       [
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -2604,6 +2607,7 @@ exports[`Button icon should apply the right icon color 1`] = `
         undefined,
         undefined,
         undefined,
+        undefined,
         {
           "tintColor": "red",
         },
@@ -2677,6 +2681,7 @@ exports[`Button icon should apply the right icon color 2`] = `
     source={12}
     style={
       [
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -2758,6 +2763,7 @@ exports[`Button icon should apply the right icon color 3`] = `
         undefined,
         undefined,
         undefined,
+        undefined,
         {
           "tintColor": "red",
         },
@@ -2833,6 +2839,7 @@ exports[`Button icon should include custom iconStyle provided as a prop 1`] = `
     source={12}
     style={
       [
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -2917,6 +2924,7 @@ exports[`Button icon should return icon style according to different variations 
         undefined,
         undefined,
         undefined,
+        undefined,
         {
           "tintColor": "#5A48F5",
         },
@@ -2993,6 +3001,7 @@ exports[`Button icon should return icon style according to different variations 
         undefined,
         undefined,
         undefined,
+        undefined,
         {
           "tintColor": "#5A48F5",
         },
@@ -3066,6 +3075,7 @@ exports[`Button icon should return icon style according to different variations 
     source={12}
     style={
       [
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -4420,6 +4430,7 @@ exports[`Button labelColor should return undefined color if this is an icon butt
     source={12}
     style={
       [
+        undefined,
         undefined,
         undefined,
         undefined,

--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -47,9 +47,11 @@ export type IconProps = Omit<RNImageProps, 'source' | 'tintColor'> &
 
 type Props = IconProps & BaseComponentInjectedProps;
 
+const DEFAULT_WEB_ICON_SIZE = 16;
+
 const Icon = forwardRef((props: Props, ref: any) => {
   const {
-    size,
+    size = Constants.isWeb ? DEFAULT_WEB_ICON_SIZE : undefined,
     tintColor,
     style,
     supportRTL,

--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -47,11 +47,9 @@ export type IconProps = Omit<RNImageProps, 'source' | 'tintColor'> &
 
 type Props = IconProps & BaseComponentInjectedProps;
 
-const DEFAULT_WEB_ICON_SIZE = 16;
-
 const Icon = forwardRef((props: Props, ref: any) => {
   const {
-    size = Constants.isWeb ? DEFAULT_WEB_ICON_SIZE : undefined,
+    size,
     tintColor,
     style,
     supportRTL,
@@ -87,6 +85,8 @@ const Icon = forwardRef((props: Props, ref: any) => {
   }, [source, assetGroup, assetName]);
 
   const renderImage = () => {
+    const {width, height} = others || {};
+    const remoteSize = Constants.isWeb && (width || height) ? {width, height} : undefined;
     return (
       <Image
         accessible={false}
@@ -95,7 +95,7 @@ const Icon = forwardRef((props: Props, ref: any) => {
         {...others}
         ref={ref}
         source={iconSource}
-        style={[margins, iconSize, shouldFlipRTL && styles.rtlFlipped, !!tintColor && {tintColor}, style]}
+        style={[margins, remoteSize, iconSize, shouldFlipRTL && styles.rtlFlipped, !!tintColor && {tintColor}, style]}
       />
     );
   };

--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -47,9 +47,11 @@ export type IconProps = Omit<RNImageProps, 'source' | 'tintColor'> &
 
 type Props = IconProps & BaseComponentInjectedProps;
 
+const DEFAULT_WEB_ICON_SIZE = 16;
+
 const Icon = forwardRef((props: Props, ref: any) => {
   const {
-    size,
+    size = Constants.isWeb ? DEFAULT_WEB_ICON_SIZE : undefined,
     tintColor,
     style,
     supportRTL,
@@ -85,7 +87,6 @@ const Icon = forwardRef((props: Props, ref: any) => {
   }, [source, assetGroup, assetName]);
 
   const renderImage = () => {
-    const {width, height} = others;
     return (
       <Image
         accessible={false}
@@ -94,14 +95,7 @@ const Icon = forwardRef((props: Props, ref: any) => {
         {...others}
         ref={ref}
         source={iconSource}
-        style={[
-          {width, height},
-          margins,
-          iconSize,
-          shouldFlipRTL && styles.rtlFlipped,
-          !!tintColor && {tintColor},
-          style
-        ]}
+        style={[margins, iconSize, shouldFlipRTL && styles.rtlFlipped, !!tintColor && {tintColor}, style]}
       />
     );
   };

--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -47,11 +47,9 @@ export type IconProps = Omit<RNImageProps, 'source' | 'tintColor'> &
 
 type Props = IconProps & BaseComponentInjectedProps;
 
-const DEFAULT_WEB_ICON_SIZE = 16;
-
 const Icon = forwardRef((props: Props, ref: any) => {
   const {
-    size = Constants.isWeb ? DEFAULT_WEB_ICON_SIZE : undefined,
+    size,
     tintColor,
     style,
     supportRTL,
@@ -87,6 +85,7 @@ const Icon = forwardRef((props: Props, ref: any) => {
   }, [source, assetGroup, assetName]);
 
   const renderImage = () => {
+    const {width, height} = others;
     return (
       <Image
         accessible={false}
@@ -95,7 +94,14 @@ const Icon = forwardRef((props: Props, ref: any) => {
         {...others}
         ref={ref}
         source={iconSource}
-        style={[margins, iconSize, shouldFlipRTL && styles.rtlFlipped, !!tintColor && {tintColor}, style]}
+        style={[
+          {width, height},
+          margins,
+          iconSize,
+          shouldFlipRTL && styles.rtlFlipped,
+          !!tintColor && {tintColor},
+          style
+        ]}
       />
     );
   };


### PR DESCRIPTION
## Description
As part of the `Assets` structure we did, we removed the default size for Web in Icon.
This fix set the `width and height` if it's passed to the component instead of default size.

## Changelog
Fix Icon set width and height for web source if passed.

## Additional info
None
