### PR TITLE
Docs Deployment - Moved to release cycle

### DIFF
--- a/.github/workflows/deployDocs.yml
+++ b/.github/workflows/deployDocs.yml
@@ -3,7 +3,7 @@ name: Deploy Documentation
 on:
   push:
     branches:
-      - master
+      - release
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
## Description
Moved docs release workflow to run on release branch instead of master.

## Changelog
Docs - docs are now released with release branch and not on master

## Additional info
N/A