### PR TITLE
Fix ScreenFooter - add zIndex to container

### DIFF
--- a/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
+++ b/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
@@ -267,7 +267,8 @@ const styles = StyleSheet.create({
     position: 'absolute',
     bottom: 0,
     left: 0,
-    right: 0
+    right: 0,
+    zIndex: 1
   },
   contentContainer: {
     paddingTop: Spacings.s4,


### PR DESCRIPTION
## Description
Add zIndex to ScreenFooter container to fix FloatingButton pressability

## Changelog
Add zIndex: 1 to ScreenFooter container

## Additional info
Fix for FloatingButton not being pressable


