### PR TITLE
figma embed removed footer

### DIFF
--- a/docuilib/package.json
+++ b/docuilib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uilib-docs",
-  "version": "3.25.0",
+  "version": "3.26.0",
   "main": "./src/index.ts",
   "scripts": {
     "docusaurus": "docusaurus",

--- a/docuilib/src/components/pageComponents/ContentItem.tsx
+++ b/docuilib/src/components/pageComponents/ContentItem.tsx
@@ -96,7 +96,7 @@ type ContentItemProps = {
 
 export const ContentItem = ({item, componentName, showCodeButton, category}: ContentItemProps) => {
   const getFigmaEmbed = (value: string, height = 450) => {
-    const modifiedValue = !value.includes('page-selector=') ? value + '&page-selector=false' : value;
+    const modifiedValue = !value.includes('page-selector=') ? value + '&page-selector=false&footer=false' : value;
     return <iframe width={'100%'} height={height} src={modifiedValue}/>;
   };
 


### PR DESCRIPTION
## Description
Figma embed removed footer ([Figma docs](https://www.figma.com/developers/embed#resources) look for `footer`)

## Changelog
Figma embed removed footer

## Additional info
None