### PR TITLE
fix(SortableGridList): forward ScrollView props to inner ScrollView

### DIFF
--- a/packages/react-native-ui-lib/src/components/sortableGridList/__tests__/index.spec.tsx
+++ b/packages/react-native-ui-lib/src/components/sortableGridList/__tests__/index.spec.tsx
@@ -47,4 +47,10 @@ describe('SortableGridlist', () => {
     expect(onOrderChange).toHaveBeenCalledWith(newOrder.map(index => TEST_DATA[index]),
       newOrder.map(index => TEST_DATA[index].id));
   });
+  it('should forward ScrollView props to the inner ScrollView', () => {
+    const {getByTestId} = render(<TestCase scrollEnabled={false} showsVerticalScrollIndicator={false}/>);
+    const scrollView = getByTestId(testID);
+    expect(scrollView.props.scrollEnabled).toBe(false);
+    expect(scrollView.props.showsVerticalScrollIndicator).toBe(false);
+  });
 });

--- a/packages/react-native-ui-lib/src/components/sortableGridList/index.tsx
+++ b/packages/react-native-ui-lib/src/components/sortableGridList/index.tsx
@@ -16,8 +16,28 @@ function generateItemsOrder(data: SortableGridListProps['data']) {
   return _.map(data, item => item.id);
 }
 
+const CONSUMED_PROPS = [
+  'renderItem',
+  'onOrderChange',
+  'flexMigration',
+  'orderByIndex',
+  'data',
+  'extraData',
+  // Consumed by useGridLayout — re-applied via listStyle / listContentStyle / listColumnWrapperStyle.
+  'style',
+  'contentContainerStyle',
+  'columnWrapperStyle',
+  'numColumns',
+  'itemSpacing',
+  'maxItemWidth',
+  'listPadding',
+  'keepItemSize',
+  'containerWidth'
+];
+
 function SortableGridList<T = any>(props: SortableGridListProps<T>) {
-  const {renderItem, onOrderChange, flexMigration, orderByIndex = false, ...others} = props;
+  const {renderItem, onOrderChange, flexMigration, orderByIndex = false, data} = props;
+  const scrollViewProps = _.omit(props, CONSUMED_PROPS);
 
   const {
     itemContainerStyle,
@@ -28,7 +48,6 @@ function SortableGridList<T = any>(props: SortableGridListProps<T>) {
     listContentStyle,
     listColumnWrapperStyle
   } = useGridLayout(props);
-  const {data} = others;
   const itemsOrder = useSharedValue<ItemsOrder>(generateItemsOrder(data));
 
   // TODO: Remove once flexMigration migration is completed
@@ -79,6 +98,7 @@ function SortableGridList<T = any>(props: SortableGridListProps<T>) {
   return (
     <GestureHandlerRootView style={flexMigration ? styles.container : undefined}>
       <ScrollView
+        {...scrollViewProps}
         style={listStyle}
         contentContainerStyle={[styles.listContent, listContentStyle, listColumnWrapperStyle]}
       >


### PR DESCRIPTION
## Description

`SortableGridListProps` already extends `ScrollViewProps`, so consumers can type props like `scrollEnabled`, `showsVerticalScrollIndicator`, `keyboardShouldPersistTaps`, `refreshControl` on `<SortableGridList>`. However, none of them are forwarded to the internal `<ScrollView>` — they are silently dropped. This is also inconsistent with `SortableList`, which already spreads `{...others}` onto its inner `FlatList`.

This PR makes the implementation match the public type:

- Build `scrollViewProps` by `_.omit`-ing the props that `SortableGridList` and `useGridLayout` consume directly. The grid-layout style props (`style` / `contentContainerStyle` / `columnWrapperStyle`) are re-applied via the computed `listStyle` / `listContentStyle` / `listColumnWrapperStyle` further down, so they must be excluded from the spread to avoid clobbering the layout.
- Spread `{...scrollViewProps}` on the inner `ScrollView`.
- Add a unit test that asserts `scrollEnabled` and `showsVerticalScrollIndicator` reach the inner `ScrollView`.

### Motivation / use case

Drag-reorder UIs where the list fits on one screen need `scrollEnabled={false}` to prevent the inner `ScrollView`'s scroll gesture from competing with `SortableItem`'s long-press-drag gesture (drags near the top/bottom edge become unreliable otherwise). Today the only way to do this is via `patch-package`.

Closes #4002.

## Changelog

SortableGridList - now forwards all `ScrollView` props (e.g. `scrollEnabled`, `showsVerticalScrollIndicator`, `refreshControl`) to its internal `ScrollView`, as already implied by `SortableGridListProps extends ScrollViewProps`.

## Additional info

- Verified locally: `yarn workspace react-native-ui-lib jest sortableGridList` → 8/8 passing (added test included).
- `yarn build:dev` (TS check) passes with no new errors.
- ESLint on the changed file reports 0 errors / 0 new warnings.