### PR TITLE
fix/DynamicFontModule - double callback invocation causing SIGABRT on Android

### DIFF
--- a/packages/uilib-native/android/src/main/java/com/wix/reactnativeuilib/dynamicfont/DynamicFontModule.java
+++ b/packages/uilib-native/android/src/main/java/com/wix/reactnativeuilib/dynamicfont/DynamicFontModule.java
@@ -130,10 +130,9 @@ public class DynamicFontModule extends ReactContextBaseJavaModule {
       ReactFontManager.getInstance().setTypeface(name, Typeface.NORMAL, typeface);
 
       cacheFile.delete();
+      callback.invoke(null, name);
     } catch(Exception e) {
       callback.invoke(e.getMessage());
-    } finally {
-      callback.invoke(null, name);
     }
   }
 }

--- a/packages/uilib-native/android/src/main/java/com/wix/reactnativeuilib/dynamicfont/DynamicFontModule.java
+++ b/packages/uilib-native/android/src/main/java/com/wix/reactnativeuilib/dynamicfont/DynamicFontModule.java
@@ -130,7 +130,7 @@ public class DynamicFontModule extends ReactContextBaseJavaModule {
       ReactFontManager.getInstance().setTypeface(name, Typeface.NORMAL, typeface);
 
       cacheFile.delete();
-    } catch (Exception e) {
+    } catch(Exception e) {
       callback.invoke(e.getMessage());
       return;
     }

--- a/packages/uilib-native/android/src/main/java/com/wix/reactnativeuilib/dynamicfont/DynamicFontModule.java
+++ b/packages/uilib-native/android/src/main/java/com/wix/reactnativeuilib/dynamicfont/DynamicFontModule.java
@@ -130,9 +130,10 @@ public class DynamicFontModule extends ReactContextBaseJavaModule {
       ReactFontManager.getInstance().setTypeface(name, Typeface.NORMAL, typeface);
 
       cacheFile.delete();
-      callback.invoke(null, name);
-    } catch(Exception e) {
+    } catch (Exception e) {
       callback.invoke(e.getMessage());
+      return;
     }
+    callback.invoke(null, name);
   }
 }


### PR DESCRIPTION
## Description

`DynamicFontModule.loadFont` (Android) had a `catch`/`finally` structure where **both blocks invoked the React Native callback**, causing a fatal crash when an exception occurred during font loading.

**Root cause:**
```java
// BEFORE (buggy)
} catch(Exception e) {
    callback.invoke(e.getMessage());  // invoked on exception
} finally {
    callback.invoke(null, name);      // ALWAYS invoked — crashes when catch also ran
}
```

React Native enforces that native callbacks are invoked **exactly once**. When any exception is thrown during font loading (e.g. `Typeface.createFromFile` failing on certain Android devices), both `catch` and `finally` fire, invoking the callback twice and triggering a fatal `SIGABRT`:

```
Abort message: 'Callback arg cannot be called more than once'
```

**Fix:** Move the success callback into the `try` block and remove the `finally`. The callback is now invoked exactly once — success path inside `try`, error path inside `catch`.

```java
/ AFTER (fixed)
      cacheFile.delete();
    } catch(Exception e) {
      callback.invoke(e.getMessage());
      return;
    }
    callback.invoke(null, name);   // outside try/catch — exactly once

## Changelog

`DynamicFontModule` (Android) — fixed intermittent fatal crash (`SIGABRT`) caused by the native callback being invoked twice when an exception occurred during `loadFont`. The app would crash ~4 seconds after launch before any UI interaction.

## Additional info

- Crash signature: `signal 6 (SIGABRT)`, `Abort message: 'Callback arg cannot be called more than once'`, stack trace pointing to `DynamicFontModule.loadFont`
- Intermittent — only reproduces when an exception is thrown mid-load (e.g. on certain cloud/real devices where `Typeface.createFromFile` or file I/O fails transiently)
- Only affects apps that load custom fonts via `DynamicFonts` on startup (branded apps); standard apps are unaffected
- Note: the commented-out `loadFontFromFile` method in the same file already uses the correct pattern (a `wasLoaded` flag guarding the `finally`) — this fix aligns `loadFont` with that same intention, simplified