### PR TITLE
fix(ScreenFooter): init animatedValue to 1 for opacity-based animations when visible

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unicorn-demo-app",
-  "version": "1.1.16",
+  "version": "9.1.0-snapshot.8044",
   "main": "src/index.js",
   "author": "Ethan Sharabi <ethan.shar@gmail.com>",
   "license": "MIT",

--- a/packages/react-native-ui-lib/package.json
+++ b/packages/react-native-ui-lib/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-ui-lib",
-    "version": "9.0.0",
+    "version": "9.1.0-snapshot.8044",
     "main": "src/index.ts",
     "types": "src/index.d.ts",
     "author": "Ethan Sharabi <ethan.shar@gmail.com>",

--- a/packages/react-native-ui-lib/src/components/screenFooter/useAnimatedFooterStyle.ts
+++ b/packages/react-native-ui-lib/src/components/screenFooter/useAnimatedFooterStyle.ts
@@ -27,7 +27,7 @@ const useAnimatedFooterStyle = (
   });
 
   const [height, setHeight] = useState(0);
-  const animatedValue = useSharedValue(animationType === 'fade' && visible ? 1 : 0);
+  const animatedValue = useSharedValue(animationType !== 'slide' && visible ? 1 : 0);
 
   useEffect(() => {
     if (animationType === 'slide') {
@@ -76,3 +76,4 @@ const styles = StyleSheet.create({
     zIndex: 50
   }
 });
+


### PR DESCRIPTION
## Description

On Android, when `animationType='none'` (or `animationDuration=0`) and `visible=true`, the footer's `animatedValue` was initialized to `0` instead of `1`. This caused the footer to render with `opacity: 0` for at least one UI-thread frame, blocking touches in the footer area even though the footer appeared invisible.

### Root cause

```ts
// before — only 'fade' started at 1; 'none' incorrectly started at 0
const animatedValue = useSharedValue(animationType === 'fade' && visible ? 1 : 0);
```

Both `'fade'` and `'none'` use the `opacity` path in `useAnimatedStyle`. Only `'slide'` uses `translateY` and legitimately starts at `0`. So the initial value guard should be `!== 'slide'`, not `=== 'fade'`.

### Fix

```ts
// after — both 'fade' and 'none' start at 1 when visible; no invisible-but-blocking frame on mount
const animatedValue = useSharedValue(animationType !== 'slide' && visible ? 1 : 0);
```

### Why this doesn't regress hide-on-scroll for `animationType='none'`

PR #4009 broke hide-on-scroll by changing `else → else if (animationType === 'fade')` in `useAnimatedStyle`, which excluded `'none'` from receiving opacity. PR #4019 reverted that. This fix is orthogonal — it only touches the **initial value**, not the style callback. The `else` branch (restored by #4019) still drives opacity to `0` when `visible` becomes `false`.

## Changelog
ScreenFooter - fix touch blocking on Android when animationType is 'none' and footer is visible on mount

## Additional info
Related: #4009, #4019