### PR TITLE
[Slider] Fix Android hitSlop by replacing touchArea overlay with responder system

### DIFF
--- a/packages/react-native-ui-lib/jestSetup/jest-setup.js
+++ b/packages/react-native-ui-lib/jestSetup/jest-setup.js
@@ -77,6 +77,7 @@ jest.mock('react-native-gesture-handler',
       PanMock.onFinalize = getDefaultMockedHandler('onFinalize');
       PanMock.activateAfterLongPress = getDefaultMockedHandler('activateAfterLongPress');
       PanMock.enabled = getDefaultMockedHandler('enabled');
+      PanMock.hitSlop = getDefaultMockedHandler('hitSlop');
       PanMock.onTouchesMove = getDefaultMockedHandler('onTouchesMove');
       PanMock.prepare = jest.fn();
       PanMock.initialize = jest.fn();

--- a/packages/react-native-ui-lib/src/components/slider/index.tsx
+++ b/packages/react-native-ui-lib/src/components/slider/index.tsx
@@ -498,6 +498,10 @@ class Slider extends PureComponent<InternalSliderProps, State> {
     this.handleMeasure('thumbSize', nativeEvent);
   };
 
+  handleContainerShouldSetResponder = () => {
+    return !this.props.disabled;
+  };
+
   handleTrackPress = (event: GestureResponderEvent) => {
     if (this.props.disabled) {
       return;
@@ -672,10 +676,11 @@ class Slider extends PureComponent<InternalSliderProps, State> {
         onLayout={this.onContainerLayout}
         onAccessibilityAction={this.onAccessibilityAction}
         testID={testID}
+        onStartShouldSetResponder={this.handleContainerShouldSetResponder}
+        onResponderRelease={this.handleTrackPress}
         {...this.getAccessibilityProps()}
       >
         {this.renderTrack()}
-        <View style={styles.touchArea} onTouchEnd={this.handleTrackPress}/>
         {this.renderRangeThumb()}
         {this.renderThumb()}
       </View>
@@ -700,9 +705,5 @@ const styles = StyleSheet.create({
   },
   trackDisableRTL: {
     right: 0
-  },
-  touchArea: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: 'transparent'
   }
 });

--- a/packages/react-native-ui-lib/src/incubator/slider/Thumb.tsx
+++ b/packages/react-native-ui-lib/src/incubator/slider/Thumb.tsx
@@ -62,6 +62,7 @@ const Thumb = (props: ThumbProps) => {
   const lastOffset = useSharedValue(0);
 
   const gesture = Gesture.Pan()
+    .hitSlop(hitSlop ?? DEFAULT_THUMB_HIT_SLOP)
     .onBegin(() => {
       onSeekStart?.();
       isPressed.value = true;


### PR DESCRIPTION
## Description
Fixes an Android bug where touches near the Slider thumb fail to start a drag.

**Slider** – The `touchArea` overlay (`absoluteFillObject`) intercepted touches in the thumb's `hitSlop` zone before they reached the PanResponder.
Replaced it with the container's Gesture Responder System (`onStartShouldSetResponder + onResponderRelease`) — the thumb (deepest child) wins for direct touches, the container handles track taps. 
`hitSlop` now works consistently on both platforms.

**Incubator.Slider** – Added `.hitSlop()` to the RNGH `Gesture.Pan()` on the thumb, so the gesture handler natively recognizes touches in the expanded hit area on Android. 
Also added `hitSlop` to the Pan gesture mock in jest setup.

## Changelog

**Slider, Incubator.Slider** - Fixed Android bug where touches near the thumb failed to start a drag.

## Additional info
- MADS-4866
- React Native [Gesture Responder System docs](https://reactnative.dev/docs/gesture-responder-system)