### PR TITLE
Docs - fix playground preview divider

### DIFF
--- a/docuilib/src/components/UILivePreview.module.scss
+++ b/docuilib/src/components/UILivePreview.module.scss
@@ -28,6 +28,7 @@ $editor-height: 700px;
   max-width: calc(100% - ($preview-width + $preview-margin));
   border-radius: 8px;
   overflow-y: scroll;
+  scrollbar-width: none;
 
   pre {
     min-height: 100%;
@@ -71,7 +72,6 @@ $editor-height: 700px;
   border: 10px solid rgba(255, 255, 255, 0.2);
   box-shadow: 0 0 15px rgba(110, 120, 129, 0.05);
   overflow: hidden;
-  scrollbar-width: none;
 }
 
 .iframe {

--- a/docuilib/src/components/UILivePreview.module.scss
+++ b/docuilib/src/components/UILivePreview.module.scss
@@ -71,6 +71,7 @@ $editor-height: 700px;
   border: 10px solid rgba(255, 255, 255, 0.2);
   box-shadow: 0 0 15px rgba(110, 120, 129, 0.05);
   overflow: hidden;
+  scrollbar-width: none;
 }
 
 .iframe {

--- a/docuilib/src/components/UILivePreview.module.scss
+++ b/docuilib/src/components/UILivePreview.module.scss
@@ -33,7 +33,6 @@ $editor-height: 700px;
     min-height: 100%;
     padding: 20px !important;
     background-color: #1d1e21 !important;
-    border-right: 1px solid #d2d6d8;
   }
 }
 
@@ -57,6 +56,11 @@ $editor-height: 700px;
     background-color: rgba(255, 255, 255, 0.8) !important;
     margin: 10px;
   }
+}
+
+.previewContainer {
+  border-left: 1px solid #d2d6d8;
+  display: flex;
 }
 
 .preview {

--- a/docuilib/src/components/UILivePreview.tsx
+++ b/docuilib/src/components/UILivePreview.tsx
@@ -1,6 +1,7 @@
 import React, {useEffect, useRef, useState} from 'react';
 import {LiveProvider, LiveEditor, LiveError} from 'react-live';
 import {themes} from 'prism-react-renderer';
+import {Button} from 'react-native-ui-lib/core';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import CodeBlock from '@theme/CodeBlock';
@@ -15,12 +16,6 @@ export default function UILivePreview({code: initialCode, componentName = undefi
   const [iframeLoaded, setIframeLoaded] = useState(false);
   const {siteConfig} = useDocusaurusContext();
   const iframeRef = useRef(null);
-  // const {code: formattedCode} = useFormattedCode(initialCode, {printWidth: 100});
-  // const [code, setCode] = useState(formattedCode);
-
-  // useEffect(() => {
-  //   setCode(formattedCode);
-  // }, [formattedCode]);
   const {code: formattedCode} = useFormattedCode(initialCode, {printWidth: 100});
   const [code, setCode] = useState(formattedCode);
 
@@ -43,6 +38,10 @@ export default function UILivePreview({code: initialCode, componentName = undefi
     return <CodeBlock language="jsx">{code}</CodeBlock>;
   }
 
+  const handleFormat = () => {
+    setCode(formattedCode);
+  };
+
   return (
     <BrowserOnly>
       {() => {
@@ -52,6 +51,15 @@ export default function UILivePreview({code: initialCode, componentName = undefi
           <LiveProvider code={code} scope={ReactLiveScope} theme={themes.oceanicNext}>
             <div className={styles.container}>
               <div className={styles.codeContainer}>
+                <div className={styles.codeHeader}>
+                  <Button
+                    label="Prettify"
+                    size={Button.sizes.small}
+                    onPress={handleFormat}
+                    backgroundColor="#2d2d2d"
+                    borderRadius={4}
+                  />
+                </div>
                 <LiveEditor onChange={setCode} className={styles.liveEditor}/>
                 <div className={styles.errorContainer}>
                   <LiveError/>

--- a/docuilib/src/components/UILivePreview.tsx
+++ b/docuilib/src/components/UILivePreview.tsx
@@ -16,6 +16,8 @@ export default function UILivePreview({code: initialCode, componentName = undefi
   const [iframeLoaded, setIframeLoaded] = useState(false);
   const {siteConfig} = useDocusaurusContext();
   const iframeRef = useRef(null);
+  // const [code, setCode] = useState(initialCode);
+  // const {code: formattedCode} = useFormattedCode(code, {printWidth: 100});
   const {code: formattedCode} = useFormattedCode(initialCode, {printWidth: 100});
   const [code, setCode] = useState(formattedCode);
 
@@ -34,13 +36,13 @@ export default function UILivePreview({code: initialCode, componentName = undefi
     iframeRef.current?.contentWindow.postMessage(message, '*');
   };
 
+  // const handleFormat = () => {
+  //   setCode(formattedCode);
+  // };
+
   if (!liveScopeSupport && !isComponentSupported(componentName)) {
     return <CodeBlock language="jsx">{code}</CodeBlock>;
   }
-
-  const handleFormat = () => {
-    setCode(formattedCode);
-  };
 
   return (
     <BrowserOnly>
@@ -51,7 +53,7 @@ export default function UILivePreview({code: initialCode, componentName = undefi
           <LiveProvider code={code} scope={ReactLiveScope} theme={themes.oceanicNext}>
             <div className={styles.container}>
               <div className={styles.codeContainer}>
-                <div className={styles.codeHeader}>
+                {/* <div className={styles.codeHeader}>
                   <Button
                     label="Prettify"
                     size={Button.sizes.small}
@@ -59,7 +61,7 @@ export default function UILivePreview({code: initialCode, componentName = undefi
                     backgroundColor="#2d2d2d"
                     borderRadius={4}
                   />
-                </div>
+                </div> */}
                 <LiveEditor onChange={setCode} className={styles.liveEditor}/>
                 <div className={styles.errorContainer}>
                   <LiveError/>

--- a/docuilib/src/components/UILivePreview.tsx
+++ b/docuilib/src/components/UILivePreview.tsx
@@ -4,7 +4,6 @@ import {themes} from 'prism-react-renderer';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import CodeBlock from '@theme/CodeBlock';
-import {Button} from 'react-native-ui-lib/core';
 import ReactLiveScope from '../theme/ReactLiveScope';
 import {isComponentSupported} from '../utils/componentUtils';
 import useFormattedCode from '../hooks/useFormattedCode';
@@ -16,8 +15,18 @@ export default function UILivePreview({code: initialCode, componentName = undefi
   const [iframeLoaded, setIframeLoaded] = useState(false);
   const {siteConfig} = useDocusaurusContext();
   const iframeRef = useRef(null);
-  const [code, setCode] = useState(initialCode);
-  const {code: formattedCode} = useFormattedCode(code, {printWidth: 100});
+  // const {code: formattedCode} = useFormattedCode(initialCode, {printWidth: 100});
+  // const [code, setCode] = useState(formattedCode);
+
+  // useEffect(() => {
+  //   setCode(formattedCode);
+  // }, [formattedCode]);
+  const {code: formattedCode} = useFormattedCode(initialCode, {printWidth: 100});
+  const [code, setCode] = useState(formattedCode);
+
+  useEffect(() => {
+    setCode(formattedCode);
+  }, [formattedCode]);
 
   useEffect(() => {
     if (iframeLoaded) {
@@ -28,10 +37,6 @@ export default function UILivePreview({code: initialCode, componentName = undefi
   const sendMessageToIframe = code => {
     const message = {type: IFRAME_MESSAGE_TYPE, code};
     iframeRef.current?.contentWindow.postMessage(message, '*');
-  };
-
-  const handleFormat = () => {
-    setCode(formattedCode);
   };
 
   if (!liveScopeSupport && !isComponentSupported(componentName)) {
@@ -47,28 +52,21 @@ export default function UILivePreview({code: initialCode, componentName = undefi
           <LiveProvider code={code} scope={ReactLiveScope} theme={themes.oceanicNext}>
             <div className={styles.container}>
               <div className={styles.codeContainer}>
-                <div className={styles.codeHeader}>
-                  <Button
-                    label="Prettify"
-                    size={Button.sizes.small}
-                    onPress={handleFormat}
-                    backgroundColor="#2d2d2d"
-                    borderRadius={4}
-                  />
-                </div>
                 <LiveEditor onChange={setCode} className={styles.liveEditor}/>
                 <div className={styles.errorContainer}>
                   <LiveError/>
                 </div>
               </div>
-              <div className={styles.preview}>
-                <iframe
-                  ref={iframeRef}
-                  className={styles.iframe}
-                  src={iframeSource}
-                  title="Simulator"
-                  onLoad={() => setIframeLoaded(true)}
-                />
+              <div className={styles.previewContainer}>
+                <div className={styles.preview}>
+                  <iframe
+                    ref={iframeRef}
+                    className={styles.iframe}
+                    src={iframeSource}
+                    title="Simulator"
+                    onLoad={() => setIframeLoaded(true)}
+                  />
+                </div>
               </div>
             </div>
           </LiveProvider>

--- a/docuilib/src/components/UILivePreview.tsx
+++ b/docuilib/src/components/UILivePreview.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useRef, useState} from 'react';
 import {LiveProvider, LiveEditor, LiveError} from 'react-live';
 import {themes} from 'prism-react-renderer';
-import {Button} from 'react-native-ui-lib/core';
+// import {Button} from 'react-native-ui-lib/core';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import CodeBlock from '@theme/CodeBlock';
@@ -16,10 +16,10 @@ export default function UILivePreview({code: initialCode, componentName = undefi
   const [iframeLoaded, setIframeLoaded] = useState(false);
   const {siteConfig} = useDocusaurusContext();
   const iframeRef = useRef(null);
-  // const [code, setCode] = useState(initialCode);
-  // const {code: formattedCode} = useFormattedCode(code, {printWidth: 100});
   const {code: formattedCode} = useFormattedCode(initialCode, {printWidth: 100});
   const [code, setCode] = useState(formattedCode);
+  // const [code, setCode] = useState(initialCode);
+  // const {code: formattedCode} = useFormattedCode(code, {printWidth: 100});
 
   useEffect(() => {
     setCode(formattedCode);


### PR DESCRIPTION
## Description
Docs - fix playground preview divider
Remove prettify button - crashes the site when editing the code in the live editor

## Changelog
Docs - fix playground preview divider

## Additional info

