### PR TITLE
fix: replace url-parse with native URL API

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@types/react": "19.0.0",
     "@types/react-test-renderer": "^19.0.0",
     "@types/tinycolor2": "^1.4.2",
-    "@types/url-parse": "^1.4.3",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "@welldone-software/why-did-you-render": "^3.2.1",

--- a/packages/react-native-ui-lib/package.json
+++ b/packages/react-native-ui-lib/package.json
@@ -39,7 +39,6 @@
         "react-native-redash": "^12.0.3",
         "semver": "^5.5.0",
         "tinycolor2": "^1.4.2",
-        "url-parse": "^1.2.0",
         "wix-react-native-text-size": "1.0.9"
     },
     "devDependencies": {
@@ -71,7 +70,6 @@
         "@types/react": "19.0.0",
         "@types/react-test-renderer": "19.0.0",
         "@types/tinycolor2": "^1.4.2",
-        "@types/url-parse": "^1.4.3",
         "@welldone-software/why-did-you-render": "^3.2.1",
         "babel-plugin-lodash": "^3.3.4",
         "babel-plugin-module-resolver": "^5.0.0",

--- a/packages/react-native-ui-lib/src/helpers/AvatarHelper.ts
+++ b/packages/react-native-ui-lib/src/helpers/AvatarHelper.ts
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import URL from 'url-parse';
 import Colors from '../style/colors';
 import {Typography} from 'style';
 
@@ -100,10 +99,8 @@ export function isBlankGravatarUrl(url: string) {
 }
 
 export function patchGravatarUrl(gravatarUrl: string) {
-  const url = new URL(gravatarUrl, true);
-  const {query} = url;
-  query.d = '404';
-  delete query.default;
-  url.set('query', query);
+  const url = new URL(gravatarUrl);
+  url.searchParams.set('d', '404');
+  url.searchParams.delete('default');
   return url.toString();
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3088,13 +3088,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/url-parse@npm:^1.4.3":
-  version: 1.4.11
-  resolution: "@types/url-parse@npm:1.4.11"
-  checksum: 10c0/24a470a28393871c83e94006a80f6fb2e7c6dd9c0b031ee575fe792291cf28aec1f0523512b77a09190a4918158e7c68c03c04b8aa97e76b0153aec52f767bd6
-  languageName: node
-  linkType: hard
-
 "@types/yargs-parser@npm:*":
   version: 21.0.3
   resolution: "@types/yargs-parser@npm:21.0.3"
@@ -9351,13 +9344,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"querystringify@npm:^2.1.1":
-  version: 2.2.0
-  resolution: "querystringify@npm:2.2.0"
-  checksum: 10c0/3258bc3dbdf322ff2663619afe5947c7926a6ef5fb78ad7d384602974c467fadfc8272af44f5eb8cddd0d011aae8fabf3a929a8eee4b86edcc0a21e6bd10f9aa
-  languageName: node
-  linkType: hard
-
 "queue-microtask@npm:^1.2.2":
   version: 1.2.3
   resolution: "queue-microtask@npm:1.2.3"
@@ -9659,7 +9645,6 @@ __metadata:
     "@types/react": "npm:19.0.0"
     "@types/react-test-renderer": "npm:^19.0.0"
     "@types/tinycolor2": "npm:^1.4.2"
-    "@types/url-parse": "npm:^1.4.3"
     "@typescript-eslint/eslint-plugin": "npm:^5.62.0"
     "@typescript-eslint/parser": "npm:^5.62.0"
     "@welldone-software/why-did-you-render": "npm:^3.2.1"
@@ -9710,7 +9695,6 @@ __metadata:
     "@types/react": "npm:19.0.0"
     "@types/react-test-renderer": "npm:19.0.0"
     "@types/tinycolor2": "npm:^1.4.2"
-    "@types/url-parse": "npm:^1.4.3"
     "@welldone-software/why-did-you-render": "npm:^3.2.1"
     babel-plugin-lodash: "npm:^3.3.4"
     babel-plugin-module-resolver: "npm:^5.0.0"
@@ -9753,7 +9737,6 @@ __metadata:
     tinycolor2: "npm:^1.4.2"
     typescript: "npm:5.0.4"
     uilib-native: "workspace:*"
-    url-parse: "npm:^1.2.0"
     wix-react-native-text-size: "npm:1.0.9"
   peerDependencies:
     react: ">=19.0.0"
@@ -10074,13 +10057,6 @@ __metadata:
   version: 0.8.7
   resolution: "require-relative@npm:0.8.7"
   checksum: 10c0/b2d36d20cb849c26fb8134064048162e029ebbf373c915e6d31b2d5caa9e9b599c7b3e70700c019c28c9347369e85ecbcf139956788ece2774d8cb355d24c36f
-  languageName: node
-  linkType: hard
-
-"requires-port@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "requires-port@npm:1.0.0"
-  checksum: 10c0/b2bfdd09db16c082c4326e573a82c0771daaf7b53b9ce8ad60ea46aa6e30aaf475fe9b164800b89f93b748d2c234d8abff945d2551ba47bf5698e04cd7713267
   languageName: node
   linkType: hard
 
@@ -11418,16 +11394,6 @@ __metadata:
   dependencies:
     punycode: "npm:^2.1.0"
   checksum: 10c0/4ef57b45aa820d7ac6496e9208559986c665e49447cb072744c13b66925a362d96dd5a46c4530a6b8e203e5db5fe849369444440cb22ecfc26c679359e5dfa3c
-  languageName: node
-  linkType: hard
-
-"url-parse@npm:^1.2.0":
-  version: 1.5.10
-  resolution: "url-parse@npm:1.5.10"
-  dependencies:
-    querystringify: "npm:^2.1.1"
-    requires-port: "npm:^1.0.0"
-  checksum: 10c0/bd5aa9389f896974beb851c112f63b466505a04b4807cea2e5a3b7092f6fbb75316f0491ea84e44f66fed55f1b440df5195d7e3a8203f64fcefa19d182f5be87
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Removes the `url-parse` dependency from `react-native-ui-lib` and uses the native `URL` / `URLSearchParams` APIs in `AvatarHelper` instead.

- `isGravatarUrl` and `patchGravatarUrl` now use the global `URL` constructor (no import shadowing)
- `patchGravatarUrl` sets `d=404` and removes `default` via `searchParams`
- Drops `url-parse` and `@types/url-parse` from package manifests and lockfile

This fully resolves the OSV supply-chain issue without needing to bump `url-parse` (see #4031).

## Changelog

**AvatarHelper** — Removed `url-parse` dependency; Gravatar URL helpers now use native `URL` APIs.

## Additional info

All existing `AvatarHelper` tests pass (`yarn workspace react-native-ui-lib test AvatarHelper.spec.js`).
