### PR TITLE
Remove react-native-safe-area-context from peerDeps

### DIFF
--- a/packages/react-native-ui-lib/package.json
+++ b/packages/react-native-ui-lib/package.json
@@ -112,7 +112,6 @@
         "react-native": ">=0.77.3",
         "react-native-gesture-handler": ">=2.24.0",
         "react-native-reanimated": ">=3.17.5",
-        "react-native-safe-area-context": ">=5.6.2",
         "uilib-native": "^5.0.1"
     },
     "jest": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9698,7 +9698,6 @@ __metadata:
     react-native: ">=0.77.3"
     react-native-gesture-handler: ">=2.24.0"
     react-native-reanimated: ">=3.17.5"
-    react-native-safe-area-context: ">=5.6.2"
     uilib-native: ^5.0.1
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description
Remove react-native-safe-area-context from peerDeps

## Changelog
None

## Additional info
None