### PR TITLE
ScrollFooter - fix another issue with touch not working after scroll (Android real device) | no animation + hide on scroll

### DIFF
--- a/packages/react-native-ui-lib/src/components/screenFooter/useAnimatedFooterStyle.ts
+++ b/packages/react-native-ui-lib/src/components/screenFooter/useAnimatedFooterStyle.ts
@@ -42,7 +42,7 @@ const useAnimatedFooterStyle = (
     let translateY = 0;
     if (animationType === 'slide') {
       translateY = animatedValue.value;
-    } else if (animationType === 'fade') {
+    } else {
       style = {opacity: animatedValue.value};
     }
 
@@ -50,7 +50,7 @@ const useAnimatedFooterStyle = (
       translateY += keyboard.height.value;
     }
 
-    if (animationType === 'slide' || translateY !== 0) {
+    if (translateY !== 0) {
       style.transform = [{translateY}];
     }
 


### PR DESCRIPTION
## Description
ScrollFooter
Revert previous change (`animationType === 'fade'`) as it broke hide on scroll when `animationType = 'none'`
Fix both issues with touch not working after scroll (remove `animationType === 'slide' ||`)

## Changelog
ScrollFooter - fix another issue with touch not working after scroll (Android real device) | no animation + hide on scroll

## Additional info
None
