### PR TITLE
UI-LIB scrollview fix for new arch #3775

### DIFF
--- a/lib/ios/reactnativeuilib/keyboardtrackingview/KeyboardTrackingViewTempManager.m
+++ b/lib/ios/reactnativeuilib/keyboardtrackingview/KeyboardTrackingViewTempManager.m
@@ -11,11 +11,12 @@
 #import "UIResponder+FirstResponderTemp.h"
 
 #import <WebKit/WebKit.h>
-#import <React/RCTScrollView.h>
+
 #import <React/RCTBridge.h>
 #import <React/RCTUIManager.h>
 #import <React/UIView+React.h>
 #import <React/RCTUIManagerUtils.h>
+#import <React/RCTSurfaceHostingView.h>
 
 #import <objc/runtime.h>
 
@@ -70,7 +71,7 @@ typedef NS_ENUM(NSUInteger, KeyboardTrackingScrollBehavior) {
     
     if (self)
     {
-        [self addObserver:self forKeyPath:@"bounds" options:NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew context:NULL];
+        [self addObserver:self forKeyPath:@"frame" options:NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew context:NULL];
         _inputViewsMap = [NSMapTable weakToWeakObjectsMapTable];
         _deferedInitializeAccessoryViewsCount = 0;
         
@@ -93,20 +94,21 @@ typedef NS_ENUM(NSUInteger, KeyboardTrackingScrollBehavior) {
     return self;
 }
 
--(RCTRootView*)getRootView
+-(UIView*)getRootView
 {
     UIView *view = self;
     while (view.superview != nil)
     {
         view = view.superview;
-        if ([view isKindOfClass:[RCTRootView class]])
+        if ([view isKindOfClass:[RCTSurfaceHostingView class]]) {
             break;
+        }
     }
     
-    if ([view isKindOfClass:[RCTRootView class]])
-    {
-        return (RCTRootView*)view;
+    if ([view isKindOfClass:[RCTSurfaceHostingView class]]) {
+        return view;
     }
+    
     return nil;
 }
 
@@ -169,10 +171,20 @@ typedef NS_ENUM(NSUInteger, KeyboardTrackingScrollBehavior) {
     [self updateBottomViewFrame];
 }
 
+- (UIScrollView*)extractUIScrollView:(UIView*)view
+{
+    for (UIView* subview in view.subviews) {
+        if ([subview isKindOfClass:[UIScrollView class]]) {
+            return (UIScrollView*)subview;
+        }
+    }
+    
+    return nil;
+}
+
 - (void)initializeAccessoryViewsAndHandleInsets
 {
     NSArray<UIView*>* allSubviews = [self getBreadthFirstSubviewsForView:[self getRootView]];
-    NSMutableArray<RCTScrollView*>* rctScrollViewsArray = [NSMutableArray array];
     
     for (UIView* subview in allSubviews)
     {
@@ -180,26 +192,29 @@ typedef NS_ENUM(NSUInteger, KeyboardTrackingScrollBehavior) {
         {
             if(_scrollViewToManage == nil)
             {
-                if(_requiresSameParentToManageScrollView && [subview isKindOfClass:[RCTScrollView class]] && subview.superview == self.superview)
-                {
-                    _scrollViewToManage = ((RCTScrollView*)subview).scrollView;
+                if ([NSStringFromClass([subview class]) isEqualToString:@"RCTScrollViewComponentView"]) {
+                  UIScrollView *scrollView = [self extractUIScrollView:subview];
+                  
+                    if ([scrollView isKindOfClass:[UIScrollView class]])
+                    {
+                        if(_requiresSameParentToManageScrollView && subview.superview == self.superview)
+                        {
+                          _scrollViewToManage = scrollView;
+                        }
+                        else if(!_requiresSameParentToManageScrollView)
+                        {
+                          _scrollViewToManage = scrollView;
+                        }
+                        
+                        if(_scrollViewToManage != nil)
+                        {
+                          _scrollIsInverted = CGAffineTransformEqualToTransform(subview.superview.transform, CGAffineTransformMakeScale(1, -1));
+                        }
+                    }
                 }
-                else if(!_requiresSameParentToManageScrollView && [subview isKindOfClass:[UIScrollView class]])
-                {
-                    _scrollViewToManage = (UIScrollView*)subview;
-                }
-                
-                if(_scrollViewToManage != nil)
-                {
-                    _scrollIsInverted = CGAffineTransformEqualToTransform(_scrollViewToManage.superview.transform, CGAffineTransformMakeScale(1, -1));
-                }
-            }
-            
-            if([subview isKindOfClass:[RCTScrollView class]])
-            {
-                [rctScrollViewsArray addObject:(RCTScrollView*)subview];
             }
         }
+          
         
         if ([subview isKindOfClass:NSClassFromString(@"RCTTextField")])
         {
@@ -247,13 +262,11 @@ typedef NS_ENUM(NSUInteger, KeyboardTrackingScrollBehavior) {
         }
     }
     
-    for (RCTScrollView *scrollView in rctScrollViewsArray)
+    if(_scrollViewToManage != nil)
     {
-        if(scrollView.scrollView == _scrollViewToManage)
+        if(_scrollViewToManage.delegate == nil)
         {
-            [scrollView removeScrollListener:self];
-            [scrollView addScrollListener:self];
-            break;
+            _scrollViewToManage.delegate = self;
         }
     }
     
@@ -338,12 +351,12 @@ typedef NS_ENUM(NSUInteger, KeyboardTrackingScrollBehavior) {
 
 -(void)dealloc
 {
-    [self removeObserver:self forKeyPath:@"bounds"];
+    [self removeObserver:self forKeyPath:@"frame"];
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context
 {
-    _ObservingInputAccessoryViewTemp.height = self.bounds.size.height;
+    _ObservingInputAccessoryViewTemp.height = self.frame.size.height;
 }
 
 - (void)ObservingInputAccessoryViewTempKeyboardWillDisappear:(ObservingInputAccessoryViewTemp *)ObservingInputAccessoryViewTemp


### PR DESCRIPTION
## Description
Fixing the KeyboardTrackingViewTemp object in KeyboardTrackingViewTempManager.m to comply with rn77 new arch.

## Changelog
KeyboardTrackingViewTempManager.m contains the following changes:

- -(RCTRootView*)getRootView is converted to return a RCTSurfaceHostingView as rootView
- addObserver:self forKeyPath:@"bounds" is changed to "frame" because the fabric architecture's layout engine updates the "frame" when layout changes occur. The "bounds" was only called once and prematurely.
- Changes done in - (void)initializeAccessoryViewsAndHandleInsets to handle the ScrollView components according to new arch where it is wrapped in the RCTScrollViewComponentView class.


