### PR TITLE
Fix WheelPicker horizontal bounce

### DIFF
--- a/packages/react-native-ui-lib/src/components/WheelPicker/index.tsx
+++ b/packages/react-native-ui-lib/src/components/WheelPicker/index.tsx
@@ -354,6 +354,8 @@ const WheelPicker = <T extends WheelPickerItemValue>(props: WheelPickerProps<T>)
         <GestureHandlerRootView style={styles.gestureContainer}>
           <AnimatedFlatList
             {...androidFlatListProps}
+            directionalLockEnabled
+            alwaysBounceHorizontal={false}
             {...flatListProps}
             testID={`${testID}.list`}
             listKey={`${testID}.flatList`}


### PR DESCRIPTION
## Summary
- prevent WheelPicker FlatList from locking into horizontal bounce/scroll behavior
- keep the picker constrained to vertical wheel interaction

## Testing
- pre-push checks ran during git push