### PR TITLE
ScreenFooterScreen - fix errors when SafeAreaContext is not installed

### DIFF
--- a/demo/src/optionalDependencies/SafeAreaContextPackage.tsx
+++ b/demo/src/optionalDependencies/SafeAreaContextPackage.tsx
@@ -1,0 +1,6 @@
+let SafeAreaContextPackage;
+try {
+  SafeAreaContextPackage = require('react-native-safe-area-context');
+} catch {}
+
+export default SafeAreaContextPackage;

--- a/demo/src/optionalDependencies/index.ts
+++ b/demo/src/optionalDependencies/index.ts
@@ -1,0 +1,1 @@
+export {default as SafeAreaContextPackage} from './SafeAreaContextPackage';

--- a/demo/src/screens/componentScreens/ScreenFooterScreen.tsx
+++ b/demo/src/screens/componentScreens/ScreenFooterScreen.tsx
@@ -19,11 +19,8 @@ import {
   Incubator,
   Icon
 } from 'react-native-ui-lib';
-
-let SafeAreaProvider: React.ComponentType<any> | undefined;
-try {
-  SafeAreaProvider = require('react-native-safe-area-context').SafeAreaProvider;
-} catch {}
+import {SafeAreaContextPackage} from '../../optionalDependencies';
+const SafeAreaProvider = SafeAreaContextPackage?.SafeAreaProvider;
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const basketIcon = require('../../assets/icons/collections.png');


### PR DESCRIPTION
## Description
ScreenFooterScreen - fix errors when SafeAreaContext is not installed
Apparently it's important for the optional dep to be in a different file

## Changelog
ScreenFooterScreen - fix errors when SafeAreaContext is not installed

## Additional info
None