### PR TITLE
feat (ChipsInput): Add ChipsInputChangeReason export to index

### DIFF
--- a/packages/react-native-ui-lib/src/components/chipsInput/index.tsx
+++ b/packages/react-native-ui-lib/src/components/chipsInput/index.tsx
@@ -12,6 +12,9 @@ export enum ChipsInputChangeReason {
   Removed = 'removed'
 }
 
+export type ChipsInputChangeReasonUnion = `${ChipsInputChangeReason}`;
+export type ChipsInputChangeReasonProps = ChipsInputChangeReasonUnion | ChipsInputChangeReason;
+
 type RenderChip = {index: number; chip: ChipsInputChipProps; isMarkedForRemoval: boolean};
 
 export type ChipsInputChipProps = ChipProps & {invalid?: boolean};

--- a/packages/react-native-ui-lib/src/components/chipsInput/index.tsx
+++ b/packages/react-native-ui-lib/src/components/chipsInput/index.tsx
@@ -12,7 +12,7 @@ export enum ChipsInputChangeReason {
   Removed = 'removed'
 }
 
-export type ChipsInputChangeReasonUnion = `${ChipsInputChangeReason}`;
+type ChipsInputChangeReasonUnion = `${ChipsInputChangeReason}`;
 export type ChipsInputChangeReasonProps = ChipsInputChangeReasonUnion | ChipsInputChangeReason;
 
 type RenderChip = {index: number; chip: ChipsInputChipProps; isMarkedForRemoval: boolean};

--- a/packages/react-native-ui-lib/src/index.ts
+++ b/packages/react-native-ui-lib/src/index.ts
@@ -47,7 +47,7 @@ export {default as Button, ButtonProps, ButtonSize, ButtonAnimationDirection} fr
 export {default as Card, CardProps, CardSectionProps, CardSelectionOptions} from './components/card';
 export {default as Carousel, CarouselProps, PageControlPosition} from './components/carousel';
 export {default as Checkbox, CheckboxProps, CheckboxRef} from './components/checkbox';
-export {default as ChipsInput, ChipsInputProps, ChipsInputChipProps, ChipsInputChangeReason} from './components/chipsInput';
+export {default as ChipsInput, ChipsInputProps, ChipsInputChipProps, ChipsInputChangeReason, ChipsInputChangeReasonUnion, ChipsInputChangeReasonProps} from './components/chipsInput';
 export {default as Chip, ChipProps} from './components/chip';
 export {default as ColorPicker, ColorPickerProps} from './components/colorPicker';
 export {default as ColorPalette, ColorPaletteProps} from './components/colorPalette';

--- a/packages/react-native-ui-lib/src/index.ts
+++ b/packages/react-native-ui-lib/src/index.ts
@@ -47,7 +47,7 @@ export {default as Button, ButtonProps, ButtonSize, ButtonAnimationDirection} fr
 export {default as Card, CardProps, CardSectionProps, CardSelectionOptions} from './components/card';
 export {default as Carousel, CarouselProps, PageControlPosition} from './components/carousel';
 export {default as Checkbox, CheckboxProps, CheckboxRef} from './components/checkbox';
-export {default as ChipsInput, ChipsInputProps, ChipsInputChipProps} from './components/chipsInput';
+export {default as ChipsInput, ChipsInputProps, ChipsInputChipProps, ChipsInputChangeReason} from './components/chipsInput';
 export {default as Chip, ChipProps} from './components/chip';
 export {default as ColorPicker, ColorPickerProps} from './components/colorPicker';
 export {default as ColorPalette, ColorPaletteProps} from './components/colorPalette';

--- a/packages/react-native-ui-lib/src/index.ts
+++ b/packages/react-native-ui-lib/src/index.ts
@@ -47,7 +47,7 @@ export {default as Button, ButtonProps, ButtonSize, ButtonAnimationDirection} fr
 export {default as Card, CardProps, CardSectionProps, CardSelectionOptions} from './components/card';
 export {default as Carousel, CarouselProps, PageControlPosition} from './components/carousel';
 export {default as Checkbox, CheckboxProps, CheckboxRef} from './components/checkbox';
-export {default as ChipsInput, ChipsInputProps, ChipsInputChipProps, ChipsInputChangeReason, ChipsInputChangeReasonUnion, ChipsInputChangeReasonProps} from './components/chipsInput';
+export {default as ChipsInput, ChipsInputProps, ChipsInputChipProps, ChipsInputChangeReason, ChipsInputChangeReasonProps} from './components/chipsInput';
 export {default as Chip, ChipProps} from './components/chip';
 export {default as ColorPicker, ColorPickerProps} from './components/colorPicker';
 export {default as ColorPalette, ColorPaletteProps} from './components/colorPalette';


### PR DESCRIPTION
## Description
Exports ChipsInputChangeReason as a top-level API so consumers can import it directly from react-native-ui-lib instead of using Incubator.

## Changelog
feat: ChipsInput - Export ChipsInputChangeReason from public API

## Additional info
Related to 4728
