### PR TITLE
ScreenFooter - fix overflow in Fit mode, fix stretching issues

### DIFF
--- a/demo/src/screens/componentScreens/ScreenFooterScreen.tsx
+++ b/demo/src/screens/componentScreens/ScreenFooterScreen.tsx
@@ -200,7 +200,7 @@ const ScreenFooterContent = () => {
     // Extra Text (Total price)
     if (showExtraText) {
       items.push(
-        <View key="extra-text" centerV flexS marginB-s4={!isHorizontal}>
+        <View key="extra-text" center flexS marginB-s4={!isHorizontal}>
           <Text {...{[textPreset.main]: true}} numberOfLines={1}>
             Total:{' '}
             <Text {...{[textPreset.main]: true}} style={{fontWeight: 'bold'}}>
@@ -217,7 +217,7 @@ const ScreenFooterContent = () => {
     // Image (Basket icon)
     if (showExtraText && showImage) {
       items.push(
-        <View key="extra-image" centerV marginB-s4={!isHorizontal}>
+        <View key="extra-image" center marginB-s4={!isHorizontal}>
           <Icon source={basketIcon} size={imageSize} tintColor={Colors.$iconDefault} />
         </View>
       );

--- a/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
+++ b/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
@@ -199,7 +199,7 @@ const ScreenFooter = (props: ScreenFooterProps) => {
     (child: React.ReactNode, index: number) => {
       if (itemsFit === ItemsFit.FIXED && itemWidth) {
         const fixedStyle: ViewStyle = isHorizontal
-          ? {width: itemWidth, flexShrink: 1, overflow: 'hidden', flexDirection: 'row', justifyContent: 'center'}
+          ? {width: itemWidth, flexShrink: 1, overflow: 'hidden'}
           : {width: itemWidth, maxWidth: '100%'};
         return (
           <View key={index} style={fixedStyle}>
@@ -210,11 +210,20 @@ const ScreenFooter = (props: ScreenFooterProps) => {
 
       if (isHorizontal && React.isValidElement(child) && itemsFit === ItemsFit.STRETCH) {
         return (
-          <View flex row centerH key={index}>
+          <View flex key={index}>
             {child}
           </View>
         );
       }
+
+      if (isHorizontal) {
+        return (
+          <View flexS key={index}>
+            {child}
+          </View>
+        );
+      }
+
       return child;
     },
     [itemsFit, itemWidth, isHorizontal]


### PR DESCRIPTION
## Description
- Fixed layout bugs in horizontal STRETCH, FIXED, and FIT modes caused by the previous row + justifyContent: center approach for centering items. That approach centered items but prevented buttons from stretching,

- Replaced with column-direction wrappers (where default alignItems: 'stretch' handles button stretching) and cloneElement with the center modifier to inject centering into children's internal layout. This is necessary because alignItems: 'stretch' and alignItems: 'center' can't both be applied to the same container - the wrapper handles stretch, and the clone handles centering.

- Restored flexShrink wrapping for horizontal FIT mode, which was lost during the earlier refactor.

## Changelog
ScreenFooter - overflow and stretching bug fixes.

## Additional info
N/A
