### PR TITLE
Drawer item custom icon and text colors

### DIFF
--- a/src/components/drawer/index.tsx
+++ b/src/components/drawer/index.tsx
@@ -16,7 +16,9 @@ interface DrawerItemProps {
   width?: number;
   background?: string;
   text?: string;
+  textColor?: string;
   icon?: number;
+  iconColor?: string;
   onPress?: Function;
   keepOpen?: boolean;
   style?: ViewStyle;
@@ -347,7 +349,7 @@ class Drawer extends PureComponent<DrawerProps> {
               {
                 width: itemsIconSize,
                 height: itemsIconSize,
-                tintColor: itemsTintColor,
+                tintColor: item.iconColor || itemsTintColor,
                 opacity,
                 transform: [{scale}]
               }
@@ -359,7 +361,7 @@ class Drawer extends PureComponent<DrawerProps> {
             style={[
               styles.actionText,
               {
-                color: itemsTintColor,
+                color: item.textColor || itemsTintColor,
                 opacity,
                 transform: [{scale}]
               },


### PR DESCRIPTION
## Description
Currently we can set `itemsTintColor` for all the drawer items, if we want to set each drawer is own colors we need to expose `text/icon` color.
Drawer item support custom text and icon colors.

## Changelog
Drawer item support custom text and icon colors.

## Additional info
MADS-4291
