### PR TITLE
Pass on avatar accessibility label

### DIFF
--- a/src/components/avatar/index.tsx
+++ b/src/components/avatar/index.tsx
@@ -360,7 +360,13 @@ const Avatar = forwardRef<any, AvatarProps>((props: AvatarProps, ref: React.Forw
     >
       <View testID={`${testID}.container`} style={textContainerStyle}>
         {!_.isUndefined(text) && (
-          <Text numberOfLines={1} ellipsizeMode={labelEllipsizeMode} style={textStyle} testID={`${testID}.label`}>
+          <Text
+            numberOfLines={1}
+            ellipsizeMode={labelEllipsizeMode}
+            style={textStyle}
+            testID={`${testID}.label`}
+            accessibilityLabel={accessibilityProps?.accessibilityLabel}
+          >
             {text}
           </Text>
         )}


### PR DESCRIPTION
## Description
When the user pass a custom accessibility label (when avatar is NOT clickable) we are ignoring it because the reader just read the avatar text. 
This pass on the label to the Avatar text to give the user more control

## Changelog
Fix Avatar custom accessibility label when Avatar is not clickable 

## Additional info
<!--
If applicable, add additional info such as link to the bug being fixed by this PR etc
-->
