### PR TITLE
Update release script to include --legacy-peer-deps

### DIFF
--- a/packages/react-native-ui-lib/scripts/release/release.js
+++ b/packages/react-native-ui-lib/scripts/release/release.js
@@ -86,8 +86,10 @@ function tryPublishAndTag(version) {
 
 function tagAndPublish(newVersion) {
   console.log(`trying to publish ${newVersion}...`);
-  exec.execSync(`npm --no-git-tag-version version ${newVersion}`);
-  exec.execSync(`npm publish --tag ${VERSION_TAG}`);
+  // Add --legacy-peer-deps here to bypass the ERESOLVE error
+  exec.execSync(`npm --no-git-tag-version version ${newVersion} --legacy-peer-deps`);
+  // It is also safer to add it to the publish command
+  exec.execSync(`npm publish --tag ${VERSION_TAG} --legacy-peer-deps`);
   if (isRelease) {
     exec.execSync(`git tag -a ${newVersion} -m "${newVersion}"`);
   }


### PR DESCRIPTION
## Description
Update release script to include --legacy-peer-deps

IMPORTANT when reverting this we need to make sure we move build:local to use yarn as well, so we properly test it
Also look at https://github.com/wix/react-native-ui-lib/commit/72f48233510de76769ea3445ce853f25ccf38903

## Changelog
Update release script to include --legacy-peer-deps

## Additional info
N/A