### PR TITLE
feat(Button): add customBackground prop for custom background elements

### DIFF
--- a/demo/src/screens/componentScreens/ButtonsScreen.tsx
+++ b/demo/src/screens/componentScreens/ButtonsScreen.tsx
@@ -296,12 +296,15 @@ export default class ButtonsScreen extends Component {
               label="Image Background"
               customBackground={
                 <Image
-                  source={{uri: 'https://picsum.photos/300'}}
+                  source={{
+                    uri: 'https://images.pexels.com/photos/748837/pexels-photo-748837.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260'
+                  }}
                   style={{width: 200, height: 50}}
                   resizeMode="cover"
                 />
               }
               style={{marginBottom: ButtonSpace}}
+              $textNeutralHeavy
             />
           </View>
 

--- a/demo/src/screens/componentScreens/ButtonsScreen.tsx
+++ b/demo/src/screens/componentScreens/ButtonsScreen.tsx
@@ -1,6 +1,17 @@
 import React, {Component} from 'react';
-import {ScrollView, StyleSheet, Alert, Image} from 'react-native';
-import {Text, View, Assets, Constants, Button, Colors, Typography, ButtonProps} from 'react-native-ui-lib';
+import {ScrollView, StyleSheet, Alert} from 'react-native';
+import {
+  Text,
+  View,
+  Assets,
+  Constants,
+  Button,
+  Colors,
+  Typography,
+  ButtonProps,
+  Incubator,
+  Image
+} from 'react-native-ui-lib';
 
 const ButtonSpace = 20;
 const plusIcon = Assets.getAssetByPath('icons.demo.plus');
@@ -267,6 +278,31 @@ export default class ButtonsScreen extends Component {
             <Button label="hyperlink button" hyperlink style={{marginBottom: ButtonSpace}}/>
 
             <Button label="Icon on right" iconSource={plusIcon} iconOnRight/>
+
+            <Text style={styles.header}>Custom Backgrounds</Text>
+            <Button
+              label="Gradient Background"
+              customBackground={
+                <Incubator.Gradient
+                  colors={[Colors.$backgroundPrimaryHeavy, Colors.$backgroundPrimaryMedium]}
+                  type="rectangle"
+                  width={200}
+                  height={50}
+                />
+              }
+              style={{marginBottom: ButtonSpace}}
+            />
+            <Button
+              label="Image Background"
+              customBackground={
+                <Image
+                  source={{uri: 'https://picsum.photos/300'}}
+                  style={{width: 200, height: 50}}
+                  resizeMode="cover"
+                />
+              }
+              style={{marginBottom: ButtonSpace}}
+            />
           </View>
 
           <View marginT-20>

--- a/src/components/button/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/button/__tests__/__snapshots__/index.spec.js.snap
@@ -2292,6 +2292,272 @@ exports[`Button container size should return style for xSmall button 2`] = `
 </View>
 `;
 
+exports[`Button customBackground should render button with custom background element 1`] = `
+<View
+  accessibilityRole="button"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  hitSlop={
+    {
+      "bottom": 7.5,
+      "left": 0,
+      "right": 0,
+      "top": 7.5,
+    }
+  }
+  onClick={[Function]}
+  onLayout={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    {
+      "alignItems": "center",
+      "backgroundColor": "transparent",
+      "borderRadius": 999,
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "minWidth": 90,
+      "opacity": 1,
+      "paddingHorizontal": 20,
+      "paddingVertical": 9.5,
+    }
+  }
+>
+  <View
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "overflow": "hidden",
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "borderRadius": 999,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        [
+          undefined,
+          undefined,
+          undefined,
+          {
+            "flex": 1,
+          },
+          undefined,
+          {},
+          {},
+          {},
+          {
+            "backgroundColor": "red",
+          },
+        ]
+      }
+    />
+  </View>
+  <Text
+    fsTagName="unmask"
+    numberOfLines={1}
+    style={
+      [
+        {
+          "backgroundColor": "transparent",
+          "color": "#20303C",
+          "writingDirection": "ltr",
+        },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        [
+          {
+            "backgroundColor": "transparent",
+            "flexDirection": "row",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": "400",
+            "lineHeight": 24,
+          },
+          {
+            "color": "#FFFFFF",
+          },
+          undefined,
+          undefined,
+          undefined,
+        ],
+      ]
+    }
+    testID="undefined.label"
+  >
+    Button
+  </Text>
+</View>
+`;
+
+exports[`Button customBackground should render custom background element with transparent backgroundColor when provided 1`] = `
+<View
+  accessibilityRole="button"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  hitSlop={
+    {
+      "bottom": 7.5,
+      "left": 0,
+      "right": 0,
+      "top": 7.5,
+    }
+  }
+  onClick={[Function]}
+  onLayout={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    {
+      "alignItems": "center",
+      "backgroundColor": "transparent",
+      "borderRadius": 999,
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "minWidth": 90,
+      "opacity": 1,
+      "paddingHorizontal": 20,
+      "paddingVertical": 9.5,
+    }
+  }
+>
+  <View
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "overflow": "hidden",
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "borderRadius": 999,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        [
+          undefined,
+          undefined,
+          undefined,
+          {
+            "flex": 1,
+          },
+          undefined,
+          {},
+          {},
+          {},
+          {
+            "backgroundColor": "blue",
+          },
+        ]
+      }
+    />
+  </View>
+  <Text
+    fsTagName="unmask"
+    numberOfLines={1}
+    style={
+      [
+        {
+          "backgroundColor": "transparent",
+          "color": "#20303C",
+          "writingDirection": "ltr",
+        },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        [
+          {
+            "backgroundColor": "transparent",
+            "flexDirection": "row",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": "400",
+            "lineHeight": 24,
+          },
+          {
+            "color": "#FFFFFF",
+          },
+          undefined,
+          undefined,
+          undefined,
+        ],
+      ]
+    }
+    testID="undefined.label"
+  >
+    Button
+  </Text>
+</View>
+`;
+
 exports[`Button hyperlink should render button as a hyperlink 1`] = `
 <View
   accessibilityRole="button"

--- a/src/components/button/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/components/button/__tests__/__snapshots__/index.spec.js.snap
@@ -2334,7 +2334,7 @@ exports[`Button customBackground should render button with custom background ele
   style={
     {
       "alignItems": "center",
-      "backgroundColor": "transparent",
+      "backgroundColor": undefined,
       "borderRadius": 999,
       "flexDirection": "row",
       "justifyContent": "center",
@@ -2346,19 +2346,31 @@ exports[`Button customBackground should render button with custom background ele
   }
 >
   <View
+    absF={true}
     style={
       [
+        undefined,
+        undefined,
+        undefined,
+        undefined,
         {
           "bottom": 0,
           "left": 0,
-          "overflow": "hidden",
           "position": "absolute",
           "right": 0,
           "top": 0,
         },
-        {
-          "borderRadius": 999,
-        },
+        {},
+        {},
+        {},
+        [
+          {
+            "overflow": "hidden",
+          },
+          {
+            "borderRadius": 999,
+          },
+        ],
       ]
     }
   >
@@ -2467,7 +2479,7 @@ exports[`Button customBackground should render custom background element with tr
   style={
     {
       "alignItems": "center",
-      "backgroundColor": "transparent",
+      "backgroundColor": undefined,
       "borderRadius": 999,
       "flexDirection": "row",
       "justifyContent": "center",
@@ -2479,19 +2491,31 @@ exports[`Button customBackground should render custom background element with tr
   }
 >
   <View
+    absF={true}
     style={
       [
+        undefined,
+        undefined,
+        undefined,
+        undefined,
         {
           "bottom": 0,
           "left": 0,
-          "overflow": "hidden",
           "position": "absolute",
           "right": 0,
           "top": 0,
         },
-        {
-          "borderRadius": 999,
-        },
+        {},
+        {},
+        {},
+        [
+          {
+            "overflow": "hidden",
+          },
+          {
+            "borderRadius": 999,
+          },
+        ],
       ]
     }
   >

--- a/src/components/button/__tests__/index.spec.js
+++ b/src/components/button/__tests__/index.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import Button from '../index';
+import View from '../../view';
 import {Colors, ThemeManager} from '../../../style';
 import {Constants} from '../../../commons';
 
@@ -228,6 +229,20 @@ describe('Button', () => {
 
     it('should return style for round button', () => {
       expect(renderer.create(<Button label="Button" round/>).toJSON()).toMatchSnapshot();
+    });
+  });
+
+  describe('customBackground', () => {
+    it('should render button with custom background element', () => {
+      const CustomBackground = () => <View flex style={{backgroundColor: 'red'}}/>;
+      const tree = renderer.create(<Button label="Button" customBackground={<CustomBackground/>}/>).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should render custom background element with transparent backgroundColor when provided', () => {
+      const CustomBackground = () => <View flex style={{backgroundColor: 'blue'}}/>;
+      const tree = renderer.create(<Button label="Button" backgroundColor="green" customBackground={<CustomBackground/>}/>).toJSON();
+      expect(tree).toMatchSnapshot();
     });
   });
 

--- a/src/components/button/button.api.json
+++ b/src/components/button/button.api.json
@@ -161,6 +161,11 @@
       "name": "animateTo",
       "type": "ButtonAnimationDirection",
       "description": "the direction of the animation ('left' and 'right' will effect the button's own alignment)"
+    },
+    {
+      "name": "customBackground",
+      "type": "React.ReactElement",
+      "description": "Custom element to render as button background (takes precedence over backgroundColor)"
     }
   ],
   "snippet": [

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -1,18 +1,10 @@
 import _ from 'lodash';
 import React, {PureComponent} from 'react';
-import {
-  Platform,
-  StyleSheet,
-  LayoutAnimation,
-  LayoutChangeEvent,
-  ImageStyle,
-  TextStyle,
-  StyleProp,
-  View
-} from 'react-native';
+import {Platform, StyleSheet, LayoutAnimation, LayoutChangeEvent, ImageStyle, TextStyle, StyleProp} from 'react-native';
 import {asBaseComponent, forwardRef, Constants} from '../../commons/new';
 import {Colors, Typography, BorderRadiuses} from 'style';
 import TouchableOpacity from '../touchableOpacity';
+import View from '../view';
 import type {Dictionary, ComponentStatics} from '../../typings/common';
 import Text from '../text';
 import Icon from '../icon';
@@ -376,7 +368,11 @@ class Button extends PureComponent<Props, ButtonState> {
 
     if (customBackground) {
       const borderRadiusStyle = this.getBorderRadiusStyle();
-      return <View style={[this.styles.backgroundElement, borderRadiusStyle]}>{customBackground}</View>;
+      return (
+        <View absF style={[this.styles.backgroundElement, borderRadiusStyle]}>
+          {customBackground}
+        </View>
+      );
     }
   }
 
@@ -395,7 +391,7 @@ class Button extends PureComponent<Props, ButtonState> {
     } = this.props;
     const shadowStyle = this.getShadowStyle();
     const {margins, paddings} = modifiers;
-    const backgroundColor = customBackground ? 'transparent' : this.getBackgroundColor();
+    const backgroundColor = customBackground ? undefined : this.getBackgroundColor();
     const outlineStyle = this.getOutlineStyle();
     const containerSizeStyle = this.getContainerSizeStyle();
     const borderRadiusStyle = this.getBorderRadiusStyle();
@@ -462,11 +458,6 @@ function createStyles() {
       ...Typography.text70
     },
     backgroundElement: {
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      right: 0,
-      bottom: 0,
       overflow: 'hidden'
     }
   });

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -1,6 +1,15 @@
 import _ from 'lodash';
 import React, {PureComponent} from 'react';
-import {Platform, StyleSheet, LayoutAnimation, LayoutChangeEvent, ImageStyle, TextStyle, StyleProp} from 'react-native';
+import {
+  Platform,
+  StyleSheet,
+  LayoutAnimation,
+  LayoutChangeEvent,
+  ImageStyle,
+  TextStyle,
+  StyleProp,
+  View
+} from 'react-native';
 import {asBaseComponent, forwardRef, Constants} from '../../commons/new';
 import {Colors, Typography, BorderRadiuses} from 'style';
 import TouchableOpacity from '../touchableOpacity';
@@ -362,6 +371,15 @@ class Button extends PureComponent<Props, ButtonState> {
     };
   }
 
+  renderCustomBackground() {
+    const {customBackground} = this.props;
+
+    if (customBackground) {
+      const borderRadiusStyle = this.getBorderRadiusStyle();
+      return <View style={[this.styles.backgroundElement, borderRadiusStyle]}>{customBackground}</View>;
+    }
+  }
+
   render() {
     const {
       onPress,
@@ -372,11 +390,12 @@ class Button extends PureComponent<Props, ButtonState> {
       modifiers,
       forwardedRef,
       hitSlop: hitSlopProp,
+      customBackground,
       ...others
     } = this.props;
     const shadowStyle = this.getShadowStyle();
     const {margins, paddings} = modifiers;
-    const backgroundColor = this.getBackgroundColor();
+    const backgroundColor = customBackground ? 'transparent' : this.getBackgroundColor();
     const outlineStyle = this.getOutlineStyle();
     const containerSizeStyle = this.getContainerSizeStyle();
     const borderRadiusStyle = this.getBorderRadiusStyle();
@@ -408,6 +427,7 @@ class Button extends PureComponent<Props, ButtonState> {
         {...others}
         ref={forwardedRef}
       >
+        {this.renderCustomBackground()}
         {this.props.children}
         {this.props.iconOnRight ? this.renderLabel() : this.renderIcon()}
         {this.props.iconOnRight ? this.renderIcon() : this.renderLabel()}
@@ -440,6 +460,14 @@ function createStyles() {
       backgroundColor: 'transparent',
       flexDirection: 'row',
       ...Typography.text70
+    },
+    backgroundElement: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      overflow: 'hidden'
     }
   });
 }

--- a/src/components/button/types.ts
+++ b/src/components/button/types.ts
@@ -153,6 +153,10 @@ export type ButtonProps = TouchableOpacityProps &
      * the direction of the animation ('left' and 'right' will effect the button's own alignment)
      */
     animateTo?: ButtonAnimationDirectionProp;
+    /**
+     * Custom element to render as button background (takes precedence over backgroundColor)
+     */
+    customBackground?: React.ReactElement;
   };
 
 export type ButtonState = {


### PR DESCRIPTION
## Description
New `customBackground` prop to the Button component that allows users to render custom React elements as button backgrounds.
This prop takes precedence over the `backgroundColor`.

## Changelog
Button - Added `customBackground` prop to enable custom background elements

## Additional info
N/A
