### PR TITLE
actionSheet content shrink bug

### DIFF
--- a/packages/react-native-ui-lib/src/commons/withScrollEnabler.tsx
+++ b/packages/react-native-ui-lib/src/commons/withScrollEnabler.tsx
@@ -26,10 +26,8 @@ function withScrollEnabler<PROPS, STATICS = {}>(WrappedComponent: React.Componen
 
     const checkScroll = useCallback(() => {
       const isScrollEnabled = Math.floor(contentSize.current) > layoutSize.current;
-      if (isScrollEnabled !== scrollEnabled) {
-        setScrollEnabled(isScrollEnabled);
-      }
-    }, [scrollEnabled]);
+      setScrollEnabled(isScrollEnabled);
+    }, []);
 
     const onContentSizeChange = useCallback((contentWidth: number, contentHeight: number) => {
       const size = props.horizontal ? contentWidth : contentHeight;


### PR DESCRIPTION
## Description
to allow 2-lines options on actionSheet, we made a change in private to actionSheet. but that has created a new bug with content shrinking in actionSheet. This PR fixes that.

Bugs that this fixed can be seen in more detail in the relevant ticket.

## Changelog
WithScrollEnabler - removed redundant condition.

## Additional info
Ticket 2893