### PR TITLE
KeyboardAccessoryView - fix "Argument appears to not be a ReactComponent"

### DIFF
--- a/lib/components/Keyboard/KeyboardInput/TextInputKeyboardManager/TextInputKeyboardManager.ios.ts
+++ b/lib/components/Keyboard/KeyboardInput/TextInputKeyboardManager/TextInputKeyboardManager.ios.ts
@@ -44,7 +44,7 @@ export default class TextInputKeyboardManager {
 }
 
 function findNodeHandle(ref: any) {
-  return ReactNative.findNodeHandle(ref.current || ref);
+  return ref.current?.getNodeHandle?.() || ref?.getNodeHandle?.() || ReactNative.findNodeHandle(ref.current || ref);
 }
 
 const springAnimation = {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uilib-native",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "homepage": "https://github.com/wix/react-native-ui-lib",
   "description": "uilib native components (separated from js components)",
   "main": "components/index",

--- a/src/components/textField/useImperativeInputHandle.ts
+++ b/src/components/textField/useImperativeInputHandle.ts
@@ -1,5 +1,5 @@
 import React, {useContext, useImperativeHandle, useRef} from 'react';
-import {TextInput, TextInputProps} from 'react-native';
+import {findNodeHandle, TextInput, TextInputProps} from 'react-native';
 import FieldContext from './FieldContext';
 
 const useImperativeInputHandle = (ref: React.Ref<any>, props: Pick<TextInputProps, 'onChangeText'>) => {
@@ -7,6 +7,7 @@ const useImperativeInputHandle = (ref: React.Ref<any>, props: Pick<TextInputProp
   const context = useContext(FieldContext);
   useImperativeHandle(ref, () => {
     return {
+      getNodeHandle: () => inputRef.current ? findNodeHandle(inputRef.current) : null,
       isFocused: () => inputRef.current?.isFocused(),
       focus: () => inputRef.current?.focus(),
       blur: () => inputRef.current?.blur(),


### PR DESCRIPTION
## Description
In our demo app (on iOS) go to the `KeyboardAccessoryViewScreen`.
Press on one of the custom keyboards. 
You'll get the following error:
```
Error: Argument appears to not be a ReactComponent. Keys: isFocused,focus,blur,clear,validate,isValid
```

I don't like the solution too much, but could not find a better solution.

Maybe we should change `getNodeHandle` to `_getNodeHandle` to make it more pronounced it's internal?

## Changelog
KeyboardAccessoryView - fix "Argument appears to not be a ReactComponent"

## Additional info
Fixes #1996
