### PR TITLE
fix: Dialog - prevent open animation interruption by residual touch on Android

### DIFF
--- a/packages/react-native-ui-lib/jestSetup/jest-setup.js
+++ b/packages/react-native-ui-lib/jestSetup/jest-setup.js
@@ -79,6 +79,7 @@ jest.mock('react-native-gesture-handler',
       PanMock.onFinalize = getDefaultMockedHandler('onFinalize');
       PanMock.activateAfterLongPress = getDefaultMockedHandler('activateAfterLongPress');
       PanMock.enabled = getDefaultMockedHandler('enabled');
+      PanMock.minDistance = getDefaultMockedHandler('minDistance');
       PanMock.hitSlop = getDefaultMockedHandler('hitSlop');
       PanMock.onTouchesMove = getDefaultMockedHandler('onTouchesMove');
       PanMock.prepare = jest.fn();

--- a/packages/react-native-ui-lib/src/components/dialog/index.tsx
+++ b/packages/react-native-ui-lib/src/components/dialog/index.tsx
@@ -195,6 +195,7 @@ const Dialog = (props: DialogProps, ref: ForwardedRef<DialogImperativeMethods>) 
     // which fires onPress on END while the touch is still settling) leaks into this freshly-mounted
     // pan and drives `visibility` mid-open, interrupting the open spring so the sheet rests part-way.
     // A plain touchable trigger (Button) lifts cleanly before the modal mounts and is unaffected.
+    // 10dp is small enough to keep drag-to-dismiss responsive while ignoring near-static residual touches.
     .minDistance(10)
     .onStart(event => {
       initialTranslation.value =

--- a/packages/react-native-ui-lib/src/components/dialog/index.tsx
+++ b/packages/react-native-ui-lib/src/components/dialog/index.tsx
@@ -190,6 +190,12 @@ const Dialog = (props: DialogProps, ref: ForwardedRef<DialogImperativeMethods>) 
   };
 
   const panGesture = Gesture.Pan()
+    // MOBAPP-2994: require a deliberate drag before the pan engages. Without this, on Android/Fabric
+    // the residual touch stream from a gesture-handler trigger (e.g. List.Item's TapGestureHandler,
+    // which fires onPress on END while the touch is still settling) leaks into this freshly-mounted
+    // pan and drives `visibility` mid-open, interrupting the open spring so the sheet rests part-way.
+    // A plain touchable trigger (Button) lifts cleanly before the modal mounts and is unaffected.
+    .minDistance(10)
     .onStart(event => {
       initialTranslation.value =
         getTranslationReverseInterpolation(isVertical ? event.translationY : event.translationX) - visibility.value;


### PR DESCRIPTION
## Description

On Android, a bottom-direction `Dialog` (and therefore `ActionSheet`, which builds on it) can open only part-way — resting below its final position with just the header visible — when it is opened as a direct result of a gesture-driven trigger (e.g. `List.Item`, whose `TapGestureHandler` fires `onPress` on gesture END while the touch is still settling). A plain touchable trigger (e.g. `Button`) lifts cleanly before the modal mounts and is unaffected.

Root cause: the Dialog's own `panGesture` has no activation threshold, so on Android the residual touch stream from the triggering gesture leaks into the freshly-mounted pan and drives `visibility` mid-open, interrupting the `withSpring(1)` open animation. Because the translation is `interpolate(visibility, [0,1], [hiddenLocation, 0], CLAMP)`, an interrupted `visibility` (< 1) leaves the card translated part-way down. Dismiss is unaffected (the residual touch is long gone by then), which is why the close animation always plays from the full height.

Fix: add `.minDistance(10)` to the Dialog `panGesture` so it only engages on a deliberate drag. A residual, near-static touch can no longer activate the pan and overwrite `visibility`, while drag-to-dismiss (movement well beyond the threshold) keeps working unchanged.

## Changelog

Dialog/ActionSheet: fixed the bottom sheet occasionally opening part-way on Android when triggered from a gesture-based component (e.g. `List.Item`); the open animation is no longer interrupted by the triggering touch.

## Additional info

Under investigation for MOBAPP-2994 (Wix OneApp — "Mute Notifications" ActionSheet opening partially on Android). Draft while verifying on-device via the standard snapshot → wrapper → app build flow.
