### PR TITLE
Migrate FloatingButton to use new ScreenFooter component internally

### DIFF
--- a/demo/src/screens/componentScreens/FloatingButtonScreen.tsx
+++ b/demo/src/screens/componentScreens/FloatingButtonScreen.tsx
@@ -1,6 +1,7 @@
 import React, {Component} from 'react';
 import {View, StyleSheet, Alert, ScrollView} from 'react-native';
-import {Colors, Text, FloatingButton, FloatingButtonLayouts, Keyboard} from 'react-native-ui-lib';
+import {SafeAreaProvider} from 'react-native-safe-area-context';
+import {Colors, Text, TextField, FloatingButton, FloatingButtonLayouts} from 'react-native-ui-lib';
 import {renderBooleanOption} from '../ExampleScreenPresenter';
 
 interface State {
@@ -8,7 +9,7 @@ interface State {
   showPrimary: boolean;
   showSecondary: boolean;
   showVertical: boolean;
-  withTrackingView: boolean;
+  hoisted: boolean;
 }
 
 export default class FloatingButtonScreen extends Component<{}, State> {
@@ -18,7 +19,7 @@ export default class FloatingButtonScreen extends Component<{}, State> {
     showSecondary: true,
     showVertical: true,
     fullWidth: false,
-    withTrackingView: false
+    hoisted: true
   };
 
   notNow = () => {
@@ -32,72 +33,64 @@ export default class FloatingButtonScreen extends Component<{}, State> {
   };
 
   render() {
-    const {showSecondary, showVertical, withTrackingView} = this.state;
-    const Container = withTrackingView ? Keyboard.KeyboardTrackingView : React.Fragment;
+    const {showSecondary, showVertical, hoisted} = this.state;
     return (
-      <View style={styles.container}>
-        <Text text60 center $textDefault marginB-s4>
-          Trigger Floating Button
-        </Text>
-        {renderBooleanOption.call(this, 'Show Floating Button', 'showButton')}
-        {renderBooleanOption.call(this, 'Full Width Button', 'fullWidth')}
-        {renderBooleanOption.call(this, 'Show Primary Button', 'showPrimary')}
-        {renderBooleanOption.call(this, 'Show Secondary Button', 'showSecondary')}
-        {renderBooleanOption.call(this, 'Button Layout Vertical', 'showVertical')}
-        {renderBooleanOption.call(this, 'With tracking view', 'withTrackingView')}
-
-        <ScrollView showsVerticalScrollIndicator={false}>
-          <View paddingT-20>
-            <Text text70 $textDefault style={{fontWeight: 'bold'}}>
-              Scroll behind a FloatingButton
+      <SafeAreaProvider>
+        <View style={styles.container}>
+            <Text text60 center $textDefault marginB-s4>
+              Trigger Floating Button
             </Text>
-            <Text text80 $textDefault marginT-10 style={{lineHeight: 24}}>
-              Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
-              industry standard dummy text ever since the 1500s, when an unknown printer took a galley of type and
-              scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into
-              electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release
-              of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software
-              like Aldus PageMaker including versions of Lorem Ipsum. Contrary to popular belief, Lorem Ipsum is not
-              simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000
-              years old. Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been
-              the industry standard dummy text ever since the 1500s, when an unknown printer took a galley of type and
-              scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into
-              electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release
-              of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software
-              like Aldus PageMaker including versions of Lorem Ipsum. Contrary to popular belief, Lorem Ipsum is not
-              simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000
-              years old.
-            </Text>
-          </View>
-        </ScrollView>
+            {renderBooleanOption.call(this, 'Show Floating Button', 'showButton')}
+            {renderBooleanOption.call(this, 'Full Width Button', 'fullWidth')}
+            {renderBooleanOption.call(this, 'Show Primary Button', 'showPrimary')}
+            {renderBooleanOption.call(this, 'Show Secondary Button', 'showSecondary')}
+            {renderBooleanOption.call(this, 'Button Layout Vertical', 'showVertical')}
+            {renderBooleanOption.call(this, 'Hoisted (keyboard-aware)', 'hoisted')}
 
-        <Container>
-          <FloatingButton
-            visible={this.state.showButton}
-            fullWidth={this.state.fullWidth}
-            button={
-              this.state.showPrimary
-                ? {
-                  label: 'Approve',
-                  onPress: this.close
-                }
-                : undefined
-            }
-            secondaryButton={
-              showSecondary
-                ? {
-                  label: 'Not now',
-                  onPress: this.notNow
-                }
-                : undefined
-            }
-            buttonLayout={showVertical ? FloatingButtonLayouts.VERTICAL : FloatingButtonLayouts.HORIZONTAL}
-            // bottomMargin={80}
-            // hideBackgroundOverlay
-            // withoutAnimation
-          />
-        </Container>
-      </View>
+            <TextField migrate placeholder="Tap to test keyboard hoisting" marginB-s4/>
+
+            <ScrollView showsVerticalScrollIndicator={false} keyboardDismissMode="on-drag" keyboardShouldPersistTaps="handled">
+              <View paddingT-20>
+                <Text text70 $textDefault style={{fontWeight: 'bold'}}>
+                  Scroll behind a FloatingButton
+                </Text>
+                <Text text80 $textDefault marginT-10 style={{lineHeight: 24}}>
+                  Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
+                  industry standard dummy text ever since the 1500s, when an unknown printer took a galley of type and
+                  scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap
+                  into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the
+                  release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing
+                  software like Aldus PageMaker including versions of Lorem Ipsum. Contrary to popular belief, Lorem
+                  Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC,
+                  making it over 2000 years old.
+                </Text>
+              </View>
+            </ScrollView>
+
+            <FloatingButton
+              visible={this.state.showButton}
+              fullWidth={this.state.fullWidth}
+              button={
+                this.state.showPrimary
+                  ? {
+                    label: 'Approve',
+                    onPress: this.close
+                  }
+                  : undefined
+              }
+              secondaryButton={
+                showSecondary
+                  ? {
+                    label: 'Not now',
+                    onPress: this.notNow
+                  }
+                  : undefined
+              }
+              buttonLayout={showVertical ? FloatingButtonLayouts.VERTICAL : FloatingButtonLayouts.HORIZONTAL}
+              hoisted={hoisted}
+            />
+        </View>
+      </SafeAreaProvider>
     );
   }
 }

--- a/demo/src/screens/componentScreens/FloatingButtonScreen.tsx
+++ b/demo/src/screens/componentScreens/FloatingButtonScreen.tsx
@@ -37,58 +37,62 @@ export default class FloatingButtonScreen extends Component<{}, State> {
     return (
       <SafeAreaProvider>
         <View style={styles.container}>
-            <Text text60 center $textDefault marginB-s4>
-              Trigger Floating Button
-            </Text>
-            {renderBooleanOption.call(this, 'Show Floating Button', 'showButton')}
-            {renderBooleanOption.call(this, 'Full Width Button', 'fullWidth')}
-            {renderBooleanOption.call(this, 'Show Primary Button', 'showPrimary')}
-            {renderBooleanOption.call(this, 'Show Secondary Button', 'showSecondary')}
-            {renderBooleanOption.call(this, 'Button Layout Vertical', 'showVertical')}
-            {renderBooleanOption.call(this, 'Hoisted (keyboard-aware)', 'hoisted')}
+          <Text text60 center $textDefault marginB-s4>
+            Trigger Floating Button
+          </Text>
+          {renderBooleanOption.call(this, 'Show Floating Button', 'showButton')}
+          {renderBooleanOption.call(this, 'Full Width Button', 'fullWidth')}
+          {renderBooleanOption.call(this, 'Show Primary Button', 'showPrimary')}
+          {renderBooleanOption.call(this, 'Show Secondary Button', 'showSecondary')}
+          {renderBooleanOption.call(this, 'Button Layout Vertical', 'showVertical')}
+          {renderBooleanOption.call(this, 'Hoisted (keyboard-aware)', 'hoisted')}
 
-            <TextField migrate placeholder="Tap to test keyboard hoisting" marginB-s4/>
+          <TextField migrate placeholder="Tap to test keyboard hoisting" marginB-s4 />
 
-            <ScrollView showsVerticalScrollIndicator={false} keyboardDismissMode="on-drag" keyboardShouldPersistTaps="handled">
-              <View paddingT-20>
-                <Text text70 $textDefault style={{fontWeight: 'bold'}}>
-                  Scroll behind a FloatingButton
-                </Text>
-                <Text text80 $textDefault marginT-10 style={{lineHeight: 24}}>
-                  Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
-                  industry standard dummy text ever since the 1500s, when an unknown printer took a galley of type and
-                  scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap
-                  into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the
-                  release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing
-                  software like Aldus PageMaker including versions of Lorem Ipsum. Contrary to popular belief, Lorem
-                  Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC,
-                  making it over 2000 years old.
-                </Text>
-              </View>
-            </ScrollView>
+          <ScrollView
+            showsVerticalScrollIndicator={false}
+            keyboardDismissMode="on-drag"
+            keyboardShouldPersistTaps="handled"
+          >
+            <View paddingT-20>
+              <Text text70 $textDefault style={{fontWeight: 'bold'}}>
+                Scroll behind a FloatingButton
+              </Text>
+              <Text text80 $textDefault marginT-10 style={{lineHeight: 24}}>
+                Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
+                industry standard dummy text ever since the 1500s, when an unknown printer took a galley of type and
+                scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap
+                into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the
+                release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing
+                software like Aldus PageMaker including versions of Lorem Ipsum. Contrary to popular belief, Lorem Ipsum
+                is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it
+                over 2000 years old.
+              </Text>
+            </View>
+          </ScrollView>
 
-            <FloatingButton
-              visible={this.state.showButton}
-              fullWidth={this.state.fullWidth}
-              button={
-                this.state.showPrimary
-                  ? {
+          <FloatingButton
+            visible={this.state.showButton}
+            fullWidth={this.state.fullWidth}
+            button={
+              this.state.showPrimary
+                ? {
                     label: 'Approve',
                     onPress: this.close
                   }
-                  : undefined
-              }
-              secondaryButton={
-                showSecondary
-                  ? {
+                : undefined
+            }
+            secondaryButton={
+              showSecondary
+                ? {
                     label: 'Not now',
                     onPress: this.notNow
                   }
-                  : undefined
-              }
-              buttonLayout={showVertical ? FloatingButtonLayouts.VERTICAL : FloatingButtonLayouts.HORIZONTAL}
-              hoisted={hoisted}
-            />
+                : undefined
+            }
+            buttonLayout={showVertical ? FloatingButtonLayouts.VERTICAL : FloatingButtonLayouts.HORIZONTAL}
+            hoisted={hoisted}
+          />
         </View>
       </SafeAreaProvider>
     );

--- a/packages/react-native-ui-lib/src/components/floatingButton/__tests__/index.spec.tsx
+++ b/packages/react-native-ui-lib/src/components/floatingButton/__tests__/index.spec.tsx
@@ -14,11 +14,11 @@ const secondaryButton = {
 };
 
 const StickyTestCase = props => {
-  return <FloatingButton hoisted={false} {...props} testID={TEST_ID} />;
+  return <FloatingButton hoisted={false} {...props} testID={TEST_ID}/>;
 };
 
 const HoistedTestCase = props => {
-  return <FloatingButton {...props} testID={TEST_ID} />;
+  return <FloatingButton {...props} testID={TEST_ID}/>;
 };
 
 export const FloatingButtonDriver = (props: ComponentProps) => {
@@ -37,11 +37,11 @@ describe('FloatingButton', () => {
   describe('visible', () => {
     it('should render a button according to visibility', async () => {
       const props = {};
-      const renderTree = render(<StickyTestCase {...props} />);
+      const renderTree = render(<StickyTestCase {...props}/>);
       const buttonDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.button`});
       expect(await buttonDriver.exists()).not.toBeTruthy();
 
-      renderTree.rerender(<StickyTestCase visible button={button} />);
+      renderTree.rerender(<StickyTestCase visible button={button}/>);
       expect(await buttonDriver.exists()).toBeTruthy();
     });
   });
@@ -49,28 +49,28 @@ describe('FloatingButton', () => {
   describe('buttons', () => {
     it('should render a button', async () => {
       const props = {visible: true, button};
-      const renderTree = render(<StickyTestCase {...props} />);
+      const renderTree = render(<StickyTestCase {...props}/>);
       const buttonDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.button`});
       expect(await buttonDriver.exists()).toBeTruthy();
     });
 
     it('should not render a secondary button when not provided', async () => {
       const props = {visible: true};
-      const renderTree = render(<StickyTestCase {...props} />);
+      const renderTree = render(<StickyTestCase {...props}/>);
       const buttonDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.secondaryButton`});
       expect(await buttonDriver.exists()).not.toBeTruthy();
     });
 
     it('should render a button with a label', async () => {
       const props = {visible: true, button};
-      const renderTree = render(<StickyTestCase {...props} />);
+      const renderTree = render(<StickyTestCase {...props}/>);
       const buttonDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.button`});
       expect(await buttonDriver.getLabel().getText()).toEqual(button.label);
     });
 
     it('should render secondary button with label', async () => {
       const props = {visible: true, secondaryButton};
-      const renderTree = render(<StickyTestCase {...props} />);
+      const renderTree = render(<StickyTestCase {...props}/>);
       const buttonDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.secondaryButton`});
       expect(await buttonDriver.getLabel().getText()).toEqual(secondaryButton.label);
     });
@@ -79,7 +79,7 @@ describe('FloatingButton', () => {
   describe('buttonLayout', () => {
     it('should use vertical layout by default', () => {
       const props = {visible: true, button, secondaryButton};
-      const renderTree = render(<StickyTestCase {...props} />);
+      const renderTree = render(<StickyTestCase {...props}/>);
       const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
 
       expect(contentDriver.getStyle().flexDirection).toBe('column');
@@ -88,7 +88,7 @@ describe('FloatingButton', () => {
 
     it('should use horizontal layout when specified', () => {
       const props = {visible: true, button, secondaryButton, buttonLayout: FloatingButtonLayouts.HORIZONTAL};
-      const renderTree = render(<StickyTestCase {...props} />);
+      const renderTree = render(<StickyTestCase {...props}/>);
       const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
 
       expect(contentDriver.getStyle().flexDirection).toBe('row');
@@ -99,7 +99,7 @@ describe('FloatingButton', () => {
   describe('bottomMargin', () => {
     it('should have default paddingBottom when bottomMargin is not provided', () => {
       const props = {visible: true, button};
-      const renderTree = render(<StickyTestCase {...props} />);
+      const renderTree = render(<StickyTestCase {...props}/>);
       const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
       const defaultPaddingBottom = contentDriver.getStyle().paddingBottom as number;
 
@@ -108,7 +108,7 @@ describe('FloatingButton', () => {
 
     it('should have default paddingBottom with both buttons when bottomMargin is not provided', () => {
       const props = {visible: true, button, secondaryButton};
-      const renderTree = render(<StickyTestCase {...props} />);
+      const renderTree = render(<StickyTestCase {...props}/>);
       const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
       const defaultPaddingBottom = contentDriver.getStyle().paddingBottom as number;
 
@@ -117,7 +117,7 @@ describe('FloatingButton', () => {
 
     it('should apply bottomMargin as paddingBottom on the content container', () => {
       const props = {visible: true, button, bottomMargin: 10};
-      const renderTree = render(<StickyTestCase {...props} />);
+      const renderTree = render(<StickyTestCase {...props}/>);
       const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
 
       expect(contentDriver.getStyle().paddingBottom).toBe(10);
@@ -125,7 +125,7 @@ describe('FloatingButton', () => {
 
     it('should apply bottomMargin as paddingBottom with both buttons', () => {
       const props = {visible: true, button, secondaryButton, bottomMargin: 10};
-      const renderTree = render(<StickyTestCase {...props} />);
+      const renderTree = render(<StickyTestCase {...props}/>);
       const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
 
       expect(contentDriver.getStyle().paddingBottom).toBe(10);
@@ -135,7 +135,7 @@ describe('FloatingButton', () => {
   describe('fullWidth', () => {
     it('should stretch items in vertical layout when fullWidth is true', () => {
       const props = {visible: true, button, secondaryButton, fullWidth: true};
-      const renderTree = render(<StickyTestCase {...props} />);
+      const renderTree = render(<StickyTestCase {...props}/>);
       const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
 
       expect(contentDriver.getStyle().flexDirection).toBe('column');
@@ -150,7 +150,7 @@ describe('FloatingButton', () => {
         buttonLayout: FloatingButtonLayouts.HORIZONTAL,
         fullWidth: true
       };
-      const renderTree = render(<StickyTestCase {...props} />);
+      const renderTree = render(<StickyTestCase {...props}/>);
       const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
 
       expect(contentDriver.getStyle().flexDirection).toBe('row');
@@ -161,14 +161,14 @@ describe('FloatingButton', () => {
   describe('hoisted (default)', () => {
     it('should render a button in hoisted mode', async () => {
       const props = {visible: true, button};
-      const renderTree = render(<HoistedTestCase {...props} />);
+      const renderTree = render(<HoistedTestCase {...props}/>);
       const buttonDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.button`});
       expect(await buttonDriver.exists()).toBeTruthy();
     });
 
     it('should render both buttons in hoisted mode', async () => {
       const props = {visible: true, button, secondaryButton};
-      const renderTree = render(<HoistedTestCase {...props} />);
+      const renderTree = render(<HoistedTestCase {...props}/>);
       const primaryDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.button`});
       const secondaryDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.secondaryButton`});
       expect(await primaryDriver.exists()).toBeTruthy();
@@ -177,11 +177,11 @@ describe('FloatingButton', () => {
 
     it('should render a button according to visibility in hoisted mode', async () => {
       const props = {};
-      const renderTree = render(<HoistedTestCase {...props} />);
+      const renderTree = render(<HoistedTestCase {...props}/>);
       const buttonDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.button`});
       expect(await buttonDriver.exists()).not.toBeTruthy();
 
-      renderTree.rerender(<HoistedTestCase visible button={button} />);
+      renderTree.rerender(<HoistedTestCase visible button={button}/>);
       expect(await buttonDriver.exists()).toBeTruthy();
     });
   });

--- a/packages/react-native-ui-lib/src/components/floatingButton/__tests__/index.spec.tsx
+++ b/packages/react-native-ui-lib/src/components/floatingButton/__tests__/index.spec.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {StyleSheet, ViewStyle} from 'react-native';
 import {render} from '@testing-library/react-native';
 import FloatingButton, {FloatingButtonLayouts} from '../index';
-import {Spacings} from '../../../style';
 import {ButtonDriver} from '../../button/Button.driver.new';
 import {useComponentDriver, ComponentProps} from '../../../testkit/new/Component.driver';
 
@@ -144,7 +143,10 @@ describe('FloatingButton', () => {
     });
 
     it('should use horizontal layout when fullWidth is true with horizontal layout', () => {
-      const props = {visible: true, button, secondaryButton, buttonLayout: FloatingButtonLayouts.HORIZONTAL, fullWidth: true};
+      const props = {
+        visible: true, button, secondaryButton,
+        buttonLayout: FloatingButtonLayouts.HORIZONTAL, fullWidth: true
+      };
       const renderTree = render(<StickyTestCase {...props}/>);
       const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
 

--- a/packages/react-native-ui-lib/src/components/floatingButton/__tests__/index.spec.tsx
+++ b/packages/react-native-ui-lib/src/components/floatingButton/__tests__/index.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {StyleSheet, ViewStyle} from 'react-native';
 import {render} from '@testing-library/react-native';
 import FloatingButton, {FloatingButtonLayouts} from '../index';
+import {Spacings} from '../../../style';
 import {ButtonDriver} from '../../button/Button.driver.new';
 import {useComponentDriver, ComponentProps} from '../../../testkit/new/Component.driver';
 
@@ -13,8 +14,12 @@ const secondaryButton = {
   label: 'Second'
 };
 
-const TestCase = (props) => {
+const StickyTestCase = (props) => {
   return <FloatingButton hoisted={false} {...props} testID={TEST_ID}/>;
+};
+
+const HoistedTestCase = (props) => {
+  return <FloatingButton {...props} testID={TEST_ID}/>;
 };
 
 export const FloatingButtonDriver = (props: ComponentProps) => {
@@ -33,11 +38,11 @@ describe('FloatingButton', () => {
   describe('visible', () => {
     it('should render a button according to visibility', async () => {
       const props = {};
-      const renderTree = render(<TestCase {...props}/>);
+      const renderTree = render(<StickyTestCase {...props}/>);
       const buttonDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.button`});
       expect(await buttonDriver.exists()).not.toBeTruthy();
 
-      renderTree.rerender(<TestCase visible button={button}/>);
+      renderTree.rerender(<StickyTestCase visible button={button}/>);
       expect(await buttonDriver.exists()).toBeTruthy();
     });
   });
@@ -45,28 +50,28 @@ describe('FloatingButton', () => {
   describe('buttons', () => {
     it('should render a button', async () => {
       const props = {visible: true, button};
-      const renderTree = render(<TestCase {...props}/>);
+      const renderTree = render(<StickyTestCase {...props}/>);
       const buttonDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.button`});
       expect(await buttonDriver.exists()).toBeTruthy();
     });
 
     it('should not render a secondary button when not provided', async () => {
       const props = {visible: true};
-      const renderTree = render(<TestCase {...props}/>);
+      const renderTree = render(<StickyTestCase {...props}/>);
       const buttonDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.secondaryButton`});
       expect(await buttonDriver.exists()).not.toBeTruthy();
     });
 
     it('should render a button with a label', async () => {
       const props = {visible: true, button};
-      const renderTree = render(<TestCase {...props}/>);
+      const renderTree = render(<StickyTestCase {...props}/>);
       const buttonDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.button`});
       expect(await buttonDriver.getLabel().getText()).toEqual(button.label);
     });
 
     it('should render secondary button with label', async () => {
       const props = {visible: true, secondaryButton};
-      const renderTree = render(<TestCase {...props}/>);
+      const renderTree = render(<StickyTestCase {...props}/>);
       const buttonDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.secondaryButton`});
       expect(await buttonDriver.getLabel().getText()).toEqual(secondaryButton.label);
     });
@@ -75,7 +80,7 @@ describe('FloatingButton', () => {
   describe('buttonLayout', () => {
     it('should use vertical layout by default', () => {
       const props = {visible: true, button, secondaryButton};
-      const renderTree = render(<TestCase {...props}/>);
+      const renderTree = render(<StickyTestCase {...props}/>);
       const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
 
       expect(contentDriver.getStyle().flexDirection).toBe('column');
@@ -84,7 +89,7 @@ describe('FloatingButton', () => {
 
     it('should use horizontal layout when specified', () => {
       const props = {visible: true, button, secondaryButton, buttonLayout: FloatingButtonLayouts.HORIZONTAL};
-      const renderTree = render(<TestCase {...props}/>);
+      const renderTree = render(<StickyTestCase {...props}/>);
       const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
 
       expect(contentDriver.getStyle().flexDirection).toBe('row');
@@ -92,10 +97,46 @@ describe('FloatingButton', () => {
     });
   });
 
+  describe('bottomMargin', () => {
+    it('should have default paddingBottom when bottomMargin is not provided', () => {
+      const props = {visible: true, button};
+      const renderTree = render(<StickyTestCase {...props}/>);
+      const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
+      const defaultPaddingBottom = contentDriver.getStyle().paddingBottom as number;
+
+      expect(defaultPaddingBottom).toBeGreaterThan(0);
+    });
+
+    it('should have default paddingBottom with both buttons when bottomMargin is not provided', () => {
+      const props = {visible: true, button, secondaryButton};
+      const renderTree = render(<StickyTestCase {...props}/>);
+      const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
+      const defaultPaddingBottom = contentDriver.getStyle().paddingBottom as number;
+
+      expect(defaultPaddingBottom).toBeGreaterThan(0);
+    });
+
+    it('should apply bottomMargin as paddingBottom on the content container', () => {
+      const props = {visible: true, button, bottomMargin: 10};
+      const renderTree = render(<StickyTestCase {...props}/>);
+      const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
+
+      expect(contentDriver.getStyle().paddingBottom).toBe(10);
+    });
+
+    it('should apply bottomMargin as paddingBottom with both buttons', () => {
+      const props = {visible: true, button, secondaryButton, bottomMargin: 10};
+      const renderTree = render(<StickyTestCase {...props}/>);
+      const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
+
+      expect(contentDriver.getStyle().paddingBottom).toBe(10);
+    });
+  });
+
   describe('fullWidth', () => {
     it('should stretch items in vertical layout when fullWidth is true', () => {
       const props = {visible: true, button, secondaryButton, fullWidth: true};
-      const renderTree = render(<TestCase {...props}/>);
+      const renderTree = render(<StickyTestCase {...props}/>);
       const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
 
       expect(contentDriver.getStyle().flexDirection).toBe('column');
@@ -104,11 +145,39 @@ describe('FloatingButton', () => {
 
     it('should use horizontal layout when fullWidth is true with horizontal layout', () => {
       const props = {visible: true, button, secondaryButton, buttonLayout: FloatingButtonLayouts.HORIZONTAL, fullWidth: true};
-      const renderTree = render(<TestCase {...props}/>);
+      const renderTree = render(<StickyTestCase {...props}/>);
       const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
 
       expect(contentDriver.getStyle().flexDirection).toBe('row');
       expect(contentDriver.getStyle().alignItems).toBe('center');
+    });
+  });
+
+  describe('hoisted (default)', () => {
+    it('should render a button in hoisted mode', async () => {
+      const props = {visible: true, button};
+      const renderTree = render(<HoistedTestCase {...props}/>);
+      const buttonDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.button`});
+      expect(await buttonDriver.exists()).toBeTruthy();
+    });
+
+    it('should render both buttons in hoisted mode', async () => {
+      const props = {visible: true, button, secondaryButton};
+      const renderTree = render(<HoistedTestCase {...props}/>);
+      const primaryDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.button`});
+      const secondaryDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.secondaryButton`});
+      expect(await primaryDriver.exists()).toBeTruthy();
+      expect(await secondaryDriver.exists()).toBeTruthy();
+    });
+
+    it('should render a button according to visibility in hoisted mode', async () => {
+      const props = {};
+      const renderTree = render(<HoistedTestCase {...props}/>);
+      const buttonDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.button`});
+      expect(await buttonDriver.exists()).not.toBeTruthy();
+
+      renderTree.rerender(<HoistedTestCase visible button={button}/>);
+      expect(await buttonDriver.exists()).toBeTruthy();
     });
   });
 });

--- a/packages/react-native-ui-lib/src/components/floatingButton/__tests__/index.spec.tsx
+++ b/packages/react-native-ui-lib/src/components/floatingButton/__tests__/index.spec.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import {ViewStyle} from 'react-native';
+import {StyleSheet, ViewStyle} from 'react-native';
 import {render} from '@testing-library/react-native';
-import {Spacings} from '../../../style';
 import FloatingButton, {FloatingButtonLayouts} from '../index';
 import {ButtonDriver} from '../../button/Button.driver.new';
 import {useComponentDriver, ComponentProps} from '../../../testkit/new/Component.driver';
@@ -15,11 +14,18 @@ const secondaryButton = {
 };
 
 const TestCase = (props) => {
-  return <FloatingButton {...props} testID={TEST_ID}/>;
+  return <FloatingButton hoisted={false} {...props} testID={TEST_ID}/>;
 };
+
 export const FloatingButtonDriver = (props: ComponentProps) => {
   const driver = useComponentDriver(props);
   const getStyle = () => driver.getElement().props.style as ViewStyle;
+  return {...driver, getStyle};
+};
+
+const ContentDriver = (props: ComponentProps) => {
+  const driver = useComponentDriver(props);
+  const getStyle = () => StyleSheet.flatten(driver.getElement().props.style) as ViewStyle;
   return {...driver, getStyle};
 };
 
@@ -30,7 +36,7 @@ describe('FloatingButton', () => {
       const renderTree = render(<TestCase {...props}/>);
       const buttonDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.button`});
       expect(await buttonDriver.exists()).not.toBeTruthy();
-      
+
       renderTree.rerender(<TestCase visible button={button}/>);
       expect(await buttonDriver.exists()).toBeTruthy();
     });
@@ -44,7 +50,7 @@ describe('FloatingButton', () => {
       expect(await buttonDriver.exists()).toBeTruthy();
     });
 
-    it('should not render a secondary button', async () => {
+    it('should not render a secondary button when not provided', async () => {
       const props = {visible: true};
       const renderTree = render(<TestCase {...props}/>);
       const buttonDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.secondaryButton`});
@@ -66,91 +72,43 @@ describe('FloatingButton', () => {
     });
   });
 
-  describe('bottomMargin', () => {
-    it('should have default bottom margin', () => {
-      const props = {visible: true, button};
-      const renderTree = render(<TestCase {...props}/>);
-      const buttonDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.button`});
-
-      expect(buttonDriver.getElement().props.style?.marginBottom).toBe(Spacings.s8);
-    });
-
-    it('should have default bottom margin for both buttons', () => {
-      const props = {visible: true, button, secondaryButton};
-      const renderTree = render(<TestCase {...props}/>);
-      const buttonDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.button`});
-      const buttonDriver2 = ButtonDriver({renderTree, testID: `${TEST_ID}.secondaryButton`});
-
-      expect(buttonDriver.getElement().props.style?.marginBottom).toBe(Spacings.s4);
-      expect(buttonDriver2.getElement().props.style?.marginBottom).toBe(Spacings.s7);
-    });
-
-    it('should have bottom margin that match bottomMargin prop', () => {
-      const props = {visible: true, button, bottomMargin: 10};
-      const renderTree = render(<TestCase {...props}/>);
-      const buttonDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.button`});
-
-      expect(buttonDriver.getElement().props.style?.marginBottom).toBe(10);
-    });
-
-    it('should have bottom margin for secondary button that match bottomMarginProp', () => {
-      const props = {visible: true, button, secondaryButton, bottomMargin: 10};
-      const renderTree = render(<TestCase {...props}/>);
-      const buttonDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.button`});
-      const buttonDriver2 = ButtonDriver({renderTree, testID: `${TEST_ID}.secondaryButton`});
-
-      expect(buttonDriver.getElement().props.style?.marginBottom).toBe(Spacings.s4);
-      expect(buttonDriver2.getElement().props.style?.marginBottom).toBe(10);
-    });
-  });
-
   describe('buttonLayout', () => {
-    it('should style vertical layout (default)', () => {
+    it('should use vertical layout by default', () => {
       const props = {visible: true, button, secondaryButton};
       const renderTree = render(<TestCase {...props}/>);
-      const driver = FloatingButtonDriver({renderTree, testID: TEST_ID});
-      
-      expect(driver.getStyle()?.flexDirection).toBe(undefined);
-      expect(driver.getStyle()?.alignItems).toBe('center');
-      expect(driver.getStyle()?.justifyContent).toBe('center');
-      expect(driver.getStyle()?.paddingHorizontal).toBe(undefined);
+      const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
+
+      expect(contentDriver.getStyle().flexDirection).toBe('column');
+      expect(contentDriver.getStyle().alignItems).toBe('center');
     });
-    
-    it('should style horizontal layout', () => {
+
+    it('should use horizontal layout when specified', () => {
       const props = {visible: true, button, secondaryButton, buttonLayout: FloatingButtonLayouts.HORIZONTAL};
       const renderTree = render(<TestCase {...props}/>);
-      const driver = FloatingButtonDriver({renderTree, testID: TEST_ID});
-      
-      expect(driver.getStyle()?.flexDirection).toBe('row');
-      expect(driver.getStyle()?.alignItems).toBe('center');
-      expect(driver.getStyle()?.justifyContent).toBe('center');
-      expect(driver.getStyle()?.paddingHorizontal).toBe(undefined);
+      const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
+
+      expect(contentDriver.getStyle().flexDirection).toBe('row');
+      expect(contentDriver.getStyle().alignItems).toBe('center');
     });
   });
 
   describe('fullWidth', () => {
-    it('should style vertical layout (default) when fullWidth is true', () => {
+    it('should stretch items in vertical layout when fullWidth is true', () => {
       const props = {visible: true, button, secondaryButton, fullWidth: true};
       const renderTree = render(<TestCase {...props}/>);
-      const driver = FloatingButtonDriver({renderTree, testID: TEST_ID});
-      
-      expect(driver.getStyle()?.flexDirection).toBe(undefined);
-      expect(driver.getStyle()?.alignItems).toBe(undefined);
-      expect(driver.getStyle()?.justifyContent).toBe(undefined);
-      const buttonDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.button`});
-      expect(buttonDriver.getElement().props.style.marginLeft).toBe(16);
-      expect(buttonDriver.getElement().props.style.marginRight).toBe(16);
+      const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
+
+      expect(contentDriver.getStyle().flexDirection).toBe('column');
+      expect(contentDriver.getStyle().alignItems).toBe('stretch');
     });
 
-    it('should style horizontal layout when fullWidth is true', () => {
+    it('should use horizontal layout when fullWidth is true with horizontal layout', () => {
       const props = {visible: true, button, secondaryButton, buttonLayout: FloatingButtonLayouts.HORIZONTAL, fullWidth: true};
       const renderTree = render(<TestCase {...props}/>);
-      const driver = FloatingButtonDriver({renderTree, testID: TEST_ID});
-      
-      expect(driver.getStyle()?.flexDirection).toBe('row');
-      expect(driver.getStyle()?.alignItems).toBe('center');
-      expect(driver.getStyle()?.justifyContent).toBe('center');
-      expect(driver.getStyle()?.paddingHorizontal).toBe(undefined);
+      const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
+
+      expect(contentDriver.getStyle().flexDirection).toBe('row');
+      expect(contentDriver.getStyle().alignItems).toBe('center');
     });
   });
 });

--- a/packages/react-native-ui-lib/src/components/floatingButton/__tests__/index.spec.tsx
+++ b/packages/react-native-ui-lib/src/components/floatingButton/__tests__/index.spec.tsx
@@ -13,12 +13,12 @@ const secondaryButton = {
   label: 'Second'
 };
 
-const StickyTestCase = (props) => {
-  return <FloatingButton hoisted={false} {...props} testID={TEST_ID}/>;
+const StickyTestCase = props => {
+  return <FloatingButton hoisted={false} {...props} testID={TEST_ID} />;
 };
 
-const HoistedTestCase = (props) => {
-  return <FloatingButton {...props} testID={TEST_ID}/>;
+const HoistedTestCase = props => {
+  return <FloatingButton {...props} testID={TEST_ID} />;
 };
 
 export const FloatingButtonDriver = (props: ComponentProps) => {
@@ -37,11 +37,11 @@ describe('FloatingButton', () => {
   describe('visible', () => {
     it('should render a button according to visibility', async () => {
       const props = {};
-      const renderTree = render(<StickyTestCase {...props}/>);
+      const renderTree = render(<StickyTestCase {...props} />);
       const buttonDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.button`});
       expect(await buttonDriver.exists()).not.toBeTruthy();
 
-      renderTree.rerender(<StickyTestCase visible button={button}/>);
+      renderTree.rerender(<StickyTestCase visible button={button} />);
       expect(await buttonDriver.exists()).toBeTruthy();
     });
   });
@@ -49,28 +49,28 @@ describe('FloatingButton', () => {
   describe('buttons', () => {
     it('should render a button', async () => {
       const props = {visible: true, button};
-      const renderTree = render(<StickyTestCase {...props}/>);
+      const renderTree = render(<StickyTestCase {...props} />);
       const buttonDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.button`});
       expect(await buttonDriver.exists()).toBeTruthy();
     });
 
     it('should not render a secondary button when not provided', async () => {
       const props = {visible: true};
-      const renderTree = render(<StickyTestCase {...props}/>);
+      const renderTree = render(<StickyTestCase {...props} />);
       const buttonDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.secondaryButton`});
       expect(await buttonDriver.exists()).not.toBeTruthy();
     });
 
     it('should render a button with a label', async () => {
       const props = {visible: true, button};
-      const renderTree = render(<StickyTestCase {...props}/>);
+      const renderTree = render(<StickyTestCase {...props} />);
       const buttonDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.button`});
       expect(await buttonDriver.getLabel().getText()).toEqual(button.label);
     });
 
     it('should render secondary button with label', async () => {
       const props = {visible: true, secondaryButton};
-      const renderTree = render(<StickyTestCase {...props}/>);
+      const renderTree = render(<StickyTestCase {...props} />);
       const buttonDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.secondaryButton`});
       expect(await buttonDriver.getLabel().getText()).toEqual(secondaryButton.label);
     });
@@ -79,7 +79,7 @@ describe('FloatingButton', () => {
   describe('buttonLayout', () => {
     it('should use vertical layout by default', () => {
       const props = {visible: true, button, secondaryButton};
-      const renderTree = render(<StickyTestCase {...props}/>);
+      const renderTree = render(<StickyTestCase {...props} />);
       const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
 
       expect(contentDriver.getStyle().flexDirection).toBe('column');
@@ -88,7 +88,7 @@ describe('FloatingButton', () => {
 
     it('should use horizontal layout when specified', () => {
       const props = {visible: true, button, secondaryButton, buttonLayout: FloatingButtonLayouts.HORIZONTAL};
-      const renderTree = render(<StickyTestCase {...props}/>);
+      const renderTree = render(<StickyTestCase {...props} />);
       const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
 
       expect(contentDriver.getStyle().flexDirection).toBe('row');
@@ -99,7 +99,7 @@ describe('FloatingButton', () => {
   describe('bottomMargin', () => {
     it('should have default paddingBottom when bottomMargin is not provided', () => {
       const props = {visible: true, button};
-      const renderTree = render(<StickyTestCase {...props}/>);
+      const renderTree = render(<StickyTestCase {...props} />);
       const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
       const defaultPaddingBottom = contentDriver.getStyle().paddingBottom as number;
 
@@ -108,7 +108,7 @@ describe('FloatingButton', () => {
 
     it('should have default paddingBottom with both buttons when bottomMargin is not provided', () => {
       const props = {visible: true, button, secondaryButton};
-      const renderTree = render(<StickyTestCase {...props}/>);
+      const renderTree = render(<StickyTestCase {...props} />);
       const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
       const defaultPaddingBottom = contentDriver.getStyle().paddingBottom as number;
 
@@ -117,7 +117,7 @@ describe('FloatingButton', () => {
 
     it('should apply bottomMargin as paddingBottom on the content container', () => {
       const props = {visible: true, button, bottomMargin: 10};
-      const renderTree = render(<StickyTestCase {...props}/>);
+      const renderTree = render(<StickyTestCase {...props} />);
       const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
 
       expect(contentDriver.getStyle().paddingBottom).toBe(10);
@@ -125,7 +125,7 @@ describe('FloatingButton', () => {
 
     it('should apply bottomMargin as paddingBottom with both buttons', () => {
       const props = {visible: true, button, secondaryButton, bottomMargin: 10};
-      const renderTree = render(<StickyTestCase {...props}/>);
+      const renderTree = render(<StickyTestCase {...props} />);
       const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
 
       expect(contentDriver.getStyle().paddingBottom).toBe(10);
@@ -135,7 +135,7 @@ describe('FloatingButton', () => {
   describe('fullWidth', () => {
     it('should stretch items in vertical layout when fullWidth is true', () => {
       const props = {visible: true, button, secondaryButton, fullWidth: true};
-      const renderTree = render(<StickyTestCase {...props}/>);
+      const renderTree = render(<StickyTestCase {...props} />);
       const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
 
       expect(contentDriver.getStyle().flexDirection).toBe('column');
@@ -144,10 +144,13 @@ describe('FloatingButton', () => {
 
     it('should use horizontal layout when fullWidth is true with horizontal layout', () => {
       const props = {
-        visible: true, button, secondaryButton,
-        buttonLayout: FloatingButtonLayouts.HORIZONTAL, fullWidth: true
+        visible: true,
+        button,
+        secondaryButton,
+        buttonLayout: FloatingButtonLayouts.HORIZONTAL,
+        fullWidth: true
       };
-      const renderTree = render(<StickyTestCase {...props}/>);
+      const renderTree = render(<StickyTestCase {...props} />);
       const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
 
       expect(contentDriver.getStyle().flexDirection).toBe('row');
@@ -158,14 +161,14 @@ describe('FloatingButton', () => {
   describe('hoisted (default)', () => {
     it('should render a button in hoisted mode', async () => {
       const props = {visible: true, button};
-      const renderTree = render(<HoistedTestCase {...props}/>);
+      const renderTree = render(<HoistedTestCase {...props} />);
       const buttonDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.button`});
       expect(await buttonDriver.exists()).toBeTruthy();
     });
 
     it('should render both buttons in hoisted mode', async () => {
       const props = {visible: true, button, secondaryButton};
-      const renderTree = render(<HoistedTestCase {...props}/>);
+      const renderTree = render(<HoistedTestCase {...props} />);
       const primaryDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.button`});
       const secondaryDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.secondaryButton`});
       expect(await primaryDriver.exists()).toBeTruthy();
@@ -174,11 +177,11 @@ describe('FloatingButton', () => {
 
     it('should render a button according to visibility in hoisted mode', async () => {
       const props = {};
-      const renderTree = render(<HoistedTestCase {...props}/>);
+      const renderTree = render(<HoistedTestCase {...props} />);
       const buttonDriver = ButtonDriver({renderTree, testID: `${TEST_ID}.button`});
       expect(await buttonDriver.exists()).not.toBeTruthy();
 
-      renderTree.rerender(<HoistedTestCase visible button={button}/>);
+      renderTree.rerender(<HoistedTestCase visible button={button} />);
       expect(await buttonDriver.exists()).toBeTruthy();
     });
   });

--- a/packages/react-native-ui-lib/src/components/floatingButton/floatingButton.api.json
+++ b/packages/react-native-ui-lib/src/components/floatingButton/floatingButton.api.json
@@ -1,7 +1,7 @@
 {
   "name": "FloatingButton",
   "category": "overlays",
-  "description": "Hovering button with gradient background",
+  "description": "Hovering button with gradient background, backed by ScreenFooter",
   "modifiers": [
     "margin",
     "background",
@@ -57,6 +57,12 @@
       "name": "hideBackgroundOverlay",
       "type": "boolean",
       "description": "Whether to show background overlay"
+    },
+    {
+      "name": "hoisted",
+      "type": "boolean",
+      "description": "Whether the footer should be hoisted above the keyboard. When true, uses KeyboardAccessoryView for keyboard-aware positioning. When false, uses sticky positioning.",
+      "default": "true"
     },
     {
       "name": "testID",

--- a/packages/react-native-ui-lib/src/components/floatingButton/floatingButton.api.json
+++ b/packages/react-native-ui-lib/src/components/floatingButton/floatingButton.api.json
@@ -2,11 +2,7 @@
   "name": "FloatingButton",
   "category": "overlays",
   "description": "Hovering button with gradient background, backed by ScreenFooter",
-  "modifiers": [
-    "margin",
-    "background",
-    "color"
-  ],
+  "modifiers": ["margin", "background", "color"],
   "example": "https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/FloatingButtonScreen.tsx",
   "images": [
     "https://github.com/wix/react-native-ui-lib/blob/master/demo/showcase/FloatingButton/FloatingButton.gif?raw=true"
@@ -102,11 +98,7 @@
           },
           {
             "type": "table",
-            "columns": [
-              "Property",
-              "Default",
-              "Full Width"
-            ],
+            "columns": ["Property", "Default", "Full Width"],
             "items": [
               {
                 "title": "Main button",
@@ -136,10 +128,7 @@
           },
           {
             "type": "table",
-            "columns": [
-              "Layout",
-              "Component"
-            ],
+            "columns": ["Layout", "Component"],
             "items": [
               {
                 "title": "Horizontal",

--- a/packages/react-native-ui-lib/src/components/floatingButton/index.tsx
+++ b/packages/react-native-ui-lib/src/components/floatingButton/index.tsx
@@ -1,4 +1,4 @@
-import React, {PropsWithChildren} from 'react';
+import React, {PropsWithChildren, useMemo} from 'react';
 import {StyleSheet} from 'react-native';
 import {asBaseComponent} from '../../commons/new';
 import {Colors, Shadows} from '../../style';
@@ -78,6 +78,7 @@ const FloatingButton = (props: FloatingButtonProps) => {
     visible,
     button,
     secondaryButton,
+    bottomMargin,
     fullWidth,
     buttonLayout = FloatingButtonLayouts.VERTICAL,
     duration = 300,
@@ -141,6 +142,13 @@ const FloatingButton = (props: FloatingButtonProps) => {
     ? [renderSecondaryButton(), renderPrimaryButton()]
     : [renderPrimaryButton(), renderSecondaryButton()];
 
+  const footerContentContainerStyle = useMemo(() => {
+    if (bottomMargin !== undefined) {
+      return {paddingBottom: bottomMargin};
+    }
+    return undefined;
+  }, [bottomMargin]);
+
   return (
     <ScreenFooter
       visible={visible}
@@ -149,6 +157,7 @@ const FloatingButton = (props: FloatingButtonProps) => {
       keyboardBehavior={hoisted ? KeyboardBehavior.HOISTED : KeyboardBehavior.STICKY}
       animationDuration={withoutAnimation ? 0 : duration}
       itemsFit={fullWidth ? ItemsFit.STRETCH : undefined}
+      contentContainerStyle={footerContentContainerStyle}
       testID={testID}
     >
       {children}

--- a/packages/react-native-ui-lib/src/components/floatingButton/index.tsx
+++ b/packages/react-native-ui-lib/src/components/floatingButton/index.tsx
@@ -1,15 +1,20 @@
-import React, {PropsWithChildren, PureComponent} from 'react';
-import {StyleSheet, Animated} from 'react-native';
-import {Constants, asBaseComponent} from '../../commons/new';
-import {Colors, Shadows, Spacings} from '../../style';
-import View from '../view';
-import Image from '../image';
+import React, {PropsWithChildren} from 'react';
+import {StyleSheet} from 'react-native';
+import {asBaseComponent} from '../../commons/new';
+import {Colors, Shadows} from '../../style';
 import Button, {ButtonProps} from '../button';
+import ScreenFooter, {
+  ScreenFooterLayouts,
+  ScreenFooterBackgrounds,
+  KeyboardBehavior,
+  ItemsFit
+} from '../screenFooter';
 
 export enum FloatingButtonLayouts {
   VERTICAL = 'Vertical',
   HORIZONTAL = 'Horizontal'
 }
+
 export interface FloatingButtonProps {
   /**
    * Whether the button is visible
@@ -28,7 +33,7 @@ export interface FloatingButtonProps {
    */
   bottomMargin?: number;
   /**
-   * Whether the buttons get the container's full with (vertical layout only)
+   * Whether the buttons get the container's full width (vertical layout only)
    */
   fullWidth?: boolean;
   /**
@@ -48,6 +53,12 @@ export interface FloatingButtonProps {
    */
   hideBackgroundOverlay?: boolean;
   /**
+   * Whether the footer should be hoisted above the keyboard.
+   * When true (default), uses KeyboardAccessoryView for keyboard-aware positioning.
+   * When false, uses sticky positioning.
+   */
+  hoisted?: boolean;
+  /**
    * Used as testing identifier
    * <TestID> - the floatingButton container
    * <TestID>.button - the floatingButton main button
@@ -56,220 +67,101 @@ export interface FloatingButtonProps {
   testID?: string;
 }
 
-const gradientImage = () => require('./gradient.png');
-
 /**
- * @description: Hovering button with gradient background
+ * @description: Hovering button with gradient background, backed by ScreenFooter
  * @modifiers: margin, background, color
  * @example: https://github.com/wix/react-native-ui-lib/blob/master/demo/src/screens/componentScreens/FloatingButtonScreen.tsx
  * @gif: https://github.com/wix/react-native-ui-lib/blob/master/demo/showcase/FloatingButton/FloatingButton.gif?raw=true
  */
-class FloatingButton extends PureComponent<FloatingButtonProps> {
-  static displayName = 'FloatingButton';
-  static floatingButtonLayouts = FloatingButtonLayouts;
+const FloatingButton = (props: FloatingButtonProps) => {
+  const {
+    visible,
+    button,
+    secondaryButton,
+    fullWidth,
+    buttonLayout = FloatingButtonLayouts.VERTICAL,
+    duration = 300,
+    withoutAnimation,
+    hideBackgroundOverlay,
+    hoisted = true,
+    testID
+  } = props;
 
-  static defaultProps = {
-    duration: 300,
-    buttonLayout: FloatingButtonLayouts.VERTICAL
-  };
+  const isSecondaryOnly = !!secondaryButton && !button;
+  const isHorizontal = buttonLayout === FloatingButtonLayouts.HORIZONTAL || isSecondaryOnly;
 
-  initialVisibility?: boolean;
-  firstLoad: boolean;
-  visibleAnimated: Animated.Value;
-
-  constructor(props: FloatingButtonProps) {
-    super(props);
-
-    this.initialVisibility = props.visible;
-    this.firstLoad = true;
-    this.visibleAnimated = new Animated.Value(Number(!!props.visible));
+  if (!button && !secondaryButton) {
+    return null;
   }
 
-  componentDidUpdate(prevProps: FloatingButtonProps) {
-    const {visible, duration} = this.props;
-
-    if (prevProps.visible !== visible) {
-      Animated.timing(this.visibleAnimated, {
-        toValue: Number(!!visible),
-        duration,
-        useNativeDriver: true
-      }).start();
+  const renderPrimaryButton = () => {
+    if (!button) {
+      return null;
     }
-  }
 
-  getAnimatedStyle = () => {
-    return {
-      opacity: this.visibleAnimated,
-      transform: [
-        {
-          translateY: this.visibleAnimated.interpolate({
-            inputRange: [0, 1],
-            outputRange: [Constants.screenHeight / 2, 0]
-          })
-        }
-      ]
-    };
-  };
+    const shadowStyle = !button.outline && !button.link ? styles.shadow : undefined;
+    const shouldFlex = (isHorizontal && !!secondaryButton) || (fullWidth && isHorizontal);
 
-  get isSecondaryOnly() {
-    const {secondaryButton, button} = this.props;
-    return !!secondaryButton && !button;
-  }
-
-  get isHorizontalLayout() {
-    const {buttonLayout} = this.props;
-    return buttonLayout === FloatingButtonLayouts.HORIZONTAL || this.isSecondaryOnly;
-  }
-
-  get isSecondaryHorizontal() {
-    const {secondaryButton} = this.props;
-    return secondaryButton && this.isHorizontalLayout;
-  }
-
-  get isSecondaryVertical() {
-    const {secondaryButton} = this.props;
-    return secondaryButton && !this.isHorizontalLayout;
-  }
-
-  renderButton() {
-    const {bottomMargin, button, fullWidth, testID} = this.props;
-
-    if (button) {
-      const shadowStyle = button && !button.outline && !button.link ? styles.shadow : undefined;
-      const marginStyle = {
-        marginTop: Spacings.s4,
-        marginBottom: this.isSecondaryVertical ? Spacings.s4 : bottomMargin || Spacings.s8,
-        marginLeft: this.isSecondaryHorizontal || fullWidth ? Spacings.s4 : undefined,
-        marginRight: this.isSecondaryHorizontal ? Spacings.s5 : fullWidth ? Spacings.s4 : undefined
-      };
-
-      const shouldFlex = this.isSecondaryHorizontal || (fullWidth && this.isHorizontalLayout);
-
-      return (
-        <Button
-          size={Button.sizes.large}
-          flex={!!shouldFlex}
-          style={[shadowStyle, marginStyle]}
-          testID={`${testID}.button`}
-          {...button}
-        />
-      );
-    }
-  }
-
-  renderOverlay = () => {
-    if (!this.props.hideBackgroundOverlay) {
-      return (
-        <View pointerEvents={'none'} style={styles.image}>
-          <Image
-            style={styles.image}
-            source={gradientImage()}
-            resizeMode={'stretch'}
-            tintColor={Colors.$backgroundDefault}
-          />
-        </View>
-      );
-    }
-  };
-
-  renderSecondaryButton() {
-    const {secondaryButton, bottomMargin, testID, fullWidth, button} = this.props;
-
-    if (secondaryButton) {
-      const bgColor = secondaryButton.backgroundColor || Colors.$backgroundDefault;
-      const shouldFlex = (this.isHorizontalLayout && !!button) || (fullWidth && this.isSecondaryOnly);
-
-      const buttonStyle = this.isHorizontalLayout
-        ? [styles.shadow, styles.horizontalSecondaryMargin, {backgroundColor: bgColor}]
-        : {marginBottom: bottomMargin || Spacings.s7};
-
-      return (
-        <Button
-          outline={this.isHorizontalLayout}
-          flex={shouldFlex}
-          link={!this.isHorizontalLayout}
-          size={Button.sizes.large}
-          testID={`${testID}.secondaryButton`}
-          {...secondaryButton}
-          style={buttonStyle}
-          enableShadow={false}
-        />
-      );
-    }
-  }
-
-  renderHorizontalLayout() {
     return (
-      <>
-        {this.renderOverlay()}
-        {this.renderSecondaryButton()}
-        {this.renderButton()}
-      </>
+      <Button
+        key="primary"
+        size={Button.sizes.large}
+        flex={!!shouldFlex}
+        style={shadowStyle}
+        testID={testID ? `${testID}.button` : undefined}
+        {...button}
+      />
     );
-  }
+  };
 
-  renderVerticalLayout() {
+  const renderSecondaryButton = () => {
+    if (!secondaryButton) {
+      return null;
+    }
+
+    const shouldFlex = (isHorizontal && !!button) || (fullWidth && isSecondaryOnly);
+    const bgColor = secondaryButton.backgroundColor || Colors.$backgroundDefault;
+
     return (
-      <>
-        {this.renderOverlay()}
-        {this.renderButton()}
-        {this.renderSecondaryButton()}
-      </>
+      <Button
+        key="secondary"
+        outline={isHorizontal}
+        link={!isHorizontal}
+        flex={shouldFlex}
+        size={Button.sizes.large}
+        testID={testID ? `${testID}.secondaryButton` : undefined}
+        {...secondaryButton}
+        style={isHorizontal ? [styles.shadow, {backgroundColor: bgColor}] : undefined}
+        enableShadow={false}
+      />
     );
-  }
+  };
 
-  render() {
-    // NOTE: keep this.firstLoad as true as long as the visibility changed to true
-    const {withoutAnimation, visible, fullWidth, testID, button, secondaryButton} = this.props;
+  const children = isHorizontal
+    ? [renderSecondaryButton(), renderPrimaryButton()]
+    : [renderPrimaryButton(), renderSecondaryButton()];
 
-    this.firstLoad && !visible ? (this.firstLoad = true) : (this.firstLoad = false);
+  return (
+    <ScreenFooter
+      visible={visible}
+      layout={isHorizontal ? ScreenFooterLayouts.HORIZONTAL : ScreenFooterLayouts.VERTICAL}
+      backgroundType={hideBackgroundOverlay ? ScreenFooterBackgrounds.TRANSPARENT : ScreenFooterBackgrounds.FADING}
+      keyboardBehavior={hoisted ? KeyboardBehavior.HOISTED : KeyboardBehavior.STICKY}
+      animationDuration={withoutAnimation ? 0 : duration}
+      itemsFit={fullWidth ? ItemsFit.STRETCH : undefined}
+      testID={testID}
+    >
+      {children}
+    </ScreenFooter>
+  );
+};
 
-    // NOTE: On first load, don't show if it should not be visible
-    if (this.firstLoad === true && !this.initialVisibility) {
-      return false;
-    }
-    if (!visible && withoutAnimation) {
-      return false;
-    }
-
-    if (button || secondaryButton) {
-      const hasBothButtons = !!(button && secondaryButton);
-      const shouldCenter = !fullWidth || (this.isHorizontalLayout && hasBothButtons);
-
-      return (
-        <View
-          row={this.isHorizontalLayout}
-          center={shouldCenter}
-          pointerEvents="box-none"
-          animated
-          style={[styles.container, this.getAnimatedStyle()]}
-          testID={testID}
-        >
-          {this.isHorizontalLayout ? this.renderHorizontalLayout() : this.renderVerticalLayout()}
-        </View>
-      );
-    }
-  }
-}
+FloatingButton.displayName = 'FloatingButton';
+FloatingButton.floatingButtonLayouts = FloatingButtonLayouts;
 
 const styles = StyleSheet.create({
-  container: {
-    // ...StyleSheet.absoluteFillObject, // TODO: this is breaking scenarios where the FloatingButton is inside a KeyboardTrackingView
-    top: undefined,
-    zIndex: 99
-  },
-  image: {
-    ...StyleSheet.absoluteFillObject,
-    width: '100%',
-    height: '100%'
-  },
   shadow: {
     ...Shadows.sh20.bottom
-  },
-  horizontalSecondaryMargin: {
-    marginTop: Spacings.s4,
-    marginBottom: Spacings.s7,
-    marginLeft: Spacings.s5
   }
 });
 

--- a/packages/react-native-ui-lib/src/components/floatingButton/index.tsx
+++ b/packages/react-native-ui-lib/src/components/floatingButton/index.tsx
@@ -1,6 +1,7 @@
-import React, {PropsWithChildren, useMemo} from 'react';
+import React, {PropsWithChildren, useEffect, useMemo} from 'react';
 import {StyleSheet} from 'react-native';
 import {asBaseComponent} from '../../commons/new';
+import {LogService} from '../../services';
 import {Colors, Shadows} from '../../style';
 import Button, {ButtonProps} from '../button';
 import ScreenFooter, {
@@ -75,7 +76,7 @@ export interface FloatingButtonProps {
  */
 const FloatingButton = (props: FloatingButtonProps) => {
   const {
-    visible,
+    visible = false,
     button,
     secondaryButton,
     bottomMargin,
@@ -87,6 +88,13 @@ const FloatingButton = (props: FloatingButtonProps) => {
     hoisted = true,
     testID
   } = props;
+
+  useEffect(() => {
+    LogService.warn(
+      `RNUILib FloatingButton now uses ScreenFooter internally, which requires a SafeAreaProvider. ` +
+      `If you experience safe area issues, please wrap your app (or the relevant screen) with <SafeAreaProvider> from 'react-native-safe-area-context'.`
+    );
+  }, []);
 
   const isSecondaryOnly = !!secondaryButton && !button;
   const isHorizontal = buttonLayout === FloatingButtonLayouts.HORIZONTAL || isSecondaryOnly;

--- a/packages/react-native-ui-lib/src/components/floatingButton/index.tsx
+++ b/packages/react-native-ui-lib/src/components/floatingButton/index.tsx
@@ -4,12 +4,7 @@ import {asBaseComponent} from '../../commons/new';
 import {LogService} from '../../services';
 import {Colors, Shadows} from '../../style';
 import Button, {ButtonProps} from '../button';
-import ScreenFooter, {
-  ScreenFooterLayouts,
-  ScreenFooterBackgrounds,
-  KeyboardBehavior,
-  ItemsFit
-} from '../screenFooter';
+import ScreenFooter, {ScreenFooterLayouts, ScreenFooterBackgrounds, KeyboardBehavior, ItemsFit} from '../screenFooter';
 
 export enum FloatingButtonLayouts {
   VERTICAL = 'Vertical',
@@ -91,7 +86,9 @@ const FloatingButton = (props: FloatingButtonProps) => {
 
   useEffect(() => {
     // eslint-disable-next-line max-len
-    LogService.warn('RNUILib FloatingButton now uses ScreenFooter internally, which requires a SafeAreaProvider. If you experience safe area issues, please wrap your app (or the relevant screen) with <SafeAreaProvider>.');
+    LogService.warn(
+      'RNUILib FloatingButton now uses ScreenFooter internally, which requires a SafeAreaProvider. If you experience safe area issues, please wrap your app (or the relevant screen) with <SafeAreaProvider>.'
+    );
   }, []);
 
   const footerContentContainerStyle = useMemo(() => {

--- a/packages/react-native-ui-lib/src/components/floatingButton/index.tsx
+++ b/packages/react-native-ui-lib/src/components/floatingButton/index.tsx
@@ -90,11 +90,16 @@ const FloatingButton = (props: FloatingButtonProps) => {
   } = props;
 
   useEffect(() => {
-    LogService.warn(
-      `RNUILib FloatingButton now uses ScreenFooter internally, which requires a SafeAreaProvider. ` +
-      `If you experience safe area issues, please wrap your app (or the relevant screen) with <SafeAreaProvider> from 'react-native-safe-area-context'.`
-    );
+    // eslint-disable-next-line max-len
+    LogService.warn('RNUILib FloatingButton now uses ScreenFooter internally, which requires a SafeAreaProvider. If you experience safe area issues, please wrap your app (or the relevant screen) with <SafeAreaProvider>.');
   }, []);
+
+  const footerContentContainerStyle = useMemo(() => {
+    if (bottomMargin !== undefined) {
+      return {paddingBottom: bottomMargin};
+    }
+    return undefined;
+  }, [bottomMargin]);
 
   const isSecondaryOnly = !!secondaryButton && !button;
   const isHorizontal = buttonLayout === FloatingButtonLayouts.HORIZONTAL || isSecondaryOnly;
@@ -149,13 +154,6 @@ const FloatingButton = (props: FloatingButtonProps) => {
   const children = isHorizontal
     ? [renderSecondaryButton(), renderPrimaryButton()]
     : [renderPrimaryButton(), renderSecondaryButton()];
-
-  const footerContentContainerStyle = useMemo(() => {
-    if (bottomMargin !== undefined) {
-      return {paddingBottom: bottomMargin};
-    }
-    return undefined;
-  }, [bottomMargin]);
 
   return (
     <ScreenFooter

--- a/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
+++ b/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
@@ -46,7 +46,8 @@ const ScreenFooter = (props: ScreenFooterProps) => {
     visible = true,
     animationDuration = 200,
     shadow = ScreenFooterShadow.SH20,
-    hideDivider = false
+    hideDivider = false,
+    contentContainerStyle: contentContainerStyleOverride
   } = props;
 
   const keyboard = useAnimatedKeyboard();
@@ -111,6 +112,9 @@ const ScreenFooter = (props: ScreenFooterProps) => {
     }
   }, [layout, itemsFit, alignment]);
 
+  // TODO: Consider wrapping useSafeAreaInsets in a try-catch to gracefully handle
+  // missing SafeAreaProvider (e.g. when ScreenFooter is used indirectly via FloatingButton).
+  // Fallback: Constants.getSafeAreaInsets()
   const useSafeAreaInsets = SafeAreaContextPackage?.useSafeAreaInsets ?? (() => Constants.getSafeAreaInsets());
   const insets = useSafeAreaInsets();
 
@@ -131,12 +135,15 @@ const ScreenFooter = (props: ScreenFooterProps) => {
     if (isSolid) {
       const shadowStyle = Shadows[shadow]?.top;
       const backgroundElevation = shadowStyle?.elevation || 0;
-      // When the background has a shadow (elevation on Android), it might render on top of the content
       style.push({elevation: backgroundElevation + 1});
     }
 
+    if (contentContainerStyleOverride) {
+      style.push(contentContainerStyleOverride);
+    }
+
     return style;
-  }, [layout, alignItems, justifyContent, insets.bottom, isSolid, shadow, isKeyboardVisible]);
+  }, [layout, alignItems, justifyContent, insets.bottom, isSolid, shadow, isKeyboardVisible, contentContainerStyleOverride]);
 
   const solidBackgroundStyle = useMemo(() => {
     if (!isSolid) {

--- a/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
+++ b/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
@@ -90,9 +90,12 @@ const ScreenFooter = (props: ScreenFooterProps) => {
         return childrenCount === 1 ? 'center' : 'space-between';
       }
       switch (horizontalAlignment) {
-        case FooterAlignment.START: return 'flex-start';
-        case FooterAlignment.END: return 'flex-end';
-        default: return 'center';
+        case FooterAlignment.START:
+          return 'flex-start';
+        case FooterAlignment.END:
+          return 'flex-end';
+        default:
+          return 'center';
       }
     }
     return 'flex-start';
@@ -106,9 +109,12 @@ const ScreenFooter = (props: ScreenFooterProps) => {
     }
 
     switch (alignment) {
-      case FooterAlignment.START: return 'flex-start';
-      case FooterAlignment.END: return 'flex-end';
-      default: return 'center';
+      case FooterAlignment.START:
+        return 'flex-start';
+      case FooterAlignment.END:
+        return 'flex-end';
+      default:
+        return 'center';
     }
   }, [layout, itemsFit, alignment]);
 
@@ -128,7 +134,7 @@ const ScreenFooter = (props: ScreenFooterProps) => {
     if (!isKeyboardVisible) {
       style.push({paddingBottom: insets.bottom});
     }
-    
+
     if (isSolid) {
       const shadowStyle = Shadows[shadow]?.top;
       const backgroundElevation = shadowStyle?.elevation || 0;
@@ -140,7 +146,16 @@ const ScreenFooter = (props: ScreenFooterProps) => {
     }
 
     return style;
-  }, [layout, alignItems, justifyContent, insets.bottom, isSolid, shadow, isKeyboardVisible, contentContainerStyleOverride]);
+  }, [
+    layout,
+    alignItems,
+    justifyContent,
+    insets.bottom,
+    isSolid,
+    shadow,
+    isKeyboardVisible,
+    contentContainerStyleOverride
+  ]);
 
   const solidBackgroundStyle = useMemo(() => {
     if (!isSolid) {
@@ -180,27 +195,30 @@ const ScreenFooter = (props: ScreenFooterProps) => {
     return null;
   }, [testID, isSolid, isFading, solidBackgroundStyle]);
 
-  const renderChild = useCallback((child: React.ReactNode, index: number) => {
-    if (itemsFit === ItemsFit.FIXED && itemWidth) {
-      const fixedStyle: ViewStyle = isHorizontal
-        ? {width: itemWidth, flexShrink: 1, overflow: 'hidden', flexDirection: 'row', justifyContent: 'center'}
-        : {width: itemWidth, maxWidth: '100%'};
-      return (
-        <View key={index} style={fixedStyle}>
-          {child}
-        </View>
-      );
-    }
+  const renderChild = useCallback(
+    (child: React.ReactNode, index: number) => {
+      if (itemsFit === ItemsFit.FIXED && itemWidth) {
+        const fixedStyle: ViewStyle = isHorizontal
+          ? {width: itemWidth, flexShrink: 1, overflow: 'hidden', flexDirection: 'row', justifyContent: 'center'}
+          : {width: itemWidth, maxWidth: '100%'};
+        return (
+          <View key={index} style={fixedStyle}>
+            {child}
+          </View>
+        );
+      }
 
-    if (isHorizontal && React.isValidElement(child) && itemsFit === ItemsFit.STRETCH) {
-      return (
-        <View flex row centerH key={index}>
-          {child}
-        </View>
-      );
-    }
-    return child;
-  }, [itemsFit, itemWidth, isHorizontal]);
+      if (isHorizontal && React.isValidElement(child) && itemsFit === ItemsFit.STRETCH) {
+        return (
+          <View flex row centerH key={index}>
+            {child}
+          </View>
+        );
+      }
+      return child;
+    },
+    [itemsFit, itemWidth, isHorizontal]
+  );
 
   const childrenArray = React.Children.toArray(children).slice(0, 3).map(renderChild);
 
@@ -217,10 +235,7 @@ const ScreenFooter = (props: ScreenFooterProps) => {
 
   if (keyboardBehavior === KeyboardBehavior.HOISTED) {
     return (
-      <Animated.View
-        style={[styles.container, hoistedAnimatedStyle]}
-        pointerEvents={visible ? 'box-none' : 'none'}
-      >
+      <Animated.View style={[styles.container, hoistedAnimatedStyle]} pointerEvents={visible ? 'box-none' : 'none'}>
         <Keyboard.KeyboardAccessoryView
           renderContent={renderFooterContent}
           kbInputRef={undefined}
@@ -235,11 +250,7 @@ const ScreenFooter = (props: ScreenFooterProps) => {
   }
 
   return (
-    <Animated.View
-      testID={testID}
-      onLayout={onLayout}
-      style={[styles.container, stickyAnimatedStyle]}
-    >
+    <Animated.View testID={testID} onLayout={onLayout} style={[styles.container, stickyAnimatedStyle]}>
       {renderFooterContent()}
     </Animated.View>
   );

--- a/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
+++ b/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
@@ -112,9 +112,6 @@ const ScreenFooter = (props: ScreenFooterProps) => {
     }
   }, [layout, itemsFit, alignment]);
 
-  // TODO: Consider wrapping useSafeAreaInsets in a try-catch to gracefully handle
-  // missing SafeAreaProvider (e.g. when ScreenFooter is used indirectly via FloatingButton).
-  // Fallback: Constants.getSafeAreaInsets()
   const useSafeAreaInsets = SafeAreaContextPackage?.useSafeAreaInsets ?? (() => Constants.getSafeAreaInsets());
   const insets = useSafeAreaInsets();
 

--- a/packages/react-native-ui-lib/src/components/screenFooter/screenFooter.api.json
+++ b/packages/react-native-ui-lib/src/components/screenFooter/screenFooter.api.json
@@ -123,11 +123,7 @@
           },
           {
             "type": "table",
-            "columns": [
-              "Layout Type",
-              "Use Case",
-              "Example"
-            ],
+            "columns": ["Layout Type", "Use Case", "Example"],
             "items": [
               {
                 "title": "Horizontal - Spread",
@@ -162,11 +158,7 @@
           },
           {
             "type": "table",
-            "columns": [
-              "Layout Type",
-              "Use Case",
-              "Example"
-            ],
+            "columns": ["Layout Type", "Use Case", "Example"],
             "items": [
               {
                 "title": "Vertical - Fit",
@@ -192,11 +184,7 @@
           },
           {
             "type": "table",
-            "columns": [
-              "Background Type",
-              "Visual",
-              "When to Use"
-            ],
+            "columns": ["Background Type", "Visual", "When to Use"],
             "items": [
               {
                 "title": "Solid",
@@ -231,11 +219,7 @@
           },
           {
             "type": "table",
-            "columns": [
-              "Behavior",
-              "Description",
-              "Example"
-            ],
+            "columns": ["Behavior", "Description", "Example"],
             "items": [
               {
                 "title": "Sticky",
@@ -264,4 +248,3 @@
     ]
   }
 }
-

--- a/packages/react-native-ui-lib/src/components/screenFooter/screenFooter.api.json
+++ b/packages/react-native-ui-lib/src/components/screenFooter/screenFooter.api.json
@@ -81,6 +81,11 @@
       "type": "boolean",
       "description": "If true, hides the top divider for solid background. Only applies when backgroundType is 'solid'",
       "default": "false"
+    },
+    {
+      "name": "contentContainerStyle",
+      "type": "StyleProp<ViewStyle>",
+      "description": "Custom style for the content container that wraps the footer's children. Can be used to override default padding, gap, or other layout properties."
     }
   ],
   "snippet": [

--- a/packages/react-native-ui-lib/src/components/screenFooter/types.ts
+++ b/packages/react-native-ui-lib/src/components/screenFooter/types.ts
@@ -1,5 +1,5 @@
 import {PropsWithChildren} from 'react';
-import {DimensionValue} from 'react-native';
+import {DimensionValue, StyleProp, ViewStyle} from 'react-native';
 
 export enum ScreenFooterLayouts {
     HORIZONTAL = 'horizontal',
@@ -105,5 +105,10 @@ export interface ScreenFooterProps extends PropsWithChildren<{}> {
      * Only applies when backgroundType is 'solid'
      */
     hideDivider?: boolean;
+    /**
+     * Custom style for the content container that wraps the footer's children.
+     * Can be used to override default padding, gap, or other layout properties.
+     */
+    contentContainerStyle?: StyleProp<ViewStyle>;
 }
 


### PR DESCRIPTION
## Description
- Rewrote FloatingButton component to a function component that renders ScreenFooter internally, while keeping the same external API and visual behavior. 
- All existing props work as before, mapped to their ScreenFooter equivalents. 
- Added hoisted prop (default: true) that gives FloatingButton built-in keyboard-awareness using screenFooter's logic.
- Updated FloatingButtonScreen to use SafeAreaProvider

## Changelog
floatingButton - changed to use new ScreenFooter component internally. deprecated original component.

## Additional info
Ticket 5000
