### PR TITLE
Chip - expose selected prop to screen readers via accessibilityState

### DIFF
--- a/packages/react-native-ui-lib/src/components/chip/__tests__/index.spec.tsx
+++ b/packages/react-native-ui-lib/src/components/chip/__tests__/index.spec.tsx
@@ -54,4 +54,21 @@ describe('Chip', () => {
     expect(driver.getIcon().exists()).toBeTruthy();
     expect(driver.getDismissIcon().exists()).toBeTruthy();
   });
+
+  describe('Accessibility', () => {
+    it('should set accessibilityState.selected when selected is true', () => {
+      const driver = getDriver({selected: true});
+      expect(driver.getElement().props.accessibilityState).toEqual({selected: true});
+    });
+
+    it('should set accessibilityState.selected when selected is false', () => {
+      const driver = getDriver({selected: false});
+      expect(driver.getElement().props.accessibilityState).toEqual({selected: false});
+    });
+
+    it('should not set accessibilityState when selected is not provided', () => {
+      const driver = getDriver();
+      expect(driver.getElement().props.accessibilityState).toBeUndefined();
+    });
+  });
 });

--- a/packages/react-native-ui-lib/src/components/chip/index.tsx
+++ b/packages/react-native-ui-lib/src/components/chip/index.tsx
@@ -22,6 +22,10 @@ export type ChipProps = ViewProps &
      */
     onPress?: (props: any) => void;
     /**
+     * Indicates whether the chip is selected, exposed to screen readers via accessibilityState
+     */
+    selected?: boolean;
+    /**
      * Chip's background color
      */
     backgroundColor?: string;
@@ -158,6 +162,7 @@ const Chip = ({
   labelStyle,
   onPress,
   resetSpacings,
+  selected,
   size = DEFAULT_SIZE,
   useSizeAsMinimum = true,
   recorderTag,
@@ -332,6 +337,7 @@ const Chip = ({
       style={[styles.container, {backgroundColor}, {borderRadius}, containerStyle, containerSizeStyle]}
       testID={testID}
       hitSlop={hitSlop}
+      accessibilityState={selected !== undefined ? {selected} : undefined}
       {...others}
     >
       {avatarProps && renderAvatar()}


### PR DESCRIPTION
## Description
The `Chip` component had no way to communicate selection state to screen readers.
Passing `accessibilityState` via spread worked as a workaround but was undocumented and fragile.

Added `selected` as a first-class optional prop — when provided, it maps directly to `accessibilityState={{selected}}` on the container.
When omitted, behavior is identical to today.

## Changelog
Chip - Added `selected` prop that exposes selection state to screen readers via `accessibilityState`

## Additional info
N/A