### PR TITLE
ScreenFooter - do not use Animated.View when there's no animation

### DIFF
--- a/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
+++ b/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
@@ -51,6 +51,8 @@ const ScreenFooter = (props: ScreenFooterProps) => {
     contentContainerStyle: contentContainerStyleOverride
   } = props;
 
+  const withoutAnimation = animationDuration === 0;
+
   const keyboard = useAnimatedKeyboard({
     isNavigationBarTranslucentAndroid: isAndroidEdgeToEdge,
     isStatusBarTranslucentAndroid: isAndroidEdgeToEdge
@@ -237,9 +239,18 @@ const ScreenFooter = (props: ScreenFooterProps) => {
     );
   }, [renderBackground, testID, contentContainerStyle, childrenArray]);
 
+  const Container = useMemo(() => {
+    return withoutAnimation ? View : Animated.View;
+  }, [withoutAnimation]);
+
+  const containerStyle = useMemo(() => {
+    return withoutAnimation ? styles.container : [styles.container, hoistedAnimatedStyle];
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [withoutAnimation]);
+
   if (keyboardBehavior === KeyboardBehavior.HOISTED) {
     return (
-      <Animated.View style={[styles.container, hoistedAnimatedStyle]} pointerEvents={visible ? 'box-none' : 'none'}>
+      <Container style={containerStyle} pointerEvents={visible ? 'box-none' : 'none'}>
         <Keyboard.KeyboardAccessoryView
           renderContent={renderFooterContent}
           kbInputRef={undefined}
@@ -249,7 +260,7 @@ const ScreenFooter = (props: ScreenFooterProps) => {
           revealKeyboardInteractive
           onHeightChanged={setHeight}
         />
-      </Animated.View>
+      </Container>
     );
   }
 


### PR DESCRIPTION
## Description
ScreenFooter - do not use Animated.View when there's no animation
Fix FlatList hit-testing after scroll

## Changelog
ScreenFooter - do not use Animated.View when there's no animation

## Additional info
Ticket 5041