### PR TITLE
Filetered hotfix prs from release notes

### DIFF
--- a/scripts/release/prReleaseNotesCommon.js
+++ b/scripts/release/prReleaseNotesCommon.js
@@ -50,29 +50,26 @@ async function fetchMergedPRs(postMergedDate) {
     prs => _.filter(prs, pr => {
       const isHotfix = pr.labels.some(label => label.name === 'hotfix');
       if (isHotfix) {
-        console.log(chalk.bgYellow.black(`PR ${pr.number} is a hotfix and was excluded for the release notes.`));
+        console.log(chalk.bgYellow.black(`PR ${pr.number} is a hotfix and was excluded from the release notes.`));
       }
       return !isHotfix;
     }),
     prs => _.sortBy(prs, 'mergedAt'),
     prs =>
       _.map(prs, pr => {
-        if (!pr.labels.some(label => label.name === 'hotfix')) {
-          try {
-            return {
-              mergedAt: pr.mergedAt,
-              url: pr.url,
-              branch: pr.headRefName,
-              number: pr.number,
-              title: pr.title,
-              info: parsePR(pr.body)
-            };
-          } catch {
-            console.error('Failed parsing PR: ', pr.url);
-            return null;
-          }
+        try {
+          return {
+            mergedAt: pr.mergedAt,
+            url: pr.url,
+            branch: pr.headRefName,
+            number: pr.number,
+            title: pr.title,
+            info: parsePR(pr.body)
+          };
+        } catch {
+          console.error('Failed parsing PR: ', pr.url);
+          return null;
         }
-        return null;
       }),
     prs => _.compact(prs))(PRs);
   return relevantPRs;

--- a/scripts/release/prReleaseNotesCommon.js
+++ b/scripts/release/prReleaseNotesCommon.js
@@ -31,7 +31,7 @@ function parsePR(prContent) {
   return PRInfo;
 }
 
-async function fetchMergedPRs(postMergedDate) {
+async function fetchMergedPRs(postMergedDate, _repo, isPatchRelease) {
   console.log('Find all merged PRs since - ', postMergedDate);
   // process.stderr.write(`Loading page ${page}..`);
   const str = childProcess.execSync('gh pr list --json headRefName,body,title,number,mergedAt,url,labels --limit 100 --state merged --search "base:master"',
@@ -45,14 +45,18 @@ async function fetchMergedPRs(postMergedDate) {
     console.log('\x1b[31m', 'Something went wrong', PRs.message);
     return;
   }
+  const filteringMessageStyle = chalk.bgYellow.black;
+  console.log(filteringMessageStyle(isPatchRelease
+    ? 'Patch release - only hotfix PRs will be included.'
+    : 'Non-patch release - hotfix PRs will be excluded.'));
 
   const relevantPRs = _.flow(prs => _.filter(prs, pr => !!pr.mergedAt && new Date(pr.mergedAt) > postMergedDate),
     prs => _.filter(prs, pr => {
       const isHotfix = pr.labels.some(label => label.name === 'hotfix');
-      if (isHotfix) {
-        console.log(chalk.bgYellow.black(`PR ${pr.number} is a hotfix and was excluded from the release notes.`));
+      if (isHotfix && !isPatchRelease) {
+        console.log(filteringMessageStyle(`PR ${pr.number} is a hotfix and was excluded from the release notes.`));
       }
-      return !isHotfix;
+      return isPatchRelease ? isHotfix : !isHotfix;
     }),
     prs => _.sortBy(prs, 'mergedAt'),
     prs =>
@@ -160,9 +164,9 @@ function getReleaseNotesForType(PRs, title) {
   return releaseNotes;
 }
 
-async function _generateReleaseNotes(latestVersion, newVersion, fileNamePrefix, repo, header, tagPrefix, categories) {
+async function _generateReleaseNotes(latestVersion, newVersion, fileNamePrefix, repo, header, tagPrefix, categories, isPatchRelease) {
   const latestReleaseDate = fetchLatestReleaseDate(tagPrefix, latestVersion);
-  const PRs = await fetchMergedPRs(latestReleaseDate, repo);
+  const PRs = await fetchMergedPRs(latestReleaseDate, repo, isPatchRelease);
   if (!PRs) {
     return;
   }
@@ -201,6 +205,13 @@ async function _generateReleaseNotes(latestVersion, newVersion, fileNamePrefix, 
   console.log(`\x1b[1m\x1b[32m✔\x1b[0m \x1b[32m${fileNamePrefix}-release-notes.txt was successfully written to ${process.env.HOME}/Downloads\x1b[0m \x1b[1m\x1b[32m✔\x1b[0m`);
 }
 
+function isPatchRelease(lastVersion, newVersion) {
+  const [lastMajor, lastMinor, lastPatch] = lastVersion.split('.').map(Number);
+  const [newMajor, newMinor, newPatch] = newVersion.split('.').map(Number);
+
+  return lastMajor === newMajor && lastMinor === newMinor && newPatch - lastPatch > 0;
+}
+
 async function generateReleaseNotes(latestVersion,
   newVersion,
   fileNamePrefix,
@@ -222,11 +233,12 @@ async function generateReleaseNotes(latestVersion,
     });
   });
 
+
   rl.on('close', () => {
     const header = getHeader(newVer);
     console.info(`Current latest version is v${latestVer}`);
     console.info(`Generating release notes out or PRs for v${newVer}`);
-    _generateReleaseNotes(latestVer, newVer, fileNamePrefix, repo, header, tagPrefix, categories);
+    _generateReleaseNotes(latestVer, newVer, fileNamePrefix, repo, header, tagPrefix, categories, isPatchRelease(latestVer, newVer));
   });
 }
 

--- a/scripts/release/prReleaseNotesCommon.js
+++ b/scripts/release/prReleaseNotesCommon.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const _ = require('lodash');
+const chalk = require('chalk');
 const childProcess = require('child_process');
 const readline = require('readline');
 
@@ -46,6 +47,13 @@ async function fetchMergedPRs(postMergedDate) {
   }
 
   const relevantPRs = _.flow(prs => _.filter(prs, pr => !!pr.mergedAt && new Date(pr.mergedAt) > postMergedDate),
+    prs => _.filter(prs, pr => {
+      const isHotfix = pr.labels.some(label => label.name === 'hotfix');
+      if (isHotfix) {
+        console.log(chalk.bgYellow.black(`PR ${pr.number} is a hotfix and was excluded for the release notes.`));
+      }
+      return !isHotfix;
+    }),
     prs => _.sortBy(prs, 'mergedAt'),
     prs =>
       _.map(prs, pr => {


### PR DESCRIPTION
## Description
Changed release notes generation script to ignore hot fixed prs.
Changed release notes generation so it will take hotfix prs when generating a patch release release notes.

## Changelog
Infra - release notes generation script now excludes hot fixed prs.

## Additional info
MADS-4718