### PR TITLE
Bug Fix: fix missing extractAccessibilityProps on ProgressBar

### DIFF
--- a/src/components/progressBar/index.tsx
+++ b/src/components/progressBar/index.tsx
@@ -94,7 +94,7 @@ class ProgressBar extends PureComponent<Props, State> {
       return {
         accessible: true,
         accessibilityLabel: `progress bar. ${Math.round(progress)}%`,
-        ...extractAccessibilityProps()
+        ...extractAccessibilityProps(this.props)
       };
     }
   }


### PR DESCRIPTION
## Description
After upgrading to Expo SDK 54 and react native 19, Progress bar is giving an error : [TypeError: Cannot read property 'props' of undefined] on line ...extractAccessibilityProps() in getAccessibilityProps()

Followed the same pattern from throughout the repo when calling ...extractAccessibilityProps() by passing in the props as a parameter

## Changelog
⚠️ ProgressBar - fix undefined error on extractAccessibilityProps

## Additional info
#3810 
