### PR TITLE
Incubator.Toast - change default zIndex to 100 for iOS as well

### DIFF
--- a/src/incubator/toast/index.tsx
+++ b/src/incubator/toast/index.tsx
@@ -29,7 +29,7 @@ const Toast = (props: PropsWithChildren<ToastProps>) => {
     icon,
     iconColor,
     preset,
-    zIndex = Constants.isAndroid ? 100 : undefined,
+    zIndex = 100,
     elevation,
     style,
     containerStyle,


### PR DESCRIPTION
## Description
Incubator.Toast - change default zIndex to 100 for iOS as well

## Changelog
Incubator.Toast - change default zIndex to 100 for iOS as well

## Additional info
None
