### PR TITLE
fix/added an update to targetLayout for each change in targ…

### DIFF
--- a/packages/react-native-ui-lib/src/components/hint/hooks/useHintLayout.ts
+++ b/packages/react-native-ui-lib/src/components/hint/hooks/useHintLayout.ts
@@ -1,4 +1,4 @@
-import {type ElementRef, useState, useCallback, useRef} from 'react';
+import {type ElementRef, useState, useCallback, useRef, useEffect} from 'react';
 import type {LayoutChangeEvent, LayoutRectangle, View as RNView} from 'react-native';
 import _ from 'lodash';
 import {HintProps} from '../types';
@@ -10,6 +10,14 @@ export default function useHintLayout({onBackgroundPress, targetFrame}: UseHintL
   const [targetLayoutInWindowState, setTargetLayoutInWindow] = useState<LayoutRectangle | undefined>(targetFrame);
   const [hintMessageWidth, setHintMessageWidth] = useState<number | undefined>();
   const targetRef = useRef<ElementRef<typeof RNView> | null>(null);
+
+  useEffect(() => {
+    if (targetFrame && !_.isEqual(targetFrame, targetLayoutState)) {
+      setTargetLayout(targetFrame);
+      setTargetLayoutInWindow(targetFrame);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [targetFrame]);
 
   const onTargetLayout = useCallback(({nativeEvent: {layout}}: LayoutChangeEvent) => {
     if (!_.isEqual(targetLayoutState, layout)) {


### PR DESCRIPTION
## Description
Hint - fix targetFrame prop not updating after mount
When targetFrame is passed as a prop, useHintLayout stored it only as the useState initial value, so any changes after mount were ignored. Added a useEffect to sync internal state when targetFrame changes.

## Changelog
Hint - targetFrame prop now correctly repositions when updated after mount

## Additional info
None