### PR TITLE
Picker - enhance modalProps merging in useNewPickerProps

### DIFF
--- a/src/components/picker/helpers/useNewPickerProps.tsx
+++ b/src/components/picker/helpers/useNewPickerProps.tsx
@@ -17,12 +17,12 @@ const useNewPickerProps = (props: PickerProps) => {
     renderOverlay
   } = props;
 
-  const defaultModalProps: ExpandableOverlayProps['modalProps'] = {
+  const defaultModalProps = {
     animationType: 'slide',
     transparent: Constants.isIOS && enableModalBlur,
     enableModalBlur: Constants.isIOS && enableModalBlur,
     onRequestClose: topBarProps?.onCancel
-  };
+  } satisfies ExpandableOverlayProps['modalProps'];
 
   const mergedModalProps = {
     ...defaultModalProps,

--- a/src/components/picker/helpers/useNewPickerProps.tsx
+++ b/src/components/picker/helpers/useNewPickerProps.tsx
@@ -17,18 +17,28 @@ const useNewPickerProps = (props: PickerProps) => {
     renderOverlay
   } = props;
 
-  const modalProps: ExpandableOverlayProps['modalProps'] = {
+  const defaultModalProps: ExpandableOverlayProps['modalProps'] = {
     animationType: 'slide',
     transparent: Constants.isIOS && enableModalBlur,
     enableModalBlur: Constants.isIOS && enableModalBlur,
     onRequestClose: topBarProps?.onCancel
   };
 
+  const mergedModalProps = {
+    ...defaultModalProps,
+    ...(onShow && {onShow}),
+    ...pickerModalProps,
+    ...customPickerProps?.modalProps
+  };
+
   const newProps: PickerProps = {
     renderHeader: renderCustomDialogHeader || renderHeader,
     renderInput: renderPicker || renderInput,
     renderOverlay: renderCustomModal || renderOverlay,
-    customPickerProps: {modalProps: {onShow, ...modalProps, ...pickerModalProps}, ...customPickerProps}
+    customPickerProps: {
+      ...customPickerProps,
+      modalProps: mergedModalProps
+    }
   };
   return newProps;
 };


### PR DESCRIPTION
## Description
When passing `customPickerProps` with `modalProps` the default modal props are getting overridden.
This pr fixing the issue, by merging the default props with the user custom modal props to not override the animation unless the user passed the relevant props. 

Snippet:
```
 <Picker
        placeholder="Favorite Language"
        value={language}
        onChange={item => setLanguage(item)}
        items={options}
        customPickerProps={{
          modalProps: {}
        }}
      />
```

## Changelog
Picker merging default modal props with the user custom modal props.

## Additional info
None
