### PR TITLE
Colors - update danger design tokens colors (a11y)

### DIFF
--- a/demo/src/screens/__tests__/__snapshots__/TextFieldScreen.spec.js.snap
+++ b/demo/src/screens/__tests__/__snapshots__/TextFieldScreen.spec.js.snap
@@ -728,7 +728,7 @@ exports[`TextField Screen renders screen 1`] = `
                   },
                   undefined,
                   {
-                    "color": "#FC3D2F",
+                    "color": "#D52712",
                   },
                   undefined,
                   undefined,
@@ -1269,7 +1269,7 @@ exports[`TextField Screen renders screen 1`] = `
                   },
                   undefined,
                   {
-                    "color": "#FC3D2F",
+                    "color": "#D52712",
                   },
                   undefined,
                   undefined,
@@ -1635,7 +1635,7 @@ exports[`TextField Screen renders screen 1`] = `
                     },
                     undefined,
                     {
-                      "color": "#FC3D2F",
+                      "color": "#D52712",
                     },
                     undefined,
                     undefined,
@@ -1866,7 +1866,7 @@ exports[`TextField Screen renders screen 1`] = `
                     },
                     undefined,
                     {
-                      "color": "#FC3D2F",
+                      "color": "#D52712",
                     },
                     undefined,
                     undefined,
@@ -2231,7 +2231,7 @@ exports[`TextField Screen renders screen 1`] = `
                     },
                     undefined,
                     {
-                      "color": "#FC3D2F",
+                      "color": "#D52712",
                     },
                     undefined,
                     undefined,
@@ -3126,7 +3126,7 @@ exports[`TextField Screen renders screen 1`] = `
                   },
                   undefined,
                   {
-                    "color": "#FC3D2F",
+                    "color": "#D52712",
                   },
                   undefined,
                   undefined,
@@ -4023,7 +4023,7 @@ exports[`TextField Screen renders screen 1`] = `
                   },
                   undefined,
                   {
-                    "color": "#FC3D2F",
+                    "color": "#D52712",
                   },
                   undefined,
                   undefined,
@@ -4726,7 +4726,7 @@ exports[`TextField Screen renders screen 1`] = `
                   },
                   undefined,
                   {
-                    "color": "#FC3D2F",
+                    "color": "#D52712",
                   },
                   undefined,
                   undefined,
@@ -4986,7 +4986,7 @@ exports[`TextField Screen renders screen 1`] = `
                   },
                   undefined,
                   {
-                    "color": "#FC3D2F",
+                    "color": "#D52712",
                   },
                   undefined,
                   undefined,
@@ -5276,7 +5276,7 @@ exports[`TextField Screen renders screen 1`] = `
                   },
                   undefined,
                   {
-                    "color": "#FC3D2F",
+                    "color": "#D52712",
                   },
                   undefined,
                   undefined,
@@ -6017,7 +6017,7 @@ exports[`TextField Screen renders screen 1`] = `
                   },
                   undefined,
                   {
-                    "color": "#FC3D2F",
+                    "color": "#D52712",
                   },
                   undefined,
                   undefined,
@@ -6318,7 +6318,7 @@ exports[`TextField Screen renders screen 1`] = `
                   },
                   undefined,
                   {
-                    "color": "#FC3D2F",
+                    "color": "#D52712",
                   },
                   undefined,
                   undefined,
@@ -6647,7 +6647,7 @@ exports[`TextField Screen renders screen 1`] = `
                   },
                   undefined,
                   {
-                    "color": "#FC3D2F",
+                    "color": "#D52712",
                   },
                   undefined,
                   undefined,
@@ -7023,7 +7023,7 @@ exports[`TextField Screen renders screen 1`] = `
                   },
                   undefined,
                   {
-                    "color": "#FC3D2F",
+                    "color": "#D52712",
                   },
                   undefined,
                   undefined,
@@ -7299,7 +7299,7 @@ exports[`TextField Screen renders screen 1`] = `
                     },
                     undefined,
                     {
-                      "color": "#FC3D2F",
+                      "color": "#D52712",
                     },
                     undefined,
                     undefined,
@@ -7554,7 +7554,7 @@ exports[`TextField Screen renders screen 1`] = `
                     },
                     undefined,
                     {
-                      "color": "#FC3D2F",
+                      "color": "#D52712",
                     },
                     undefined,
                     undefined,
@@ -7844,7 +7844,7 @@ exports[`TextField Screen renders screen 1`] = `
                     },
                     undefined,
                     {
-                      "color": "#FC3D2F",
+                      "color": "#D52712",
                     },
                     undefined,
                     undefined,

--- a/src/style/designTokens.ts
+++ b/src/style/designTokens.ts
@@ -22,6 +22,7 @@ export default {
   $backgroundWarningLight: colorsPalette.yellow70,
   $backgroundMajorLight: colorsPalette.orange80,
   $backgroundMajorHeavy: colorsPalette.orange30,
+  //backgroundDangerHeavy should be changed to backgroundDanger
   $backgroundDangerHeavy: colorsPalette.red10,
   $backgroundDangerLight: colorsPalette.red80,
   $backgroundDisabled: colorsPalette.grey50,
@@ -43,6 +44,7 @@ export default {
   $textSuccessLight: colorsPalette.green30,
   $textMajor: colorsPalette.orange10,
   $textDanger: colorsPalette.red10,
+  //textDangerLight should be deprecated
   $textDangerLight: colorsPalette.red10,
 
   // ICON
@@ -57,6 +59,7 @@ export default {
   $iconSuccessLight: colorsPalette.green30,
   $iconMajor: colorsPalette.orange10,
   $iconDanger: colorsPalette.red10,
+  //iconDangerLight should be deprecated
   $iconDangerLight: colorsPalette.red10,
   $iconDisabled: colorsPalette.grey50,
 

--- a/src/style/designTokens.ts
+++ b/src/style/designTokens.ts
@@ -22,7 +22,7 @@ export default {
   $backgroundWarningLight: colorsPalette.yellow70,
   $backgroundMajorLight: colorsPalette.orange80,
   $backgroundMajorHeavy: colorsPalette.orange30,
-  $backgroundDangerHeavy: colorsPalette.red30,
+  $backgroundDangerHeavy: colorsPalette.red10,
   $backgroundDangerLight: colorsPalette.red80,
   $backgroundDisabled: colorsPalette.grey50,
   $backgroundDark: colorsPalette.grey10,
@@ -43,7 +43,7 @@ export default {
   $textSuccessLight: colorsPalette.green30,
   $textMajor: colorsPalette.orange10,
   $textDanger: colorsPalette.red10,
-  $textDangerLight: colorsPalette.red30,
+  $textDangerLight: colorsPalette.red10,
 
   // ICON
   $iconDefault: colorsPalette.grey10,
@@ -57,7 +57,7 @@ export default {
   $iconSuccessLight: colorsPalette.green30,
   $iconMajor: colorsPalette.orange10,
   $iconDanger: colorsPalette.red10,
-  $iconDangerLight: colorsPalette.red30,
+  $iconDangerLight: colorsPalette.red10,
   $iconDisabled: colorsPalette.grey50,
 
   // OUTLINE
@@ -70,7 +70,7 @@ export default {
   $outlinePrimaryMedium: colorsPalette.blue70,
   $outlineGeneral: colorsPalette.blue30,
   $outlineWarning: colorsPalette.yellow30,
-  $outlineDanger: colorsPalette.red30,
+  $outlineDanger: colorsPalette.red10,
   $outlineInverted: colorsPalette.white,
 
   // BLACK AND WHITE


### PR DESCRIPTION
## Description
Update `danger` design tokens colors.
Changed -  `$backgroundDangerHeavy, $textDangerLight, $iconDangerLight, $outlineDanger` from `red30` to `red10`.

Note that now:
`$textDangerLight equal to $textDanger` and `$iconDangerLight equal to $iconDanger`

## Changelog
Colors - Update `danger` design tokens colors (a11y).

## Additional info
MADS-4756
