### PR TITLE
Enable prop overrides for SearchInput

### DIFF
--- a/packages/react-native-ui-lib/src/components/searchInput/index.tsx
+++ b/packages/react-native-ui-lib/src/components/searchInput/index.tsx
@@ -29,7 +29,6 @@ const SearchInput = forwardRef((props: SearchInputProps, ref: ForwardedRef<any>)
     value: controlledValue,
     onChangeText,
     onClear,
-    containerStyle,
     customRightElement,
     style,
     inaccessible
@@ -101,7 +100,6 @@ const SearchInput = forwardRef((props: SearchInputProps, ref: ForwardedRef<any>)
   };
 
   const onChangeTextHandler = (text: string) => {
-    console.log(`onChangeTextHandler, text:`, text);
     onChangeText?.(text);
     setValue(text);
     setHasValue(!_.isEmpty(text));
@@ -153,16 +151,16 @@ const SearchInput = forwardRef((props: SearchInputProps, ref: ForwardedRef<any>)
           color={invertColors ? INVERTED_TEXT_COLOR : undefined}
           $textDefault
           text65M
-          {...cancelButtonProps}
           onPress={onDismiss}
           testID={`${testID}.cancelButton`}
+          {...cancelButtonProps}
         />
       );
     }
   };
 
   const renderTextInput = () => {
-    const {placeholder} = props;
+    const {containerStyle, ...others} = props;
     const height = getHeight();
     const placeholderTextColor = invertColors ? INVERTED_TEXT_COLOR : Colors.$textDefault;
     const selectionColor = invertColors ? INVERTED_TEXT_COLOR : Colors.$textDefault;
@@ -170,10 +168,11 @@ const SearchInput = forwardRef((props: SearchInputProps, ref: ForwardedRef<any>)
       <View style={[styles.inputContainer, {height}]}>
         <TextInput
           accessibilityRole={'search'}
-          placeholder={placeholder}
+          placeholder={others.placeholder}
           placeholderTextColor={placeholderTextColor}
           underlineColorAndroid="transparent"
           selectionColor={selectionColor}
+          {...others}
           ref={searchInputRef}
           value={value}
           allowFontScaling={false}

--- a/packages/react-native-ui-lib/src/components/searchInput/types.ts
+++ b/packages/react-native-ui-lib/src/components/searchInput/types.ts
@@ -12,7 +12,7 @@ export interface SearchInputRef {
   focus: () => void;
 }
 
-export type SearchInputProps = TextInputProps & {
+export type SearchInputSpecificProps = {
   /**
    * On clear button callback.
    */
@@ -66,3 +66,5 @@ export type SearchInputProps = TextInputProps & {
    */
   preset?: SearchInputPresets | `${SearchInputPresets}`;
 };
+
+export type SearchInputProps = Omit<TextInputProps, 'style' | 'ref'> & SearchInputSpecificProps;


### PR DESCRIPTION
## Description
Fixes prop override issues in SearchInput component.
Simplified renderTextInput to match the private component pattern by destructuring only containerStyle and spreading {...others} to pass all TextInput props through.
All changes are backward compatible - existing props continue to work as before.

## Changelog
SearchInput - Fixed prop override support for cancelButtonProps and all TextInput props. Cancel button props can now override defaults, and all TextInput props pass through correctly.

## Additional info
N/A
