### PR TITLE
fix: guard isGravatarUrl against invalid URL strings

### DIFF
--- a/packages/react-native-ui-lib/src/helpers/AvatarHelper.ts
+++ b/packages/react-native-ui-lib/src/helpers/AvatarHelper.ts
@@ -90,8 +90,12 @@ export function getBackgroundColor(name?: string,
 }
 
 export function isGravatarUrl(url: string) {
-  const {hostname, pathname} = new URL(url);
-  return _.split(hostname, '.').includes('gravatar') && pathname.startsWith('/avatar/');
+  try {
+    const {hostname, pathname} = new URL(url);
+    return _.split(hostname, '.').includes('gravatar') && pathname.startsWith('/avatar/');
+  } catch {
+    return false;
+  }
 }
 
 export function isBlankGravatarUrl(url: string) {

--- a/packages/react-native-ui-lib/src/helpers/__tests__/AvatarHelper.spec.js
+++ b/packages/react-native-ui-lib/src/helpers/__tests__/AvatarHelper.spec.js
@@ -114,6 +114,12 @@ describe('services/AvatarService', () => {
       expect(uut.isGravatarUrl('https://www.gravatars.com/avatar/00000000000000000000000000000000')).toEqual(false);
       expect(uut.isGravatarUrl('https://www.grava.tar/avatar/00000000000000000000000000000000')).toEqual(false);
     });
+
+    it('should return false for an invalid url', () => {
+      expect(uut.isGravatarUrl('fakeUrl')).toEqual(false);
+      expect(uut.isGravatarUrl('fakeUri1')).toEqual(false);
+      expect(uut.isGravatarUrl('')).toEqual(false);
+    });
   });
 
   describe('isBlankGravatarUrl', () => {


### PR DESCRIPTION
## Description

PR #4033 replaced `url-parse` with the native `URL` API in `AvatarHelper`. However, the native `URL` constructor throws a `TypeError` when given an invalid URL string (e.g. `'fakeUrl'`, `''`), unlike `url-parse` which was lenient.

This caused headless test failures in `wix-react-native-ui-lib` when Avatar components received non-URL strings as the image source — `isGravatarUrl` would throw instead of returning `false`.

The fix wraps `new URL(url)` in a `try/catch` inside `isGravatarUrl` and returns `false` for any input that isn't a valid URL.

## Changelog

**AvatarHelper** — `isGravatarUrl` now returns `false` for invalid URL strings instead of throwing.

## Additional info

Fixes the regression introduced by #4033. Caught by headless tests in `wix-react-native-ui-lib` where Avatar receives arbitrary strings as image URIs.