### PR TITLE
ScreenFooter - add zIndex to styles for proper stacking order

### DIFF
--- a/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
+++ b/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
@@ -48,6 +48,7 @@ const ScreenFooter = (props: ScreenFooterProps) => {
     shadow = ScreenFooterShadow.SH20,
     hideDivider = false,
     isAndroidEdgeToEdge = !!androidVersion && androidVersion >= 35 ? true : undefined,
+    containerStyle: containerStyleOverride,
     contentContainerStyle: contentContainerStyleOverride
   } = props;
 
@@ -244,9 +245,11 @@ const ScreenFooter = (props: ScreenFooterProps) => {
   }, [withoutAnimation]);
 
   const containerStyle = useMemo(() => {
-    return withoutAnimation ? styles.container : [styles.container, hoistedAnimatedStyle];
+    return withoutAnimation
+      ? [styles.container, containerStyleOverride]
+      : [styles.container, hoistedAnimatedStyle, containerStyleOverride];
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [withoutAnimation]);
+  }, [withoutAnimation, containerStyleOverride]);
 
   if (keyboardBehavior === KeyboardBehavior.HOISTED) {
     return (
@@ -265,7 +268,7 @@ const ScreenFooter = (props: ScreenFooterProps) => {
   }
 
   return (
-    <Animated.View testID={testID} onLayout={onLayout} style={[styles.container, stickyAnimatedStyle]}>
+    <Animated.View testID={testID} onLayout={onLayout} style={[styles.container, stickyAnimatedStyle, containerStyleOverride]}>
       {renderFooterContent()}
     </Animated.View>
   );

--- a/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
+++ b/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
@@ -278,7 +278,8 @@ const styles = StyleSheet.create({
     position: 'absolute',
     bottom: 0,
     left: 0,
-    right: 0
+    right: 0,
+    zIndex: 1
   },
   contentContainer: {
     paddingTop: Spacings.s4,

--- a/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
+++ b/packages/react-native-ui-lib/src/components/screenFooter/index.tsx
@@ -279,7 +279,7 @@ const styles = StyleSheet.create({
     bottom: 0,
     left: 0,
     right: 0,
-    zIndex: 1
+    zIndex: 50
   },
   contentContainer: {
     paddingTop: Spacings.s4,

--- a/packages/react-native-ui-lib/src/components/screenFooter/screenFooter.api.json
+++ b/packages/react-native-ui-lib/src/components/screenFooter/screenFooter.api.json
@@ -88,6 +88,11 @@
       "description": "Indicates if the device is an Android device that supports edge-to-edge. Defaults to true for Android with version 35 and above, undefined for others."
     },
     {
+      "name": "containerStyle",
+      "type": "StyleProp<ViewStyle>",
+      "description": "Custom style for the outer container of the footer. Can be used to override zIndex or other container-level properties."
+    },
+    {
       "name": "contentContainerStyle",
       "type": "StyleProp<ViewStyle>",
       "description": "Custom style for the content container that wraps the footer's children. Can be used to override default padding, gap, or other layout properties."

--- a/packages/react-native-ui-lib/src/components/screenFooter/types.ts
+++ b/packages/react-native-ui-lib/src/components/screenFooter/types.ts
@@ -107,7 +107,6 @@ export interface ScreenFooterProps extends PropsWithChildren<{}> {
     hideDivider?: boolean;
     /**
      * Custom style for the outer container of the footer.
-     * Can be used to override zIndex or other container-level properties.
      */
     containerStyle?: StyleProp<ViewStyle>;
     /**

--- a/packages/react-native-ui-lib/src/components/screenFooter/types.ts
+++ b/packages/react-native-ui-lib/src/components/screenFooter/types.ts
@@ -106,6 +106,11 @@ export interface ScreenFooterProps extends PropsWithChildren<{}> {
      */
     hideDivider?: boolean;
     /**
+     * Custom style for the outer container of the footer.
+     * Can be used to override zIndex or other container-level properties.
+     */
+    containerStyle?: StyleProp<ViewStyle>;
+    /**
      * Custom style for the content container that wraps the footer's children.
      * Can be used to override default padding, gap, or other layout properties.
      */


### PR DESCRIPTION
## Description
ScreenFooter's container had no zIndex, so any sibling rendered after it in the tree would intercept touches — button visible but not tappable. zIndex: 1 fixes it.
```
import React, {useState} from 'react';
import {ScrollView, StyleSheet} from 'react-native';
import {SafeAreaProvider} from 'react-native-safe-area-context';
import {Colors, FloatingButton, Switch, Text, View} from 'react-native-ui-lib';

export default function PlaygroundScreen() {
  const [showSibling, setShowSibling] = useState(false);
  const [pressCount, setPressCount] = useState(0);

  return (
    <SafeAreaProvider>
      <View flex>
        <ScrollView contentContainerStyle={styles.scrollContent}>
          <View style={styles.eventHeader} bg-$backgroundNeutralMedium centerV centerH>
            <Text headingM>Summer Networking Event</Text>
            <Text bodyM $textNeutral>No cover image</Text>
          </View>

          <View padding-page>
            <Text headingM marginB-s4>Summer Networking Event</Text>

            <View marginB-s3>
              <Text bodyLBold>Thursday, June 19, 2025</Text>
              <Text bodyM $textNeutral>7:00 PM – 10:00 PM</Text>
            </View>

            <View marginB-s3>
              <Text bodyLBold>Wix Tel Aviv HQ</Text>
              <Text bodyM $textNeutral>40 Namal Tel Aviv St, Tel Aviv</Text>
            </View>

            <Text bodyM $textNeutral marginB-s5>142 going · 38 spots left</Text>

            <Text bodyLBold marginB-s2>About this event</Text>
            <Text bodyM $textNeutral marginB-s5>
              Join us for an evening of networking, demos, and great conversations with fellow developers and designers.
              Light refreshments will be served. Spots are limited!
            </Text>

            <View row centerV spread marginB-s3>
              <Text bodyM>Add elevated sibling</Text>
              <Switch value={showSibling} onValueChange={setShowSibling}/>
            </View>

            <Text bodyM>FloatingButton pressed: {pressCount}</Text>
          </View>
        </ScrollView>

        <FloatingButton
          visible
          withoutAnimation
          button={{label: 'RSVP', onPress: () => setPressCount(prev => prev + 1)}}
        />

        {showSibling && <View style={styles.sibling}/>}
      </View>
    </SafeAreaProvider>
  );
}

const styles = StyleSheet.create({
  scrollContent: {
    paddingBottom: 120
  },
  eventHeader: {
    height: 180,
    justifyContent: 'center',
    alignItems: 'center'
  },
  sibling: {
    position: 'absolute',
    bottom: 0,
    left: 0,
    right: 0,
    height: 100,
    zIndex: 10,
    backgroundColor: Colors.red70
  }
});
```


## Changelog
ScreenFooter / FloatingButton - fix button not being tappable when a sibling View is rendered after it in the component tree.

## Additional info
Slack thred
