### PR TITLE
Button component - return background color when not outlined

### DIFF
--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -86,6 +86,9 @@ class Button extends PureComponent<Props, ButtonState> {
 
       return backgroundColor || modifiersBackgroundColor || Colors.$backgroundPrimaryHeavy;
     }
+    if (!outline && backgroundColor) {
+      return backgroundColor;
+    }
     return 'transparent';
   }
 


### PR DESCRIPTION
## Description
Button `backgroundColor` is stronger then `transparent` event when button is `outline`.

## Changelog
Button `backgroundColor` is stronger then `transparent` event when button is `outline`.

## Additional info
MADS-4506
