### PR TITLE
getRelativeContentColor logic in Colors

### DIFF
--- a/src/components/card/index.tsx
+++ b/src/components/card/index.tsx
@@ -215,6 +215,7 @@ class Card extends PureComponent<PropTypes, State> {
     const {selectionOptions = {}, selected} = this.props;
     const {animatedSelected} = this.state;
     const selectionColor = selectionOptions?.color || DEFAULT_SELECTION_PROPS.color;
+    const backgroundColor = selectionColor || this.styles.selectedIndicator.backgroundColor;
 
     if (_.isUndefined(selected)) {
       return null;
@@ -231,10 +232,14 @@ class Card extends PureComponent<PropTypes, State> {
         pointerEvents="none"
       >
         {!selectionOptions.hideIndicator && (
-          <View style={[this.styles.selectedIndicator, {backgroundColor: selectionColor}]}>
+          <View style={[this.styles.selectedIndicator, {backgroundColor}]}>
             <Icon
               source={selectionOptions?.icon || DEFAULT_SELECTION_PROPS.icon}
-              tintColor={selectionOptions?.iconColor || DEFAULT_SELECTION_PROPS.iconColor}
+              tintColor={
+                selectionOptions?.iconColor ||
+                Colors.getRelativeContentColor(selectionColor) ||
+                DEFAULT_SELECTION_PROPS.iconColor
+              }
             />
           </View>
         )}

--- a/src/components/checkbox/index.tsx
+++ b/src/components/checkbox/index.tsx
@@ -318,12 +318,8 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
 }
 
 function createStyles(props: CheckboxProps) {
-  const {
-    color = DEFAULT_COLOR,
-    iconColor = DEFAULT_ICON_COLOR,
-    size = DEFAULT_SIZE,
-    borderRadius = DEFAULT_BORDER_RADIUS
-  } = props;
+  const {color = DEFAULT_COLOR, iconColor, size = DEFAULT_SIZE, borderRadius = DEFAULT_BORDER_RADIUS} = props;
+  const _iconColor = iconColor || Colors.getRelativeContentColor(color) || DEFAULT_ICON_COLOR;
 
   return StyleSheet.create({
     container: {
@@ -335,7 +331,7 @@ function createStyles(props: CheckboxProps) {
       borderColor: color
     },
     selectedIcon: {
-      tintColor: iconColor,
+      tintColor: _iconColor,
       alignItems: 'center',
       justifyContent: 'center'
     },

--- a/src/components/drawer/index.tsx
+++ b/src/components/drawer/index.tsx
@@ -133,7 +133,6 @@ class Drawer extends PureComponent<DrawerProps> {
   static displayName = 'Drawer';
 
   static defaultProps = {
-    itemsTintColor: Colors.white,
     itemsIconSize: 24
   };
 
@@ -308,6 +307,7 @@ class Drawer extends PureComponent<DrawerProps> {
 
   private renderAction = ({item, index, progress, itemsCount}: any) => {
     const {itemsTintColor, itemsIconSize, itemsTextStyle, itemsMinWidth} = this.props;
+    const iconColor = itemsTintColor || Colors.getRelativeContentColor(item.background || DEFAULT_BG) || Colors.white;
     const inputRange = [index / itemsCount, (index + 1) / itemsCount];
     const outputRange = [0.2, 1];
 
@@ -347,7 +347,7 @@ class Drawer extends PureComponent<DrawerProps> {
               {
                 width: itemsIconSize,
                 height: itemsIconSize,
-                tintColor: itemsTintColor,
+                tintColor: iconColor,
                 opacity,
                 transform: [{scale}]
               }
@@ -359,7 +359,7 @@ class Drawer extends PureComponent<DrawerProps> {
             style={[
               styles.actionText,
               {
-                color: itemsTintColor,
+                color: iconColor,
                 opacity,
                 transform: [{scale}]
               },

--- a/src/components/timeline/Point.tsx
+++ b/src/components/timeline/Point.tsx
@@ -1,4 +1,3 @@
-
 import React, {useMemo} from 'react';
 import {StyleSheet, LayoutChangeEvent} from 'react-native';
 import {Colors, Spacings} from '../../style';
@@ -37,18 +36,29 @@ const Point = (props: PointPropsInternal) => {
       {borderWidth: OUTLINE_WIDTH, borderColor: color && Colors.getColorTint(color, OUTLINE_TINT)};
     const circleStyle = !hasContent && isCircle && 
       {backgroundColor: 'transparent', borderWidth: CIRCLE_WIDTH, borderColor: color};
-    
+
     return [styles.point, pointSizeStyle, !removeIconBackground && pointColorStyle, outlineStyle, circleStyle];
   }, [type, color, label, removeIconBackground, icon]);
 
   const renderPointContent = () => {
     const {removeIconBackground} = props;
-    const tintColor = removeIconBackground ? Colors.$iconDefault : Colors.$iconDefaultLight;
+    const tintColor = removeIconBackground
+      ? Colors.$iconDefault
+      : color
+        ? Colors.getRelativeContentColor(color)
+        : Colors.$iconDefaultLight;
+    const textColor = color
+      ? Colors.getRelativeContentColor(color) || Colors.$textDefaultLight
+      : Colors.$textDefaultLight;
     const iconSize = removeIconBackground ? undefined : ICON_SIZE;
     if (icon) {
       return <Icon tintColor={tintColor} {...iconProps} size={iconSize} source={icon}/>;
     } else if (label) {
-      return <Text recorderTag={'unmask'} $textDefaultLight subtextBold>{label}</Text>;
+      return (
+        <Text recorderTag={'unmask'} color={textColor} subtextBold>
+          {label}
+        </Text>
+      );
     }
   };
 

--- a/src/style/colors.ts
+++ b/src/style/colors.ts
@@ -190,6 +190,12 @@ export class Colors {
   shouldReverseOnDark = (avoidReverseOnDark?: boolean) =>
     !avoidReverseOnDark && this.shouldSupportDarkMode && Scheme.isDarkMode();
 
+  getRelativeContentColor(backgroundColor: string) {
+    if (backgroundColor) {
+      return this.isDark(backgroundColor) ? colorsPalette.white : colorsPalette.grey1;
+    }
+  }
+
   getColorTint(colorValue: string | OpaqueColorValue | undefined,
     tintKey: string | number,
     options: GetColorTintOptions = {}) {


### PR DESCRIPTION
## Description
New `getRelativeContentColor` function in `Colors`.
Usage of `getRelativeContentColor`:

- `Checkbox` - icon color.
- `Card` - selected icon color.
- `Drawer` - icon and text colors.
- `TimeLine - Point` - icon and text colors.

## Changelog
`getRelativeContentColor` logic.

## Additional info
MADS-4291
