### PR TITLE
fix: avoid duplicate Android autolinking config

### DIFF
--- a/packages/react-native-ui-lib/package.json
+++ b/packages/react-native-ui-lib/package.json
@@ -158,6 +158,7 @@
         "!lib/android/build",
         "!lib/scripts",
         "lib/package.json",
-        "lib/ReactNativeUILib.podspec"
+        "lib/ReactNativeUILib.podspec",
+        "!lib/react-native.config.js"
     ]
 }


### PR DESCRIPTION
## Description
Closes #3950

This keeps `react-native-ui-lib` from publishing the generated `lib/react-native.config.js` file that is copied from `uilib-native` during package builds.

`uilib-native` remains the package that owns the Android native autolinking config and native package classes. This avoids the JS package being treated as a second Android native package in newer React Native autolinking flows.

## Changelog

- Fix Android autolinking package metadata for `react-native-ui-lib` consumers using `uilib-native`.

## Additional info

Related user workaround in #3805: patching the copied `react-native.config.js` out of the JS package resolves the RN/Expo Android build failure. This PR applies that at packaging time instead.

## Verification

- `node -e "JSON.parse(require('fs').readFileSync('packages/react-native-ui-lib/package.json','utf8'))"`
- Created a temporary `packages/react-native-ui-lib/lib/react-native.config.js` from `packages/uilib-native/react-native.config.js`, then ran `npm pack ./packages/react-native-ui-lib --dry-run --json` and confirmed `lib/react-native.config.js` is excluded from the package file list.
- `git diff --check`

I did not run a full Android build locally; this machine does not have the required React Native Android app setup for the reported RN 0.84 flow.

This was implemented with Codex assistance, with the patch kept focused and manually reviewed.