### PR TITLE
fix: ScreenFooter - correct initial opacity for animationType 'none' (Android touch blocking)

### DIFF
--- a/packages/react-native-ui-lib/src/components/screenFooter/useAnimatedFooterStyle.ts
+++ b/packages/react-native-ui-lib/src/components/screenFooter/useAnimatedFooterStyle.ts
@@ -27,7 +27,7 @@ const useAnimatedFooterStyle = (
   });
 
   const [height, setHeight] = useState(0);
-  const animatedValue = useSharedValue(animationType === 'fade' && visible ? 1 : 0);
+  const animatedValue = useSharedValue(animationType !== 'slide' && visible ? 1 : 0);
 
   useEffect(() => {
     if (animationType === 'slide') {


### PR DESCRIPTION
## Description
Fix `ScreenFooter` blocking touches on Android when `animationType='none'` (or `animationDuration=0`).

When `animationType` is `'none'`, the animated shared value was incorrectly initialized to `0`, causing the footer's opacity to be `0` on the first render frame while `pointerEvents` was still `'auto'`. This made the footer invisible but still intercept all touches within its bounds (position absolute, full width, bottom of screen, zIndex 50) — resulting in list items and other content behind the footer not responding to taps on Android.

Root cause: the initial value check only accounted for `'fade'`, not `'none'`, even though both types use opacity-based animation.

**Related:** #4009, #4019

## Changelog
ScreenFooter - fix Android touch blocking when `animationType='none'`

## Additional info
- Ticket: MOBAPP-3019
- Does **not** touch `useAnimatedStyle` — that was the cause of the regression in #4009
- Hide-on-scroll remains unaffected: the `useEffect` still drives the value `1→0` when `visible` becomes `false`