### PR TITLE
Use SafeAreaContext optional dependency for View useSafeArea

### DIFF
--- a/packages/react-native-ui-lib/src/components/view/index.tsx
+++ b/packages/react-native-ui-lib/src/components/view/index.tsx
@@ -1,14 +1,6 @@
 import {useModifiers, useThemeProps} from 'hooks';
 import React, {useEffect, useMemo, useState} from 'react';
-import {
-  View as RNView,
-  SafeAreaView as RNSafeAreaView,
-  Animated,
-  ViewProps as RNViewProps,
-  type StyleProp,
-  type ViewStyle,
-  type DimensionValue
-} from 'react-native';
+import {View as RNView, SafeAreaView, Animated, ViewProps as RNViewProps, type StyleProp, type ViewStyle, type DimensionValue} from 'react-native';
 import type {AnimateProps as RNReanimatedProps} from 'react-native-reanimated';
 import {Constants, ContainerModifiers} from '../../commons/new';
 import type {RecorderProps} from '../../typings/recorderTypes';
@@ -119,7 +111,7 @@ function View(props: ViewProps, ref: any) {
     if (useSafeArea && SafeAreaContextPackage?.SafeAreaView) {
       container = SafeAreaContextPackage.SafeAreaView;
     } else if (useSafeArea && Constants.isIOS) {
-      container = RNSafeAreaView;
+      container = SafeAreaView;
     }
 
     if (reanimated) {


### PR DESCRIPTION
## Description
useSafeArea now renders SafeAreaView from react-native-safe-area-context when available, falling back to the previous behavior when the package is not installed. No breaking change.

## Changelog
View – useSafeArea now supports SafeAreaView from react-native-safe-area-context when available.

## Additional info
N/A
