### PR TITLE
Carousel - page control hit slop fix a11y

### DIFF
--- a/src/components/checkbox/index.tsx
+++ b/src/components/checkbox/index.tsx
@@ -10,6 +10,7 @@ import {
   ImageStyle
 } from 'react-native';
 import {Colors, Spacings} from '../../style';
+import {StyleUtils} from '../../utils';
 //@ts-ignore
 import Assets from '../../assets';
 import {asBaseComponent} from '../../commons/new';
@@ -251,9 +252,7 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
     };
   };
 
-  getAccessibleHitSlop(size: number) {
-    return Math.max(0, (48 - size) / 2);    
-  }
+
 
   renderCheckbox() {
     const {selectedIcon, label, testID, style, containerStyle, indeterminate, ...others} = this.props;
@@ -267,7 +266,7 @@ class Checkbox extends Component<CheckboxProps, CheckboxState> {
         {...others}
         style={[this.getBorderStyle(), style, !label && containerStyle]}
         onPress={this.onPress}
-        hitSlop={this.getAccessibleHitSlop(this.props.size || DEFAULT_SIZE)}
+        hitSlop={StyleUtils.getAccessibleHitSlop(this.props.size || DEFAULT_SIZE)}
       >
         {
           <Animated.View

--- a/src/components/pageControl/index.tsx
+++ b/src/components/pageControl/index.tsx
@@ -3,6 +3,7 @@ import React, {PureComponent} from 'react';
 import {StyleSheet, LayoutAnimation, StyleProp, ViewStyle} from 'react-native';
 import {asBaseComponent} from '../../commons/new';
 import {Colors} from '../../style';
+import {StyleUtils} from '../../utils';
 import TouchableOpacity, {TouchableOpacityProps} from '../touchableOpacity';
 import View from '../view';
 
@@ -25,10 +26,6 @@ function getSizeStyle(size: number, index: number, currentPage: number, enlargeA
 
 function getNumberOfPagesShown(props: PageControlProps) {
   return Math.min(MAX_SHOWN_PAGES, props.numOfPages);
-}
-
-function getAccessibleHitSlop(size: number) {
-  return Math.max(0, (48 - size) / 2);
 }
 
 export interface PageControlProps {
@@ -192,6 +189,18 @@ class PageControl extends PureComponent<PageControlProps, State> {
 
   renderIndicator(index: number, size: number, enlargeActive?: boolean) {
     const {currentPage, color, inactiveColor, onPagePress, spacing = PageControl.DEFAULT_SPACING} = this.props;
+
+    const baseHitSlop = StyleUtils.getAccessibleHitSlop(size);
+    const maxHorizontalHitSlop = Math.max(0, spacing / 2 - 1); // Leave 1px gap to prevent overlap
+    const horizontalHitSlop = Math.min(baseHitSlop, maxHorizontalHitSlop);
+
+    const hitSlop = {
+      top: baseHitSlop,
+      bottom: baseHitSlop,
+      left: horizontalHitSlop,
+      right: horizontalHitSlop
+    };
+
     return (
       <TouchableOpacity
         customValue={index}
@@ -203,7 +212,7 @@ class PageControl extends PureComponent<PageControlProps, State> {
           getColorStyle(index === currentPage, color, inactiveColor),
           getSizeStyle(size, index, currentPage, enlargeActive)
         ]}
-        hitSlop={getAccessibleHitSlop(size)}
+        hitSlop={hitSlop}
       />
     );
   }

--- a/src/components/pageControl/index.tsx
+++ b/src/components/pageControl/index.tsx
@@ -189,6 +189,7 @@ class PageControl extends PureComponent<PageControlProps, State> {
 
   renderIndicator(index: number, size: number, enlargeActive?: boolean) {
     const {currentPage, color, inactiveColor, onPagePress, spacing = PageControl.DEFAULT_SPACING} = this.props;
+    const hitSlopValue = StyleUtils.getAccessibleHitSlop(size);
 
     return (
       <TouchableOpacity
@@ -202,8 +203,8 @@ class PageControl extends PureComponent<PageControlProps, State> {
           getSizeStyle(size, index, currentPage, enlargeActive)
         ]}
         hitSlop={{
-          top: StyleUtils.getAccessibleHitSlop(size),
-          bottom: StyleUtils.getAccessibleHitSlop(size)
+          top: hitSlopValue,
+          bottom: hitSlopValue
         }}
       />
     );

--- a/src/components/pageControl/index.tsx
+++ b/src/components/pageControl/index.tsx
@@ -27,6 +27,10 @@ function getNumberOfPagesShown(props: PageControlProps) {
   return Math.min(MAX_SHOWN_PAGES, props.numOfPages);
 }
 
+function getAccessibleHitSlop(size: number) {
+  return Math.max(0, (48 - size) / 2);
+}
+
 export interface PageControlProps {
   /**
    * Limit the number of page indicators shown.
@@ -114,14 +118,12 @@ class PageControl extends PureComponent<PageControlProps, State> {
 
     if (Array.isArray(props.size)) {
       if (props.size[0] >= props.size[1] || props.size[1] >= props.size[2]) {
-        console.warn(
-          'It is recommended that largeSize > mediumSize > smallSize, currently: smallSize=',
+        console.warn('It is recommended that largeSize > mediumSize > smallSize, currently: smallSize=',
           props.size[0],
           'mediumSize=',
           props.size[1],
           'largeSize=',
-          props.size[2]
-        );
+          props.size[2]);
       }
     }
   }
@@ -201,6 +203,7 @@ class PageControl extends PureComponent<PageControlProps, State> {
           getColorStyle(index === currentPage, color, inactiveColor),
           getSizeStyle(size, index, currentPage, enlargeActive)
         ]}
+        hitSlop={getAccessibleHitSlop(size)}
       />
     );
   }

--- a/src/components/pageControl/index.tsx
+++ b/src/components/pageControl/index.tsx
@@ -190,17 +190,6 @@ class PageControl extends PureComponent<PageControlProps, State> {
   renderIndicator(index: number, size: number, enlargeActive?: boolean) {
     const {currentPage, color, inactiveColor, onPagePress, spacing = PageControl.DEFAULT_SPACING} = this.props;
 
-    const baseHitSlop = StyleUtils.getAccessibleHitSlop(size);
-    const maxHorizontalHitSlop = Math.max(0, spacing / 2 - 1); // Leave 1px gap to prevent overlap
-    const horizontalHitSlop = Math.min(baseHitSlop, maxHorizontalHitSlop);
-
-    const hitSlop = {
-      top: baseHitSlop,
-      bottom: baseHitSlop,
-      left: horizontalHitSlop,
-      right: horizontalHitSlop
-    };
-
     return (
       <TouchableOpacity
         customValue={index}
@@ -212,7 +201,10 @@ class PageControl extends PureComponent<PageControlProps, State> {
           getColorStyle(index === currentPage, color, inactiveColor),
           getSizeStyle(size, index, currentPage, enlargeActive)
         ]}
-        hitSlop={hitSlop}
+        hitSlop={{
+          top: StyleUtils.getAccessibleHitSlop(size),
+          bottom: StyleUtils.getAccessibleHitSlop(size)
+        }}
       />
     );
   }

--- a/src/components/radioButton/index.tsx
+++ b/src/components/radioButton/index.tsx
@@ -10,6 +10,7 @@ import {
   ViewStyle
 } from 'react-native';
 import {Colors} from '../../style';
+import {StyleUtils} from '../../utils';
 import {asBaseComponent, forwardRef, BaseComponentInjectedProps, ForwardRefInjectedProps} from '../../commons/new';
 import TouchableOpacity from '../touchableOpacity';
 import View, {ViewProps} from '../view';
@@ -257,14 +258,7 @@ class RadioButton extends PureComponent<Props, RadioButtonState> {
     );
   }
 
-  getAccessibleHitSlop(size: number) {
-    const verticalPadding = Math.max(0, (48 - size) / 2);
-    
-    return {
-      top: verticalPadding,
-      bottom: verticalPadding
-    };
-  }
+
 
   render() {
     const {onPress, onValueChange, containerStyle, contentOnLeft, ...others} = this.props;
@@ -280,7 +274,10 @@ class RadioButton extends PureComponent<Props, RadioButtonState> {
         style={containerStyle}
         onPress={this.onPress}
         {...this.getAccessibilityProps()}
-        hitSlop={this.getAccessibleHitSlop(this.props.size || DEFAULT_SIZE)}
+        hitSlop={{
+          top: StyleUtils.getAccessibleHitSlop(this.props.size || DEFAULT_SIZE),
+          bottom: StyleUtils.getAccessibleHitSlop(this.props.size || DEFAULT_SIZE)
+        }}
       >
         {!contentOnLeft && this.renderButton()}
         {this.props.iconOnRight ? this.renderLabel() : this.renderIcon()}

--- a/src/components/radioButton/index.tsx
+++ b/src/components/radioButton/index.tsx
@@ -263,6 +263,7 @@ class RadioButton extends PureComponent<Props, RadioButtonState> {
   render() {
     const {onPress, onValueChange, containerStyle, contentOnLeft, ...others} = this.props;
     const Container = onPress || onValueChange ? TouchableOpacity : View;
+    const hitSlopValue = StyleUtils.getAccessibleHitSlop(this.props.size || DEFAULT_SIZE);
 
     return (
       // @ts-ignore
@@ -275,8 +276,8 @@ class RadioButton extends PureComponent<Props, RadioButtonState> {
         onPress={this.onPress}
         {...this.getAccessibilityProps()}
         hitSlop={{
-          top: StyleUtils.getAccessibleHitSlop(this.props.size || DEFAULT_SIZE),
-          bottom: StyleUtils.getAccessibleHitSlop(this.props.size || DEFAULT_SIZE)
+          top: hitSlopValue,
+          bottom: hitSlopValue
         }}
       >
         {!contentOnLeft && this.renderButton()}

--- a/src/utils/styleUtils.ts
+++ b/src/utils/styleUtils.ts
@@ -9,3 +9,7 @@ export function unpackStyle(style?: StyleProp<ViewStyle>, options: UnpackStyleOp
     return JSON.parse(JSON.stringify(options.flatten ? StyleSheet.flatten(style) : style));
   }
 }
+
+export function getAccessibleHitSlop(size: number) {
+  return Math.max(0, (48 - size) / 2);
+}


### PR DESCRIPTION
## Description
Carousel - pageControl set hitSlop as part of a11y fix.
Moved `getAccessibleHitSlop` function into `StyleUtils` to make reuse instead of duplications.

## Changelog
Carousel - pageControl set hitSlop as part of a11y fix.

## Additional info
MADS-4757
