### PR TITLE
Release Notes Script - to include labels and filter out hotfixes

### DIFF
--- a/scripts/release/prReleaseNotesCommon.js
+++ b/scripts/release/prReleaseNotesCommon.js
@@ -33,7 +33,7 @@ function parsePR(prContent) {
 async function fetchMergedPRs(postMergedDate) {
   console.log('Find all merged PRs since - ', postMergedDate);
   // process.stderr.write(`Loading page ${page}..`);
-  const str = childProcess.execSync('gh pr list --json headRefName,body,title,number,mergedAt,url --limit 100 --state merged --search "base:master"',
+  const str = childProcess.execSync('gh pr list --json headRefName,body,title,number,mergedAt,url,labels --limit 100 --state merged --search "base:master"',
     {
       encoding: 'utf8'
     });
@@ -49,20 +49,24 @@ async function fetchMergedPRs(postMergedDate) {
     prs => _.sortBy(prs, 'mergedAt'),
     prs =>
       _.map(prs, pr => {
-        try {
-          return {
-            mergedAt: pr.mergedAt,
-            url: pr.url,
-            branch: pr.headRefName,
-            number: pr.number,
-            title: pr.title,
-            info: parsePR(pr.body)
-          };
-        } catch {
-          console.error('Failed parsing PR: ', pr.url);
+        if (!pr.labels.some(label => label.name === 'hotfix')) {
+          try {
+            return {
+              mergedAt: pr.mergedAt,
+              url: pr.url,
+              branch: pr.headRefName,
+              number: pr.number,
+              title: pr.title,
+              info: parsePR(pr.body)
+            };
+          } catch {
+            console.error('Failed parsing PR: ', pr.url);
+            return null;
+          }
         }
-      }))(PRs);
-
+        return null;
+      }),
+    prs => _.compact(prs))(PRs);
   return relevantPRs;
 }
 


### PR DESCRIPTION
## Description
Release notes script now include pr labels, filter out PR's with `hotfix` label.
This is part of the Hotfix release notes we spoke about, and ignoring those PR in the next version.

## Changelog
Release notes script now include pr labels, filter out PR's with `hotfix` label.

## Additional info
None
