### PR TITLE
FloatingButton - improve initial visibility handling with useRef

### DIFF
--- a/packages/react-native-ui-lib/src/components/floatingButton/index.tsx
+++ b/packages/react-native-ui-lib/src/components/floatingButton/index.tsx
@@ -1,4 +1,4 @@
-import React, {PropsWithChildren, useEffect, useMemo} from 'react';
+import React, {PropsWithChildren, useEffect, useMemo, useRef} from 'react';
 import {StyleSheet} from 'react-native';
 import {asBaseComponent, Constants} from '../../commons/new';
 import {LogService} from '../../services';
@@ -85,6 +85,13 @@ const FloatingButton = (props: FloatingButtonProps) => {
     testID
   } = props;
 
+  const initialVisibility = useRef(visible);
+  const firstLoad = useRef(true);
+
+  if (firstLoad.current && visible) {
+    firstLoad.current = false;
+  }
+
   useEffect(() => {
     // eslint-disable-next-line max-len
     LogService.warn(
@@ -104,6 +111,10 @@ const FloatingButton = (props: FloatingButtonProps) => {
   }, [bottomMargin, secondaryButton, isSecondaryOnly, isHorizontal]);
 
   if (!button && !secondaryButton) {
+    return null;
+  }
+
+  if (firstLoad.current && !initialVisibility.current) {
     return null;
   }
 


### PR DESCRIPTION
## Description
Restore the old FloatingButton first-load behavior: if the button starts with visible=false, don’t render it until it first becomes visible. This prevents initially hidden floating buttons from appearing at the bottom before their first reveal. It is low-risk, only touches FloatingButton, but the first entrance animation is not restored because ScreenFooter mounts already visible.

## Changelog
DRAFT

## Additional info
DRAFT