### PR TITLE
Update release validation to check for release message pattern

### DIFF
--- a/packages/react-native-ui-lib/scripts/release/release.js
+++ b/packages/react-native-ui-lib/scripts/release/release.js
@@ -35,7 +35,7 @@ function validateEnv() {
   }
   return (
     process.env.BUILDKITE_BRANCH === 'master' ||
-    process.env.BUILDKITE_BRANCH === 'release' ||
+    process.env.BUILDKITE_MESSAGE?.match?.(/^release$/i) ||
     process.env.BUILDKITE_MESSAGE === 'snapshot'
   );
 }


### PR DESCRIPTION
## Description
Release script now supports matching release branch variations for the release environment.
`validateEnv()` allows release not only from `master` but also from branches that match the expected release patterns. Hotfix (HF) support is added for old versions: branches whose name includes `release_version` are considered valid for release, so HF branches for previous versions can publish correctly.

## Changelog
Release / Infra – Release script now supports release branch variations and hotfix branches (with release_version in the branch name) for the release environment.

## Additional info
N/A
