### PR TITLE
FloatingButton migration fix - add default bottom spacing

### DIFF
--- a/packages/react-native-ui-lib/src/components/floatingButton/__tests__/index.spec.tsx
+++ b/packages/react-native-ui-lib/src/components/floatingButton/__tests__/index.spec.tsx
@@ -4,6 +4,7 @@ import {render} from '@testing-library/react-native';
 import FloatingButton, {FloatingButtonLayouts} from '../index';
 import {ButtonDriver} from '../../button/Button.driver.new';
 import {useComponentDriver, ComponentProps} from '../../../testkit/new/Component.driver';
+import {Spacings} from '../../../style';
 
 const TEST_ID = 'floating_button';
 const button = {
@@ -97,22 +98,36 @@ describe('FloatingButton', () => {
   });
 
   describe('bottomMargin', () => {
-    it('should have default paddingBottom when bottomMargin is not provided', () => {
+    it('should default to s8 paddingBottom with primary button only', () => {
       const props = {visible: true, button};
       const renderTree = render(<StickyTestCase {...props}/>);
       const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
-      const defaultPaddingBottom = contentDriver.getStyle().paddingBottom as number;
 
-      expect(defaultPaddingBottom).toBeGreaterThan(0);
+      expect(contentDriver.getStyle().paddingBottom).toBe(Spacings.s8);
     });
 
-    it('should have default paddingBottom with both buttons when bottomMargin is not provided', () => {
+    it('should default to s7 paddingBottom with both buttons in vertical layout', () => {
       const props = {visible: true, button, secondaryButton};
       const renderTree = render(<StickyTestCase {...props}/>);
       const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
-      const defaultPaddingBottom = contentDriver.getStyle().paddingBottom as number;
 
-      expect(defaultPaddingBottom).toBeGreaterThan(0);
+      expect(contentDriver.getStyle().paddingBottom).toBe(Spacings.s7);
+    });
+
+    it('should default to s8 paddingBottom with both buttons in horizontal layout', () => {
+      const props = {visible: true, button, secondaryButton, buttonLayout: FloatingButtonLayouts.HORIZONTAL};
+      const renderTree = render(<StickyTestCase {...props}/>);
+      const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
+
+      expect(contentDriver.getStyle().paddingBottom).toBe(Spacings.s8);
+    });
+
+    it('should default to s7 paddingBottom with secondary button only', () => {
+      const props = {visible: true, secondaryButton};
+      const renderTree = render(<StickyTestCase {...props}/>);
+      const contentDriver = ContentDriver({renderTree, testID: `${TEST_ID}.content`});
+
+      expect(contentDriver.getStyle().paddingBottom).toBe(Spacings.s7);
     });
 
     it('should apply bottomMargin as paddingBottom on the content container', () => {

--- a/packages/react-native-ui-lib/src/components/floatingButton/index.tsx
+++ b/packages/react-native-ui-lib/src/components/floatingButton/index.tsx
@@ -2,7 +2,7 @@ import React, {PropsWithChildren, useEffect, useMemo} from 'react';
 import {StyleSheet} from 'react-native';
 import {asBaseComponent} from '../../commons/new';
 import {LogService} from '../../services';
-import {Colors, Shadows} from '../../style';
+import {Colors, Shadows, Spacings} from '../../style';
 import Button, {ButtonProps} from '../button';
 import ScreenFooter, {ScreenFooterLayouts, ScreenFooterBackgrounds, KeyboardBehavior, ItemsFit} from '../screenFooter';
 
@@ -91,15 +91,16 @@ const FloatingButton = (props: FloatingButtonProps) => {
     );
   }, []);
 
+  const isSecondaryOnly = !!secondaryButton && !button;
+  const isHorizontal = buttonLayout === FloatingButtonLayouts.HORIZONTAL || isSecondaryOnly;
+
   const footerContentContainerStyle = useMemo(() => {
     if (bottomMargin !== undefined) {
       return {paddingBottom: bottomMargin};
     }
-    return undefined;
-  }, [bottomMargin]);
-
-  const isSecondaryOnly = !!secondaryButton && !button;
-  const isHorizontal = buttonLayout === FloatingButtonLayouts.HORIZONTAL || isSecondaryOnly;
+    const isSecondaryAtBottom = !!secondaryButton && (isSecondaryOnly || !isHorizontal);
+    return {paddingBottom: isSecondaryAtBottom ? Spacings.s7 : Spacings.s8};
+  }, [bottomMargin, secondaryButton, isSecondaryOnly, isHorizontal]);
 
   if (!button && !secondaryButton) {
     return null;


### PR DESCRIPTION
## Description
the issue was reproduced when FloatingButton sits inside a bottom-tab navigator - the tab bar consumes the safe area, causing insets.bottom = 0. 
to fix cases like that, where insets.bottom = 0 - FloatingButton now always passes a contentContainerStyle with the correct default paddingBottom matching the pre-migration behavior.

## Changelog
FloatingButton - default bottom padding added.

## Additional info
N/A
