### PR TITLE
Docs workflow - Run check on every branch

### DIFF
--- a/.github/workflows/deployDocs.yml
+++ b/.github/workflows/deployDocs.yml
@@ -3,7 +3,7 @@ name: Deploy Documentation
 on:
   push:
     branches:
-      - '**'
+      - master
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/deployDocs.yml
+++ b/.github/workflows/deployDocs.yml
@@ -3,7 +3,7 @@ name: Deploy Documentation
 on:
   push:
     branches:
-      - release
+      - '**'
 
 jobs:
   build-and-deploy:
@@ -28,6 +28,7 @@ jobs:
         run: yarn docs:build
 
       - name: Deploy documentation
+        if: github.ref == 'refs/heads/release'
         env:
           GIT_USER: github-actions[bot]
           GIT_PASS: ${{ secrets.GITHUB_TOKEN }}
@@ -38,3 +39,8 @@ jobs:
           cd docuilib
           yarn install
           yarn deploy
+
+      - name: Deploy disclaimer
+        if: github.ref != 'refs/heads/release'
+        run: |
+          echo "Deploying will only happen on release branch"


### PR DESCRIPTION
## Description
Enabling the docs build workflow to run on every branch but only deploy on release branch. This will verify that the docs build passes whenever we change things.

## Changelog
Docs - added docs build check.

## Additional info
N/A