### PR TITLE
uilib-native - add a snapshot release

### DIFF
--- a/lib/scripts/releaseNative.js
+++ b/lib/scripts/releaseNative.js
@@ -1,16 +1,23 @@
 const exec = require('shell-utils').exec;
 const p = require('path');
 
+// Export buildkite variables for Release build
+// We cast toString() because function returns 'object'
+const IS_SNAPSHOT = process.env.BUILDKITE_MESSAGE?.match(/^snapshot$/i);
+const VERSION_TAG = IS_SNAPSHOT ? 'snapshot' : 'latest';
+
 function run() {
   if (!validateEnv()) {
     return;
   }
 
+  const packageJsonVersion = require('../package.json').version;
   const currentPublished = findCurrentPublishedVersion();
-  const packageJson = require('../package.json');
-  const newVersion = packageJson.version;
+  const newVersion = IS_SNAPSHOT
+    ? `${packageJsonVersion}-snapshot.${process.env.BUILDKITE_BUILD_NUMBER}`
+    : packageJsonVersion;
 
-  if (currentPublished !== newVersion) {
+  if (currentPublished !== packageJsonVersion) {
     createNpmRc();
     versionTagAndPublish(currentPublished, newVersion);
   }
@@ -49,8 +56,13 @@ function tryPublishAndTag(version) {
 }
 
 function tagAndPublish(newVersion) {
-  console.log(`Trying to publish ${newVersion}...`);
-  exec.execSync(`npm publish`);
+  console.log(`trying to publish ${newVersion}...`);
+  exec.execSync(`npm --no-git-tag-version version ${newVersion}`);
+  exec.execSync(`npm publish --tag ${VERSION_TAG}`);
+  if (!IS_SNAPSHOT) {
+    exec.execSync(`git tag -a ${newVersion} -m "${newVersion}"`);
+  }
+  exec.execSyncSilent(`git push deploy ${newVersion} || true`);
 }
 
 run();


### PR DESCRIPTION
## Description
uilib-native - add a snapshot release
`master` will still release the `uilib-native` package.
Starting a build with the `snapshot` message (also requires incrementing the version) will release a snapshot version with the build number (to allow for fixes without further incrementing the version)

## Changelog
None

## Additional info
None