### PR TITLE
Revert "textField - a11y label improvements, testID fix. (#3947)"

### DIFF
--- a/packages/react-native-ui-lib/src/components/textField/TextField.driver.new.ts
+++ b/packages/react-native-ui-lib/src/components/textField/TextField.driver.new.ts
@@ -10,7 +10,6 @@ import {ViewDriver} from '../view/View.driver.new';
 
 export const TextFieldDriver = (props: ComponentProps, options?: ComponentDriverOptions) => {
   const driver = usePressableDriver(useComponentDriver(props, options));
-  const inputDriver = useComponentDriver({renderTree: props.renderTree, testID: `${props.testID}.input`}, options);
 
   const floatingPlaceholderDriver = TextDriver({
     renderTree: props.renderTree,
@@ -45,37 +44,35 @@ export const TextFieldDriver = (props: ComponentProps, options?: ComponentDriver
     testID: `${props.testID}.clearButton.container`
   });
 
-  const getInputElement = () => inputDriver.queryElement() ?? driver.getElement();
-
   const getValue = (): string | undefined => {
-    return getInputElement().props.value ?? getInputElement().props.defaultValue;
+    return driver.getElement().props.value ?? driver.getElement().props.defaultValue;
   };
 
   const changeText = (text: string): void => {
-    fireEvent.changeText(getInputElement(), text);
+    fireEvent.changeText(driver.getElement(), text);
   };
 
   const focus = (): void => {
-    fireEvent(getInputElement(), 'focus');
+    fireEvent(driver.getElement(), 'focus');
   };
 
   const blur = (): void => {
-    fireEvent(getInputElement(), 'blur');
+    fireEvent(driver.getElement(), 'blur');
   };
 
   const isEnabled = (): boolean => {
-    return !getInputElement().props.accessibilityState?.disabled;
+    return !driver.getElement().props.accessibilityState?.disabled;
   };
 
   const getPlaceholder = () => {
     const exists = (): boolean => {
-      const hasPlaceholder = !!getInputElement().props.placeholder;
+      const hasPlaceholder = !!driver.getElement().props.placeholder;
       const hasText = !!getValue();
       return hasPlaceholder && (!hasText || (hasText && floatingPlaceholderDriver.exists()));
     };
     const getText = (): string | undefined => {
       if (exists()) {
-        return getInputElement().props.placeholder;
+        return driver.getElement().props.placeholder;
       }
     };
 

--- a/packages/react-native-ui-lib/src/components/textField/index.tsx
+++ b/packages/react-native-ui-lib/src/components/textField/index.tsx
@@ -92,8 +92,6 @@ const TextField = (props: InternalTextFieldProps) => {
     readonly = false,
     showMandatoryIndication,
     clearButtonStyle,
-    testID,
-    accessibilityLabel: accessibilityLabelProp,
     ...others
   } = usePreset(props);
 
@@ -140,38 +138,9 @@ const TextField = (props: InternalTextFieldProps) => {
     [typographyStyle, colorStyle, others.style, centeredTextStyle, hasValue]);
   const dummyPlaceholderStyle = useMemo(() => [inputStyle, styles.dummyPlaceholder], [inputStyle]);
 
-  const defaultAccessibilityLabel = useMemo(() => {
-    const parts: string[] = [];
-
-    if (label) {
-      parts.push(label);
-    }
-
-    if (context.isMandatory) {
-      parts.push('required');
-    }
-
-    parts.push('textField');
-
-    if (helperText) {
-      parts.push(helperText);
-    } else if (placeholder) {
-      parts.push(placeholder);
-    }
-
-    if (showCharCounter && others.maxLength) {
-      parts.push(`you can enter up to ${others.maxLength} characters`);
-    }
-
-    return parts.join(', ');
-
-  }, [label, context.isMandatory, helperText, placeholder, showCharCounter, others.maxLength]);
-
-  const accessibilityLabel = accessibilityLabelProp ?? defaultAccessibilityLabel;
-
   return (
     <FieldContext.Provider value={context}>
-      <View {...containerProps} testID={testID} accessible accessibilityLabel={accessibilityLabel} style={[margins, positionStyle, containerStyle, centeredContainerStyle]}>
+      <View {...containerProps} style={[margins, positionStyle, containerStyle, centeredContainerStyle]}>
         <View row spread style={centeredContainerStyle}>
           <Label
             label={label}
@@ -180,7 +149,7 @@ const TextField = (props: InternalTextFieldProps) => {
             labelProps={labelProps}
             floatingPlaceholder={floatingPlaceholder}
             validationMessagePosition={validationMessagePosition}
-            testID={`${testID}.label`}
+            testID={`${props.testID}.label`}
             showMandatoryIndication={showMandatoryIndication}
             enableErrors={enableErrors}
           />
@@ -191,7 +160,7 @@ const TextField = (props: InternalTextFieldProps) => {
               validationMessage={others.validationMessage}
               validationMessageStyle={_validationMessageStyle}
               retainValidationSpace={retainValidationSpace && retainTopMessageSpace}
-              testID={`${testID}.validationMessage`}
+              testID={`${props.testID}.validationMessage`}
             />
           )}
           {topTrailingAccessory && <View>{topTrailingAccessory}</View>}
@@ -220,7 +189,7 @@ const TextField = (props: InternalTextFieldProps) => {
                   floatOnFocus={floatOnFocus}
                   validationMessagePosition={validationMessagePosition}
                   extraOffset={leadingAccessoryMeasurements?.width}
-                  testID={`${testID}.floatingPlaceholder`}
+                  testID={`${props.testID}.floatingPlaceholder`}
                   showMandatoryIndication={showMandatoryIndication}
                 />
               )}
@@ -229,7 +198,6 @@ const TextField = (props: InternalTextFieldProps) => {
                 placeholderTextColor={hidePlaceholder ? 'transparent' : placeholderTextColor}
                 value={fieldState.value}
                 {...others}
-                testID={`${testID}.input`}
                 readonly={readonly}
                 style={inputStyle}
                 onFocus={onFocus}
@@ -244,7 +212,7 @@ const TextField = (props: InternalTextFieldProps) => {
           {showClearButton && (
             <ClearButton
               onClear={onClear}
-              testID={`${testID}.clearButton`}
+              testID={`${props.testID}.clearButton`}
               onChangeText={onChangeText}
               clearButtonStyle={clearButtonStyle}
             />
@@ -262,11 +230,11 @@ const TextField = (props: InternalTextFieldProps) => {
                 validationIcon={validationIcon}
                 validationMessageStyle={_validationMessageStyle}
                 retainValidationSpace={retainValidationSpace}
-                testID={`${testID}.validationMessage`}
+                testID={`${props.testID}.validationMessage`}
               />
             )}
             {helperText && (
-              <Text $textNeutralHeavy subtext marginT-s1 testID={`${testID}.helperText`}>
+              <Text $textNeutralHeavy subtext marginT-s1 testID={`${props.testID}.helperText`}>
                 {helperText}
               </Text>
             )}
@@ -277,7 +245,7 @@ const TextField = (props: InternalTextFieldProps) => {
               <CharCounter
                 maxLength={others.maxLength}
                 charCounterStyle={charCounterStyle}
-                testID={`${testID}.charCounter`}
+                testID={`${props.testID}.charCounter`}
               />
             )}
           </View>


### PR DESCRIPTION
## Summary
- Reverts #3947 which moved `testID` to the outer container View and added `accessible={true}` grouping
- The change broke iOS Appium automation tests — `accessible={true}` on the container hides all children from the iOS accessibility tree, making the inner `TextInput` unreachable by XCUITest
- Reverting until a proper solution that satisfies both accessibility grouping and QA automation access is defined

## What was reverted
- `testID` no longer on outer container — back on the inner `TextInput` directly
- `accessible` / `accessibilityLabel` removed from outer container
- Driver updated to target root element again (not `.input` sub-element)

🤖 Generated with [Claude Code](https://claude.com/claude-code)