### PR TITLE
fix(Hint): support modal props

### DIFF
--- a/packages/react-native-ui-lib/src/components/hint/Hint.driver.new.ts
+++ b/packages/react-native-ui-lib/src/components/hint/Hint.driver.new.ts
@@ -10,7 +10,7 @@ export const HintDriver = (props: ComponentProps) => {
     testID: `${props.testID}.message`
   });
 
-  const modalDriver = ModalDriver({renderTree: props.renderTree, testID: `${props.testID}.message`});
+  const modalDriver = ModalDriver({renderTree: props.renderTree, testID: `${props.testID}.modal`});
 
   return {
     ...driver,

--- a/packages/react-native-ui-lib/src/components/hint/__tests__/index.spec.tsx
+++ b/packages/react-native-ui-lib/src/components/hint/__tests__/index.spec.tsx
@@ -64,6 +64,13 @@ describe('Hint Screen component test', () => {
     expect(driver.getModal().isVisible()).toBe(false);
   });
 
+  it('Should pass modalProps to the internal modal', async () => {
+    const renderTree = render(<TestCase visible withModal modalProps={{supportedOrientations: ['landscape']}}/>);
+    const driver = HintDriver({renderTree, testID: HINT_TEST_ID});
+
+    expect(driver.getModal().getElement().props.supportedOrientations).toEqual(['landscape']);
+  });
+
   // TODO: This scenario tests doesn't pass, need to fix it using act
   it.skip('Should modal be visible when showHint is true', async () => {
     const renderTree = render(<TestCase visible withModal/>);

--- a/packages/react-native-ui-lib/src/components/hint/hint.api.json
+++ b/packages/react-native-ui-lib/src/components/hint/hint.api.json
@@ -55,6 +55,11 @@
       "description": "Open the hint using a Modal component"
     },
     {
+      "name": "modalProps",
+      "type": "ModalProps",
+      "description": "Additional props for the modal."
+    },
+    {
       "name": "useSideTip",
       "type": "boolean",
       "description": "Show side tips instead of the middle tip"

--- a/packages/react-native-ui-lib/src/components/hint/index.tsx
+++ b/packages/react-native-ui-lib/src/components/hint/index.tsx
@@ -34,6 +34,7 @@ const Hint = (props: HintProps) => {
     edgeMargins = DEFAULT_EDGE_MARGINS,
     targetFrame,
     useSideTip,
+    modalProps,
     onPress,
     onBackgroundPress,
     backdropColor,
@@ -216,6 +217,7 @@ const Hint = (props: HintProps) => {
       {renderChildren()}
       {isUsingModal ? (
         <Modal
+          {...modalProps}
           visible={showHint}
           animationType={backdropColor ? 'fade' : 'none'}
           overlayBackgroundColor={backdropColor}

--- a/packages/react-native-ui-lib/src/components/hint/types.ts
+++ b/packages/react-native-ui-lib/src/components/hint/types.ts
@@ -8,6 +8,7 @@ import type {
   TextStyle,
   ViewStyle
 } from 'react-native';
+import type {ModalProps} from '../modal';
 
 export type PositionStyle = Pick<ViewStyle, 'top' | 'bottom' | 'left' | 'right'>;
 
@@ -65,6 +66,10 @@ export interface HintProps {
    * Open the hint using a Modal component
    */
   useModal?: boolean;
+  /**
+   * Additional props for the modal.
+   */
+  modalProps?: ModalProps;
   /**
    * Show side tips instead of the middle tip
    */


### PR DESCRIPTION
## Description
Adds a `modalProps` API to `Hint` and forwards it to the internal `Modal` when Hint uses modal mode. This allows React Native Modal props such as `supportedOrientations` to be set for landscape-only apps.

Closes #3938

## Changelog
Hint: added `modalProps` to pass additional props to the internal Modal.

## Additional info
Validation:
- `yarn workspace react-native-ui-lib test packages/react-native-ui-lib/src/components/hint/__tests__/index.spec.tsx --runInBand --watchman=false`
- `yarn build:dev`
- `yarn eslint packages/react-native-ui-lib/src/components/hint/types.ts packages/react-native-ui-lib/src/components/hint/index.tsx packages/react-native-ui-lib/src/components/hint/Hint.driver.new.ts packages/react-native-ui-lib/src/components/hint/__tests__/index.spec.tsx -c .eslintrc.js`
