### PR TITLE
fix(dialog): add activeOffset to Pan gesture to prevent scroll conflicts on Android

### DIFF
--- a/packages/react-native-ui-lib/src/components/dialog/index.tsx
+++ b/packages/react-native-ui-lib/src/components/dialog/index.tsx
@@ -190,6 +190,8 @@ const Dialog = (props: DialogProps, ref: ForwardedRef<DialogImperativeMethods>) 
   };
 
   const panGesture = Gesture.Pan()
+    .activeOffsetY([-15, 15])
+    .activeOffsetX([-15, 15])
     .onStart(event => {
       initialTranslation.value =
         getTranslationReverseInterpolation(isVertical ? event.translationY : event.translationX) - visibility.value;


### PR DESCRIPTION
## Summary

- **Add `activeOffsetY([-15, 15])` and `activeOffsetX([-15, 15])`** to the `Dialog` component's `Gesture.Pan()` handler, creating a 15px activation dead zone before the pan gesture begins.

### Problem

The `Dialog` component wraps its content in a `GestureDetector` with a bare `Gesture.Pan()` that activates immediately on any touch movement. When the dialog contains a scrollable list (e.g. a `FlatList` rendered by `Picker` in dialog mode), the pan gesture intercepts vertical touch events before the nested scroll view can process them.

On **Android** — which has stricter gesture resolution than iOS — this causes nested scrollable content (such as picker item lists) to be **glitchy and unresponsive**. Users cannot scroll through items or reliably tap to select them, because the dialog's swipe-to-dismiss gesture steals the touch.

### Fix

Adding `.activeOffsetY([-15, 15]).activeOffsetX([-15, 15])` to `Gesture.Pan()` tells `react-native-gesture-handler` to not activate the pan gesture until the user has moved at least 15px in either axis. This gives nested scroll views (like `FlatList`) priority for small movements, while still allowing deliberate swipe-to-dismiss gestures.

This is a standard `react-native-gesture-handler` pattern for resolving gesture conflicts between a parent pan handler and a child scroll view.

### Changed files

| File | Change |
|------|--------|
| `packages/react-native-ui-lib/src/components/dialog/index.tsx` | Add `.activeOffsetY([-15, 15]).activeOffsetX([-15, 15])` to `Gesture.Pan()` on line 192 |

## Test plan

- [ ] Open a `Dialog` containing a scrollable `FlatList` on Android
- [ ] Verify the list scrolls smoothly without the dialog intercepting touches
- [ ] Verify swipe-to-dismiss still works with a deliberate swipe (> 15px movement)
- [ ] Verify iOS behavior is unchanged
- [ ] Verify horizontal dialog direction still works correctly