### PR TITLE
Refactor Button component to determine filled state by background color

### DIFF
--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -72,7 +72,7 @@ class Button extends PureComponent<Props, ButtonState> {
   }
 
   get isFilled() {
-    return !this.isOutline && !this.isLink;
+    return this.getBackgroundColor() !== 'transparent';
   }
 
   get isIconButton() {


### PR DESCRIPTION
## Description
Refactor Button component to determine filled state by background color instead of checking `outline` and `link` props.
This is fixing an issue when button has `backgroundColor` and `icon` in disabled mode, the Icon should be in the same color of the label if there is a background.

## Changelog
Refactor Button component to determine filled state by background color

## Additional info
None
