### PR TITLE
fix: bump url-parse to ^1.5.10 to resolve OSV vulnerability

### DIFF
--- a/packages/react-native-ui-lib/package.json
+++ b/packages/react-native-ui-lib/package.json
@@ -39,7 +39,7 @@
         "react-native-redash": "^12.0.3",
         "semver": "^5.5.0",
         "tinycolor2": "^1.4.2",
-        "url-parse": "^1.2.0",
+        "url-parse": "^1.5.10",
         "wix-react-native-text-size": "1.0.9"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11421,7 +11421,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"url-parse@npm:^1.2.0":
+"url-parse@npm:^1.5.10":
   version: 1.5.10
   resolution: "url-parse@npm:1.5.10"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -9753,7 +9753,7 @@ __metadata:
     tinycolor2: "npm:^1.4.2"
     typescript: "npm:5.0.4"
     uilib-native: "workspace:*"
-    url-parse: "npm:^1.2.0"
+    url-parse: "npm:^1.5.10"
     wix-react-native-text-size: "npm:1.0.9"
   peerDependencies:
     react: ">=19.0.0"


### PR DESCRIPTION
## Description

Buildkite CI was failing after merging #4030 due to `npq` supply chain security scanning rejecting `url-parse@^1.2.0`. The range `^1.2.0` is flagged by OSV (Open Source Vulnerabilities database) because it allows installing older vulnerable versions — even though `npm` already resolves it to `1.5.10` (the patched version) in practice, and that is the version currently installed on master.

Bumping the declared range to `^1.5.10` and updating the yarn.lock makes the intent explicit and resolves the `npq` error.

## Changelog

**packages/react-native-ui-lib** - Bumped `url-parse` from `^1.2.0` to `^1.5.10` to fix Buildkite supply chain security check failure.

## Additional info

N/A