### PR TITLE
Docs - added sitemap

### DIFF
--- a/docuilib/docusaurus.config.js
+++ b/docuilib/docusaurus.config.js
@@ -53,7 +53,8 @@ const darkCodeTheme = themes.dracula;
               require.resolve('./src/css/presets.css'),
               require.resolve('./src/css/components.css')
             ]
-          }
+          },
+          sitemap: {}
         })
       ]
     ],


### PR DESCRIPTION
## Description
Added sitemap for the docs.
According to:
- https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-sitemap
- https://docusaurus.io/docs/using-plugins#docusauruspreset-classic

## Changelog
Docs - Added sitemap

## Additional info
MADS-4742