### PR TITLE
ScreenFooter - add animationType

### DIFF
--- a/demo/src/screens/componentScreens/ScreenFooterScreen.tsx
+++ b/demo/src/screens/componentScreens/ScreenFooterScreen.tsx
@@ -10,6 +10,7 @@ import {
   ScreenFooterLayouts,
   ScreenFooterBackgrounds,
   KeyboardBehavior,
+  ScreenFooterAnimationTypeProp,
   FooterAlignment,
   HorizontalItemsDistribution,
   ItemsFit,
@@ -88,6 +89,12 @@ const KEYBOARD_BEHAVIOR_OPTIONS = [
   {label: 'Hoisted', value: KeyboardBehavior.HOISTED}
 ];
 
+const ANIMATION_TYPE_OPTIONS = [
+  {label: 'Slide', value: 'slide'},
+  {label: 'Fade', value: 'fade'},
+  {label: 'None', value: 'none'}
+];
+
 const KEYBOARD_BEHAVIOR_OPTIONS_SPACED = [
   {label: 'Sticky', value: KeyboardBehavior.STICKY},
   {label: 'Hoisted', value: KeyboardBehavior.HOISTED},
@@ -115,6 +122,7 @@ const ScreenFooterContent = () => {
   const [layout, setLayout] = useState<ScreenFooterLayouts>(ScreenFooterLayouts.HORIZONTAL);
   const [background, setBackground] = useState<ScreenFooterBackgrounds>(ScreenFooterBackgrounds.SOLID);
   const [keyboardBehavior, setKeyboardBehavior] = useState<KeyboardBehavior>(KeyboardBehavior.STICKY);
+  const [animationType, setAnimationType] = useState<ScreenFooterAnimationTypeProp>('slide');
   const [alignment, setAlignment] = useState<FooterAlignment>(FooterAlignment.CENTER);
   const [horizontalAlignment, setHorizontalAlignment] = useState<FooterAlignment>(FooterAlignment.CENTER);
   const [distribution, setDistribution] = useState<HorizontalItemsDistribution>(HorizontalItemsDistribution.STACK);
@@ -390,6 +398,21 @@ const ScreenFooterContent = () => {
           </View>
         </View>
 
+        {/* Animation type */}
+        <View marginB-s4>
+          <Text text70M marginB-s2>
+            Animation Type
+          </Text>
+          <View row>
+            <SegmentedControl
+              segments={ANIMATION_TYPE_OPTIONS}
+              initialIndex={ANIMATION_TYPE_OPTIONS.findIndex(opt => opt.value === animationType)}
+              onChangeIndex={index => setAnimationType(ANIMATION_TYPE_OPTIONS[index].value)}
+            />
+            <View flex />
+          </View>
+        </View>
+
         {/* Alignment (Cross Axis) */}
         <View marginB-s4>
           <Text text70M marginB-s2>
@@ -478,6 +501,7 @@ const ScreenFooterContent = () => {
         layout={layout}
         backgroundType={background}
         keyboardBehavior={keyboardBehavior}
+        animationType={animationType}
         alignment={alignment}
         horizontalAlignment={horizontalAlignment}
         horizontalItemsDistribution={distribution}

--- a/packages/react-native-ui-lib/src/components/floatingButton/index.tsx
+++ b/packages/react-native-ui-lib/src/components/floatingButton/index.tsx
@@ -11,7 +11,7 @@ export enum FloatingButtonLayouts {
   HORIZONTAL = 'Horizontal'
 }
 
-export interface FloatingButtonProps extends Pick<ScreenFooterProps, 'isAndroidEdgeToEdge'> {
+export interface FloatingButtonProps extends Pick<ScreenFooterProps, 'isAndroidEdgeToEdge' | 'animationType'> {
   /**
    * Whether the button is visible
    */
@@ -82,6 +82,7 @@ const FloatingButton = (props: FloatingButtonProps) => {
     hideBackgroundOverlay,
     hoisted = Constants.isAndroid,
     isAndroidEdgeToEdge,
+    animationType,
     testID
   } = props;
 
@@ -162,6 +163,7 @@ const FloatingButton = (props: FloatingButtonProps) => {
       keyboardBehavior={hoisted ? KeyboardBehavior.HOISTED : KeyboardBehavior.STICKY}
       isAndroidEdgeToEdge={isAndroidEdgeToEdge}
       animationDuration={withoutAnimation ? 0 : duration}
+      animationType={animationType}
       itemsFit={fullWidth ? ItemsFit.STRETCH : undefined}
       contentContainerStyle={footerContentContainerStyle}
       testID={testID}

--- a/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
+++ b/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
@@ -237,9 +237,9 @@ const ScreenFooter = (props: ScreenFooterProps) => {
     );
   }, [renderBackground, testID, contentContainerStyle, childrenArray]);
 
-  if (keyboardBehavior === KeyboardBehavior.HOISTED) {
-    return (
-      <Animated.View style={[styles.container, hoistedAnimatedStyle]} pointerEvents={visible ? 'box-none' : 'none'}>
+  const renderKeyboardAwareFooter = useCallback(() => {
+    if (keyboardBehavior === 'hoisted') {
+      return (
         <Keyboard.KeyboardAccessoryView
           renderContent={renderFooterContent}
           kbInputRef={undefined}
@@ -249,13 +249,27 @@ const ScreenFooter = (props: ScreenFooterProps) => {
           revealKeyboardInteractive
           onHeightChanged={setHeight}
         />
-      </Animated.View>
-    );
-  }
+      );
+    } else {
+      return renderFooterContent();
+    }
+  }, [keyboardBehavior, renderFooterContent]);
+
+  const containerStyle = useMemo(() => {
+    return keyboardBehavior === 'hoisted'
+      ? [styles.container, hoistedAnimatedStyle]
+      : [styles.container, stickyAnimatedStyle];
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [keyboardBehavior]);
 
   return (
-    <Animated.View testID={testID} onLayout={onLayout} style={[styles.container, stickyAnimatedStyle]}>
-      {renderFooterContent()}
+    <Animated.View
+      testID={testID}
+      style={containerStyle}
+      onLayout={keyboardBehavior === 'hoisted' ? undefined : onLayout}
+      pointerEvents={keyboardBehavior === 'hoisted' ? (visible ? 'box-none' : 'none') : 'auto'}
+    >
+      {renderKeyboardAwareFooter()}
     </Animated.View>
   );
 };

--- a/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
+++ b/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
@@ -18,6 +18,7 @@ import {
   HorizontalItemsDistribution,
   ItemsFit,
   KeyboardBehavior,
+  ScreenFooterAnimationTypeProp,
   ScreenFooterShadow
 } from './types';
 
@@ -29,6 +30,7 @@ export {
   HorizontalItemsDistribution,
   ItemsFit,
   KeyboardBehavior,
+  ScreenFooterAnimationTypeProp,
   ScreenFooterShadow
 };
 const ScreenFooter = (props: ScreenFooterProps) => {
@@ -44,7 +46,8 @@ const ScreenFooter = (props: ScreenFooterProps) => {
     itemWidth,
     horizontalItemsDistribution: distribution,
     visible = true,
-    animationDuration: animationDurationProp,
+    animationDuration,
+    animationType,
     shadow = ScreenFooterShadow.SH20,
     hideDivider = false,
     isAndroidEdgeToEdge,
@@ -52,7 +55,8 @@ const ScreenFooter = (props: ScreenFooterProps) => {
   } = props;
 
   const {containerStyle, setHeight} = useAnimatedFooterStyle({
-    animationDuration: animationDurationProp,
+    animationDuration,
+    animationType,
     keyboardBehavior,
     visible,
     isAndroidEdgeToEdge

--- a/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
+++ b/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
@@ -244,7 +244,7 @@ const ScreenFooter = (props: ScreenFooterProps) => {
       testID={testID}
       style={containerStyle}
       onLayout={keyboardBehavior === 'hoisted' ? undefined : onLayout}
-      pointerEvents={keyboardBehavior === 'hoisted' ? (visible ? 'box-none' : 'none') : 'auto'}
+      pointerEvents={!visible ? 'none' : keyboardBehavior === 'hoisted' ? 'box-none' : 'auto'}
     >
       {renderKeyboardAwareFooter()}
     </Animated.View>

--- a/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
+++ b/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
@@ -1,6 +1,6 @@
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import React, {useCallback, useMemo} from 'react';
 import {LayoutChangeEvent, StyleSheet, ViewStyle} from 'react-native';
-import Animated, {useAnimatedKeyboard, useAnimatedStyle, useSharedValue, withTiming} from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
 import {Keyboard} from 'uilib-native';
 import {SafeAreaContextPackage} from '../../optionalDependencies';
 import View from '../view';
@@ -9,6 +9,7 @@ import Assets from '../../assets';
 import {Colors, Shadows, Spacings} from '../../style';
 import {asBaseComponent, Constants} from '../../commons/new';
 import {useKeyboardHeight} from '../../hooks';
+import useAnimatedFooterStyle from './useAnimatedFooterStyle';
 import {
   ScreenFooterProps,
   ScreenFooterLayouts,
@@ -30,7 +31,6 @@ export {
   KeyboardBehavior,
   ScreenFooterShadow
 };
-const androidVersion = Constants.getAndroidVersion();
 const ScreenFooter = (props: ScreenFooterProps) => {
   const {
     testID,
@@ -44,38 +44,18 @@ const ScreenFooter = (props: ScreenFooterProps) => {
     itemWidth,
     horizontalItemsDistribution: distribution,
     visible = true,
-    animationDuration = 200,
+    animationDuration: animationDurationProp,
     shadow = ScreenFooterShadow.SH20,
     hideDivider = false,
-    isAndroidEdgeToEdge = !!androidVersion && androidVersion >= 35 ? true : undefined,
+    isAndroidEdgeToEdge,
     contentContainerStyle: contentContainerStyleOverride
   } = props;
 
-  const keyboard = useAnimatedKeyboard({
-    isNavigationBarTranslucentAndroid: isAndroidEdgeToEdge,
-    isStatusBarTranslucentAndroid: isAndroidEdgeToEdge
-  });
-  const [height, setHeight] = useState(0);
-  const visibilityTranslateY = useSharedValue(0);
-
-  // Update visibility translation when visible or height changes
-  useEffect(() => {
-    visibilityTranslateY.value = withTiming(visible ? 0 : height, {duration: animationDuration});
-  }, [visible, height, animationDuration, visibilityTranslateY]);
-
-  // Animated style for STICKY behavior (counters Android system offset + visibility)
-  const stickyAnimatedStyle = useAnimatedStyle(() => {
-    const counterSystemOffset = Constants.isAndroid ? keyboard.height.value : 0;
-    return {
-      transform: [{translateY: counterSystemOffset + visibilityTranslateY.value}]
-    };
-  });
-
-  // Animated style for HOISTED behavior (visibility only, keyboard handled by KeyboardAccessoryView)
-  const hoistedAnimatedStyle = useAnimatedStyle(() => {
-    return {
-      transform: [{translateY: visibilityTranslateY.value}]
-    };
+  const {containerStyle, setHeight} = useAnimatedFooterStyle({
+    animationDuration: animationDurationProp,
+    keyboardBehavior,
+    visible,
+    isAndroidEdgeToEdge
   });
 
   const onLayout = useCallback((event: LayoutChangeEvent) => {
@@ -253,13 +233,6 @@ const ScreenFooter = (props: ScreenFooterProps) => {
     }
   }, [keyboardBehavior, renderFooterContent]);
 
-  const containerStyle = useMemo(() => {
-    return keyboardBehavior === 'hoisted'
-      ? [styles.container, hoistedAnimatedStyle]
-      : [styles.container, stickyAnimatedStyle];
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [keyboardBehavior]);
-
   return (
     <Animated.View
       testID={testID}
@@ -275,12 +248,6 @@ const ScreenFooter = (props: ScreenFooterProps) => {
 ScreenFooter.displayName = 'ScreenFooter';
 
 const styles = StyleSheet.create({
-  container: {
-    position: 'absolute',
-    bottom: 0,
-    left: 0,
-    right: 0
-  },
   contentContainer: {
     paddingTop: Spacings.s4,
     paddingHorizontal: Spacings.s5,

--- a/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
+++ b/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
@@ -199,30 +199,28 @@ const ScreenFooter = (props: ScreenFooterProps) => {
     return null;
   }, [testID, isSolid, isFading, solidBackgroundStyle]);
 
-  const renderChild = useCallback(
-    (child: React.ReactNode, index: number) => {
-      if (itemsFit === ItemsFit.FIXED && itemWidth) {
-        const fixedStyle: ViewStyle = isHorizontal
-          ? {width: itemWidth, flexShrink: 1, overflow: 'hidden', flexDirection: 'row', justifyContent: 'center'}
-          : {width: itemWidth, maxWidth: '100%'};
-        return (
-          <View key={index} style={fixedStyle}>
-            {child}
-          </View>
-        );
-      }
+  const renderChild = useCallback((child: React.ReactNode, index: number) => {
+    if (itemsFit === ItemsFit.FIXED && itemWidth) {
+      const fixedStyle: ViewStyle = isHorizontal
+        ? {width: itemWidth, flexShrink: 1, overflow: 'hidden', flexDirection: 'row', justifyContent: 'center'}
+        : {width: itemWidth, maxWidth: '100%'};
+      return (
+        <View key={index} style={fixedStyle}>
+          {child}
+        </View>
+      );
+    }
 
-      if (isHorizontal && React.isValidElement(child) && itemsFit === ItemsFit.STRETCH) {
-        return (
-          <View flex row centerH key={index}>
-            {child}
-          </View>
-        );
-      }
-      return child;
-    },
-    [itemsFit, itemWidth, isHorizontal]
-  );
+    if (isHorizontal && React.isValidElement(child) && itemsFit === ItemsFit.STRETCH) {
+      return (
+        <View flex row centerH key={index}>
+          {child}
+        </View>
+      );
+    }
+    return child;
+  },
+  [itemsFit, itemWidth, isHorizontal]);
 
   const childrenArray = React.Children.toArray(children).slice(0, 3).map(renderChild);
 

--- a/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
+++ b/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
@@ -51,8 +51,6 @@ const ScreenFooter = (props: ScreenFooterProps) => {
     contentContainerStyle: contentContainerStyleOverride
   } = props;
 
-  const withoutAnimation = animationDuration === 0;
-
   const keyboard = useAnimatedKeyboard({
     isNavigationBarTranslucentAndroid: isAndroidEdgeToEdge,
     isStatusBarTranslucentAndroid: isAndroidEdgeToEdge
@@ -239,18 +237,9 @@ const ScreenFooter = (props: ScreenFooterProps) => {
     );
   }, [renderBackground, testID, contentContainerStyle, childrenArray]);
 
-  const Container = useMemo(() => {
-    return withoutAnimation ? View : Animated.View;
-  }, [withoutAnimation]);
-
-  const containerStyle = useMemo(() => {
-    return withoutAnimation ? styles.container : [styles.container, hoistedAnimatedStyle];
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [withoutAnimation]);
-
   if (keyboardBehavior === KeyboardBehavior.HOISTED) {
     return (
-      <Container style={containerStyle} pointerEvents={visible ? 'box-none' : 'none'}>
+      <Animated.View style={[styles.container, hoistedAnimatedStyle]} pointerEvents={visible ? 'box-none' : 'none'}>
         <Keyboard.KeyboardAccessoryView
           renderContent={renderFooterContent}
           kbInputRef={undefined}
@@ -260,7 +249,7 @@ const ScreenFooter = (props: ScreenFooterProps) => {
           revealKeyboardInteractive
           onHeightChanged={setHeight}
         />
-      </Container>
+      </Animated.View>
     );
   }
 

--- a/packages/react-native-ui-lib/src/components/screenFooter/screenFooter.api.json
+++ b/packages/react-native-ui-lib/src/components/screenFooter/screenFooter.api.json
@@ -55,7 +55,7 @@
     {
       "name": "visible",
       "type": "boolean",
-      "description": "If true, the footer is visible. If false, it slides down",
+      "description": "If true, the footer is visible. If false, the footer is hidden using the configured animation type",
       "default": "true"
     },
     {

--- a/packages/react-native-ui-lib/src/components/screenFooter/screenFooter.api.json
+++ b/packages/react-native-ui-lib/src/components/screenFooter/screenFooter.api.json
@@ -59,9 +59,15 @@
       "default": "true"
     },
     {
+      "name": "animationType",
+      "type": "ScreenFooterAnimationTypeProp",
+      "description": "The animation type for showing/hiding the footer [slide, fade, none]",
+      "default": "'slide'"
+    },
+    {
       "name": "animationDuration",
       "type": "number",
-      "description": "Duration of the show/hide animation in ms",
+      "description": "Duration of the show/hide animation in ms (sending 0 will disable the animation)",
       "default": "200"
     },
     {

--- a/packages/react-native-ui-lib/src/components/screenFooter/types.ts
+++ b/packages/react-native-ui-lib/src/components/screenFooter/types.ts
@@ -40,7 +40,15 @@ export enum ScreenFooterShadow {
     SH30 = 'sh30'
 }
 
-export interface ScreenFooterProps extends PropsWithChildren<{}> {
+export interface AnimatedFooterStyleProps {
+    /**
+     * Duration of the show/hide animation in ms.
+     * @default 200
+     */
+    animationDuration?: number;
+}
+
+export interface ScreenFooterProps extends AnimatedFooterStyleProps, PropsWithChildren<{}> {
     /**
      * Used as testing identifier
      */
@@ -86,11 +94,6 @@ export interface ScreenFooterProps extends PropsWithChildren<{}> {
      * If true, the footer is visible. If false, it slides down.
      */
     visible?: boolean;
-    /**
-     * Duration of the show/hide animation in ms.
-     * @default 200
-     */
-    animationDuration?: number;
     /**
      * If true, the footer will respect the safe area (add bottom padding)
      */

--- a/packages/react-native-ui-lib/src/components/screenFooter/types.ts
+++ b/packages/react-native-ui-lib/src/components/screenFooter/types.ts
@@ -40,9 +40,22 @@ export enum ScreenFooterShadow {
     SH30 = 'sh30'
 }
 
+export enum ScreenFooterAnimation {
+    NONE = 'none',
+    SLIDE = 'slide',
+    FADE = 'fade'
+}
+
+export type ScreenFooterAnimationTypeProp = ScreenFooterAnimation | `${ScreenFooterAnimation}`;
+
 export interface AnimatedFooterStyleProps {
     /**
-     * Duration of the show/hide animation in ms.
+     * The type of animation to use when showing or hiding the footer.
+     * @default 'slide'
+     */
+    animationType?: ScreenFooterAnimationTypeProp;
+    /**
+     * Duration of the show/hide animation in ms (sending 0 will disable the animation).
      * @default 200
      */
     animationDuration?: number;

--- a/packages/react-native-ui-lib/src/components/screenFooter/useAnimatedFooterStyle.ts
+++ b/packages/react-native-ui-lib/src/components/screenFooter/useAnimatedFooterStyle.ts
@@ -21,21 +21,21 @@ const useAnimatedFooterStyle = (
   });
   const [height, setHeight] = useState(0);
 
-  const visibilityTranslateY = useSharedValue(0);
+  const animatedValue = useSharedValue(0);
 
   useEffect(() => {
-    visibilityTranslateY.value = withTiming(visible ? 0 : height, {duration: animationDuration});
-  }, [visible, height, animationDuration, visibilityTranslateY]);
+    animatedValue.value = withTiming(visible ? 0 : height, {duration: animationDuration});
+  }, [visible, height, animationDuration, animatedValue]);
 
   const animatedStyle = useAnimatedStyle(() => {
     if (keyboardBehavior === 'hoisted') {
       return {
-        transform: [{translateY: visibilityTranslateY.value}]
+        transform: [{translateY: animatedValue.value}]
       };
     } else {
       const counterSystemOffset = Constants.isAndroid ? keyboard.height.value : 0;
       return {
-        transform: [{translateY: counterSystemOffset + visibilityTranslateY.value}]
+        transform: [{translateY: counterSystemOffset + animatedValue.value}]
       };
     }
   });

--- a/packages/react-native-ui-lib/src/components/screenFooter/useAnimatedFooterStyle.ts
+++ b/packages/react-native-ui-lib/src/components/screenFooter/useAnimatedFooterStyle.ts
@@ -1,0 +1,62 @@
+import {useAnimatedKeyboard, useAnimatedStyle, useSharedValue, withTiming} from 'react-native-reanimated';
+import {StyleSheet} from 'react-native';
+import {AnimatedFooterStyleProps, ScreenFooterProps} from './types';
+import {Constants} from '../../commons/new';
+import {useEffect, useMemo, useState} from 'react';
+
+const androidVersion = Constants.getAndroidVersion();
+const useAnimatedFooterStyle = (
+  props: AnimatedFooterStyleProps & Pick<ScreenFooterProps, 'keyboardBehavior' | 'visible' | 'isAndroidEdgeToEdge'>
+) => {
+  const {
+    animationDuration = 200,
+    keyboardBehavior,
+    visible,
+    isAndroidEdgeToEdge = !!androidVersion && androidVersion >= 35 ? true : undefined
+  } = props;
+
+  const keyboard = useAnimatedKeyboard({
+    isNavigationBarTranslucentAndroid: isAndroidEdgeToEdge,
+    isStatusBarTranslucentAndroid: isAndroidEdgeToEdge
+  });
+  const [height, setHeight] = useState(0);
+
+  const visibilityTranslateY = useSharedValue(0);
+
+  useEffect(() => {
+    visibilityTranslateY.value = withTiming(visible ? 0 : height, {duration: animationDuration});
+  }, [visible, height, animationDuration, visibilityTranslateY]);
+
+  const stickyAnimatedStyle = useAnimatedStyle(() => {
+    const counterSystemOffset = Constants.isAndroid ? keyboard.height.value : 0;
+    return {
+      transform: [{translateY: counterSystemOffset + visibilityTranslateY.value}]
+    };
+  });
+
+  const hoistedAnimatedStyle = useAnimatedStyle(() => {
+    return {
+      transform: [{translateY: visibilityTranslateY.value}]
+    };
+  });
+
+  const containerStyle = useMemo(() => {
+    return keyboardBehavior === 'hoisted'
+      ? [styles.container, hoistedAnimatedStyle]
+      : [styles.container, stickyAnimatedStyle];
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [keyboardBehavior]);
+
+  return {containerStyle, setHeight};
+};
+
+export default useAnimatedFooterStyle;
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0
+  }
+});

--- a/packages/react-native-ui-lib/src/components/screenFooter/useAnimatedFooterStyle.ts
+++ b/packages/react-native-ui-lib/src/components/screenFooter/useAnimatedFooterStyle.ts
@@ -1,5 +1,5 @@
 import {useAnimatedKeyboard, useAnimatedStyle, useSharedValue, withTiming} from 'react-native-reanimated';
-import {StyleSheet} from 'react-native';
+import {StyleSheet, ViewStyle} from 'react-native';
 import {AnimatedFooterStyleProps, ScreenFooterProps} from './types';
 import {Constants} from '../../commons/new';
 import {useEffect, useMemo, useState} from 'react';
@@ -9,35 +9,50 @@ const useAnimatedFooterStyle = (
   props: AnimatedFooterStyleProps & Pick<ScreenFooterProps, 'keyboardBehavior' | 'visible' | 'isAndroidEdgeToEdge'>
 ) => {
   const {
-    animationDuration = 200,
+    animationType: animationTypeProp = 'slide',
+    animationDuration: animationDurationProp = 200,
     keyboardBehavior,
     visible,
     isAndroidEdgeToEdge = !!androidVersion && androidVersion >= 35 ? true : undefined
   } = props;
 
+  const animationType = animationDurationProp === 0 ? 'none' : animationTypeProp;
+  const animationDuration = animationType === 'none' ? 0 : animationDurationProp;
+
   const keyboard = useAnimatedKeyboard({
     isNavigationBarTranslucentAndroid: isAndroidEdgeToEdge,
     isStatusBarTranslucentAndroid: isAndroidEdgeToEdge
   });
-  const [height, setHeight] = useState(0);
 
-  const animatedValue = useSharedValue(0);
+  const [height, setHeight] = useState(0);
+  const animatedValue = useSharedValue(animationType === 'fade' && visible ? 1 : 0);
 
   useEffect(() => {
-    animatedValue.value = withTiming(visible ? 0 : height, {duration: animationDuration});
-  }, [visible, height, animationDuration, animatedValue]);
+    if (animationType === 'slide') {
+      animatedValue.value = withTiming(visible ? 0 : height, {duration: animationDuration});
+    } else {
+      animatedValue.value = withTiming(visible ? 1 : 0, {duration: animationDuration});
+    }
+  }, [visible, height, animationDuration, animatedValue, animationType]);
 
   const animatedStyle = useAnimatedStyle(() => {
-    if (keyboardBehavior === 'hoisted') {
-      return {
-        transform: [{translateY: animatedValue.value}]
-      };
+    let style: ViewStyle = {};
+    let translateY = 0;
+    if (animationType === 'slide') {
+      translateY = animatedValue.value;
     } else {
-      const counterSystemOffset = Constants.isAndroid ? keyboard.height.value : 0;
-      return {
-        transform: [{translateY: counterSystemOffset + animatedValue.value}]
-      };
+      style = {opacity: animatedValue.value};
     }
+
+    if (keyboardBehavior === 'sticky' && Constants.isAndroid) {
+      translateY += keyboard.height.value;
+    }
+
+    if (translateY !== 0) {
+      style.transform = [{translateY}];
+    }
+
+    return style;
   });
 
   const containerStyle = useMemo(() => {

--- a/packages/react-native-ui-lib/src/components/screenFooter/useAnimatedFooterStyle.ts
+++ b/packages/react-native-ui-lib/src/components/screenFooter/useAnimatedFooterStyle.ts
@@ -27,23 +27,21 @@ const useAnimatedFooterStyle = (
     visibilityTranslateY.value = withTiming(visible ? 0 : height, {duration: animationDuration});
   }, [visible, height, animationDuration, visibilityTranslateY]);
 
-  const stickyAnimatedStyle = useAnimatedStyle(() => {
-    const counterSystemOffset = Constants.isAndroid ? keyboard.height.value : 0;
-    return {
-      transform: [{translateY: counterSystemOffset + visibilityTranslateY.value}]
-    };
-  });
-
-  const hoistedAnimatedStyle = useAnimatedStyle(() => {
-    return {
-      transform: [{translateY: visibilityTranslateY.value}]
-    };
+  const animatedStyle = useAnimatedStyle(() => {
+    if (keyboardBehavior === 'hoisted') {
+      return {
+        transform: [{translateY: visibilityTranslateY.value}]
+      };
+    } else {
+      const counterSystemOffset = Constants.isAndroid ? keyboard.height.value : 0;
+      return {
+        transform: [{translateY: counterSystemOffset + visibilityTranslateY.value}]
+      };
+    }
   });
 
   const containerStyle = useMemo(() => {
-    return keyboardBehavior === 'hoisted'
-      ? [styles.container, hoistedAnimatedStyle]
-      : [styles.container, stickyAnimatedStyle];
+    return [styles.container, animatedStyle];
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [keyboardBehavior]);
 

--- a/packages/react-native-ui-lib/src/components/screenFooter/useAnimatedFooterStyle.ts
+++ b/packages/react-native-ui-lib/src/components/screenFooter/useAnimatedFooterStyle.ts
@@ -58,7 +58,7 @@ const useAnimatedFooterStyle = (
   const containerStyle = useMemo(() => {
     return [styles.container, animatedStyle];
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [keyboardBehavior]);
+  }, []);
 
   return {containerStyle, setHeight};
 };

--- a/packages/react-native-ui-lib/src/components/screenFooter/useAnimatedFooterStyle.ts
+++ b/packages/react-native-ui-lib/src/components/screenFooter/useAnimatedFooterStyle.ts
@@ -50,7 +50,7 @@ const useAnimatedFooterStyle = (
       translateY += keyboard.height.value;
     }
 
-    if (translateY !== 0) {
+    if (animationType === 'slide' || translateY !== 0) {
       style.transform = [{translateY}];
     }
 

--- a/packages/react-native-ui-lib/src/index.ts
+++ b/packages/react-native-ui-lib/src/index.ts
@@ -79,6 +79,7 @@ export {
   HorizontalItemsDistribution,
   ItemsFit,
   KeyboardBehavior,
+  ScreenFooterAnimationTypeProp,
   ScreenFooterShadow
 } from './components/screenFooter';
 export {default as Gradient, GradientProps, GradientTypes} from './components/gradient';


### PR DESCRIPTION
## Description
ScreenFooter - add animationType
Review each commit separately

Note:
There was another solution created by Ziv: #3987 however I feel like it is more bug prone; and even though this solution requires the user to change the animation from `slide` to `fade` (approved by UX) it is overall safer.

## Changelog
ScreenFooter - add animationType ['slide' (default) | 'fade' | 'none']

## Additional info
Ticket 5037